### PR TITLE
fix: amélioration procédure import réseau

### DIFF
--- a/docs/import_reseau_chaleur.md
+++ b/docs/import_reseau_chaleur.md
@@ -23,6 +23,11 @@
 
 ## Deuxième étape - en dev
 
+Script :
+```sh
+./scripts/copyLocalNetworkToRemote.sh preprod reseaux_de_chaleur
+```
+
 1. Se connecter sur Scalingo : `scalingo --region osc-fr1 --app france-chaleur-urbaine-dev db-tunnel SCALINGO_POSTGRESQL_URL`
     - Le mot de passe est dans Scalingo
     - On peut maintenant accéder à la base de dev sur 127.0.0.1:10000
@@ -45,11 +50,16 @@
 6. Aller redémarrer le container *web* sur Scalingo
 
 7. Tester
-    - france-chaleur-urbaine-dev.osc-fr1.scalingo.io
+    - https://france-chaleur-urbaine-dev.osc-fr1.scalingo.io
     - Vérifier les adresses que Sebastien nous envoie à vérifier
 <br/><br/>
 
 ## Dernière étape - mise en prod
+
+Script :
+```sh
+./scripts/copyLocalNetworkToRemote.sh prod reseaux_de_chaleur
+```
 
 1. Se connecter sur Scalingo : `scalingo --region osc-fr1 --app france-chaleur-urbaine db-tunnel SCALINGO_POSTGRESQL_URL`
     - Le mot de passe est dans Scalingo

--- a/docs/import_reseau_chaleur.md
+++ b/docs/import_reseau_chaleur.md
@@ -4,32 +4,31 @@
 ## Première étape - en local
 
 1. Mise à jour de la table *reseaux_de_chaleur*
-    - Vider la table *reseaux_de_chaleur*
+    - Vider la table *reseaux_de_chaleur* : `psql postgres://postgres:postgres_fcu@localhost:5432 -c "truncate reseaux_de_chaleur"`
         - Si des colonnes ont été ajoutées il faudra peut-être supprimer et recréer la table
-    - Lancer : `psql postgres://localhost:5432 -U postgres -f reseaux_de_chaleur.sql`
-        - Le mot de passe est dans docker-compose.yml
+    - Lancer : `psql postgres://postgres:postgres_fcu@localhost:5432 -f reseaux_de_chaleur.sql`
         - Il faudra peut-être modifier le fichier pour supprimer la création de la table et des index
- 
+
 2. Faire la même chose pour les réseaux de chaleur sans tracé
         - Il faudra peut-être modifier le fichier pour changer le nom de la table par *reseaux_de_chaleur* et supprimer sa création ainsi que celle des index
 
 3. Mise à jour des données sur les réseaux depuis Airtable
-    - Lancer le script downloadNetworks.ts : `export NODE_PATH=./ && npx ts-node scripts/downloadNetworks.ts network`
-    - Normalement ce script met à jour la table *reseaux_de_chaleur_tiles*
+    - Lancer le script downloadNetworks.ts : `export NODE_PATH=./ && npx ts-node --transpile-only scripts/downloadNetworks.ts network`
+    - Normalement ce script complète la table *zones_et_reseaux_en_construction* et regénère la table *zones_et_reseaux_en_construction_tiles*
 
 4. Si mauvaise mise à jour des tiles : mise à jour de la table *reseaux_de_chaleur_tiles*
     - Vider la table (sans la supprimer)
-    - Lancer le script fillTiles.ts : `export NODE_PATH=./ && ts-node --transpile-only scripts/fillTiles.ts network 0 17`
+    - Lancer le script fillTiles.ts : `export NODE_PATH=./ && npx ts-node --transpile-only scripts/fillTiles.ts network 0 17`
 <br/><br/>
 
-## Deuxième étape - en dev 
+## Deuxième étape - en dev
 
 1. Se connecter sur Scalingo : `scalingo --region osc-fr1 --app france-chaleur-urbaine-dev db-tunnel SCALINGO_POSTGRESQL_URL`
     - Le mot de passe est dans Scalingo
     - On peut maintenant accéder à la base de dev sur 127.0.0.1:10000
 
