### PR TITLE
fix: optimisation performances dans les calculs de distance

### DIFF
--- a/src/components/Map/components/SummaryBoxes.tsx
+++ b/src/components/Map/components/SummaryBoxes.tsx
@@ -104,9 +104,12 @@ const SummaryBoxes = ({
 
   const exportData = async (bounds: number[][]) => {
     if (bounds) {
-      setExporting(true);
-      await heatNetworkService.downloadSummary(bounds, EXPORT_FORMAT.CSV);
-      setExporting(false);
+      try {
+        setExporting(true);
+        await heatNetworkService.downloadSummary(bounds, EXPORT_FORMAT.CSV);
+      } finally {
+        setExporting(false);
+      }
     }
   };
 

--- a/src/core/infrastructure/repository/dataSummary.ts
+++ b/src/core/infrastructure/repository/dataSummary.ts
@@ -43,7 +43,7 @@ const getCloseQuery = (
   geom: string,
   distance: number
 ) => `
-ST_DISTANCE(
+ST_DWithin(
   ST_Transform(${geom}, 2154),
   ST_Transform(
     ST_MakeLine(
@@ -51,8 +51,9 @@ ST_DISTANCE(
         (coords) => `ST_SetSRID(ST_MakePoint(${coords}), 4326)`
       )}]
     )
-  , 2154) 
-) < ${distance}
+  , 2154),
+  ${distance}
+)
 `;
 
 const getNetworkSummary = async (
@@ -100,10 +101,10 @@ const getGasSummary = async (coordinates: number[][]): Promise<GasSummary[]> =>
       EXISTS (
         SELECT *
         FROM reseaux_de_chaleur rdc
-        WHERE ST_Distance(
+        WHERE ST_DWithin(
           ST_Transform(rdc.geom, 2154),
-          ST_Transform(gas.geom, 2154)
-          ) < 50
+          ST_Transform(gas.geom, 2154),
+          50)
         LIMIT 1
       ) as is_close
       `)
@@ -121,10 +122,10 @@ const getEnergySummary = async (
       EXISTS (
         SELECT *
         FROM reseaux_de_chaleur rdc
-        WHERE ST_Distance(
+        WHERE ST_DWithin(
           ST_Transform(rdc.geom, 2154),
-          ST_Transform(energy.geom_adresse, 2154)
-          ) < 50
+          ST_Transform(energy.geom_adresse, 2154),
+          50)
         LIMIT 1
       ) as is_close
       `)
@@ -148,10 +149,10 @@ const exportGasSummary = async (
         EXISTS (
           SELECT *
           FROM reseaux_de_chaleur rdc
-          WHERE ST_Distance(
+          WHERE ST_DWithin(
             ST_Transform(rdc.geom, 2154),
-            ST_Transform(gas.geom, 2154)
-            ) < 50
+            ST_Transform(gas.geom, 2154),
+            50)
           LIMIT 1
         ) as is_close
       `)
@@ -169,10 +170,11 @@ const exportEnergyGasSummary = async (
         EXISTS (
           SELECT *
           FROM reseaux_de_chaleur rdc
-          WHERE ST_Distance(
+          WHERE ST_DWithin(
             ST_Transform(rdc.geom, 2154),
-            ST_Transform(energy.geom_adresse, 2154)
-            ) < 50
+            ST_Transform(energy.geom_adresse, 2154),
+            50,
+            )
           LIMIT 1
         ) as is_close
       `),
@@ -202,10 +204,10 @@ const exportEnergyFioulSummary = async (
         EXISTS (
           SELECT *
           FROM reseaux_de_chaleur rdc
-          WHERE ST_Distance(
+          WHERE ST_DWithin(
             ST_Transform(rdc.geom, 2154),
-            ST_Transform(energy.geom_adresse, 2154)
-            ) < 50
+            ST_Transform(energy.geom_adresse, 2154),
+            50)
           LIMIT 1
         ) as is_close
       `),

--- a/src/core/infrastructure/repository/dataSummary.ts
+++ b/src/core/infrastructure/repository/dataSummary.ts
@@ -102,7 +102,7 @@ const getGasSummary = async (coordinates: number[][]): Promise<GasSummary[]> =>
         SELECT *
         FROM reseaux_de_chaleur rdc
         WHERE ST_DWithin(
-          ST_Transform(rdc.geom, 2154),
+          rdc.geom,
           ST_Transform(gas.geom, 2154),
           50)
         LIMIT 1
@@ -123,7 +123,7 @@ const getEnergySummary = async (
         SELECT *
         FROM reseaux_de_chaleur rdc
         WHERE ST_DWithin(
-          ST_Transform(rdc.geom, 2154),
+          rdc.geom,
           ST_Transform(energy.geom_adresse, 2154),
           50)
         LIMIT 1
@@ -150,7 +150,7 @@ const exportGasSummary = async (
           SELECT *
           FROM reseaux_de_chaleur rdc
           WHERE ST_DWithin(
-            ST_Transform(rdc.geom, 2154),
+            rdc.geom,
             ST_Transform(gas.geom, 2154),
             50)
           LIMIT 1
@@ -171,7 +171,7 @@ const exportEnergyGasSummary = async (
           SELECT *
           FROM reseaux_de_chaleur rdc
           WHERE ST_DWithin(
-            ST_Transform(rdc.geom, 2154),
+            rdc.geom,
             ST_Transform(energy.geom_adresse, 2154),
             50,
             )
@@ -205,7 +205,7 @@ const exportEnergyFioulSummary = async (
           SELECT *
           FROM reseaux_de_chaleur rdc
           WHERE ST_DWithin(
-            ST_Transform(rdc.geom, 2154),
+            rdc.geom,
             ST_Transform(energy.geom_adresse, 2154),
             50)
           LIMIT 1


### PR DESCRIPTION
Pour la requête de téléchargement des données d'une zone, permet de passer de 1.1 minute à 4.6s chez moi.
Car on utilise l'index géospatial.
- utilisation de st_dwithin qui permet d'utiliser les indexes directement
- pas de transformation de la geom des rdc car elle est déjà en projection Lambert, sinon l'index ne peut pas être utilisé directement.
- fix du spinner qui continue de tourner en cas d'erreur