### PR TITLE
chore: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# Editor configuration, see https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false


### PR DESCRIPTION
Conf classique [editorconfig](https://editorconfig.org/) qui permet à l'IDE de comprendre les règles basiques d'indentation et surtout de supprimer automatiquement les espaces, ce qui n'est pas le cas dans pas mal de fichiers de FCU !

Le plugin pour VSCode est déjà intégré en principe.