### PR TITLE
fix: taille police xp utilisateur

### DIFF
--- a/src/data/coproprietaire/user-experience.js
+++ b/src/data/coproprietaire/user-experience.js
@@ -33,8 +33,8 @@ _Les travaux durent *2&nbsp;mois* en tout&nbsp;!_`,
     imgAlt: `Charge et travaux pour un raccordement au Réseau de chaleur`,
   },
   {
-    body: `::counter-item[04.]  
-::cartridge[_Depuis Anne profite d’une chaleur **fiable et garantie, pour 108€/mois pour son T4**._]{className=cartridge-4}
+    body: `::counter-item[04.]
+::cartridge[Depuis Anne profite d’une chaleur **fiable et garantie, pour 108€/mois pour son T4**.]{className=cartridge-4}
 
 Grâce au réseau de chaleur, la copropriété bénéficie d’une **bonne température de chauffe** et d’une distribution de l'eau chaude **sans aucune panne** et avec **un budget maîtrisé**.
 


### PR DESCRIPTION
Sur la page principale, passe de :
![image](https://github.com/betagouv/france-chaleur-urbaine/assets/8938024/92b39042-1cee-4dc4-9283-6d1db8a48ebf)
à :
![image](https://github.com/betagouv/france-chaleur-urbaine/assets/8938024/3a31bcad-af4e-468c-86b8-784f40849e26)

C'est clairement pas pratique de styler le markdown, avec les styles globaux :-/