-2. Sur la base en local 
-    - Exporter les tables *reseaux_de_chaleur* et *reseaux_de_chaleur_tiles*
+2. Sur la base en local
+    - Exporter les tables *reseaux_de_chaleur* et *reseaux_de_chaleur_tiles*
 
 3. **!!! Vérifier qu'il n'y a pas de process en cours sur Scalingo avant de continuer**
     - https://dashboard.scalingo.com/apps/osc-fr1/france-chaleur-urbaine-dev/logs
@@ -50,7 +49,7 @@
     - Vérifier les adresses que Sebastien nous envoie à vérifier
 <br/><br/>
 
-## Dernière étape - mise en prod 
+## Dernière étape - mise en prod
 
 1. Se connecter sur Scalingo : `scalingo --region osc-fr1 --app france-chaleur-urbaine db-tunnel SCALINGO_POSTGRESQL_URL`
     - Le mot de passe est dans Scalingo

--- a/scripts/copyLocalNetworkToRemote.sh
+++ b/scripts/copyLocalNetworkToRemote.sh
@@ -1,0 +1,48 @@
+#!/bin/bash -e
+
+tables=('donnees_de_consos' 'reseaux_de_chaleur' 'reseaux_de_froid' 'zone_de_developpement_prioritaire' 'zones_et_reseaux_en_construction')
+usage() {
+  echo "Usage: copyLocalNetworkToRemote.sh <preprod|prod> <${tables[@]}>"
+}
+
+env=$1
+table=$2
+if [[ $env != "preprod" && $env != "prod" ]]; then
+  usage
+  exit 1
+fi
+
+if [[ ! "${tables[@]}" =~ "$table" ]]; then
+  usage
+  exit 1
+fi
+
+# export depuis BDD locale
+pg_dump postgres://postgres:postgres_fcu@localhost:5432 --format=c --data-only -t ${table} >/tmp/table.dump
+pg_dump postgres://postgres:postgres_fcu@localhost:5432 --format=c --data-only -t ${table}_tiles >/tmp/tiles.dump
+
+if [[ $env = "prod" ]]; then
+  SCALINGO_APP=france-chaleur-urbaine
+else
+  SCALINGO_APP=france-chaleur-urbaine-dev
+fi
+
+echo "> Mise à jour table '$table' sur l'environnement de $env en cours"
+
+# ouvre un tunnel vers BDD cible
+scalingo -a $SCALINGO_APP db-tunnel SCALINGO_POSTGRESQL_URL &
+sleep 4
+
+# import vers BDD cible
+POSTGRESQL_URL=$(scalingo -a $SCALINGO_APP env-get SCALINGO_POSTGRESQL_URL)
+export PGUSER=$(expr $POSTGRESQL_URL : '.*/\([^:]*\):.*')
+export PGPASSWORD=$(expr $POSTGRESQL_URL : '.*:\([^@]*\)@.*')
+psql postgres://localhost:10000 -c "truncate ${table}"
+psql postgres://localhost:10000 -c "truncate ${table}_tiles"
+pg_restore -d postgres://localhost:10000 --data-only /tmp/table.dump
+pg_restore -d postgres://localhost:10000 --data-only /tmp/tiles.dump
+
+# ferme le tunnel
+kill %1
+
+echo "> Mise à jour terminée sur $env pour les tables '$table' et '${table}_tiles'"


### PR DESCRIPTION
2-3 corrections / maj + **ajout d'un script pour dumper les tables en local et les importer sur les environnements cibles**.

- Chez moi j'ai besoin de spécifier la clé SSH utilisée car ce n'est pas celle par défaut (~/.ssh/id_rsa) que j'utilise... cf [code scalingo](https://github.com/Scalingo/cli/blob/9b80d09bca6b25f25af053655bf54fc09fa0249c/cmd/db_tunnel.go#L65)

- Aussi, chez moi j'ai editorconfig qui supprime les espaces en fin de ligne. Ça vaudrait le coup d'ajouter une petite config dans le projet.