### PR TITLE
fix: restore anchors

### DIFF
--- a/src/pages/collectivites-et-exploitants.tsx
+++ b/src/pages/collectivites-et-exploitants.tsx
@@ -265,7 +265,7 @@ export default function Home() {
           <Slice padding={12}>
             <ResponsiveRow>
               <ResponsiveItem>
-                <SliceSubHeader>
+                <SliceSubHeader id="iframe-carte">
                   Intégrez notre cartographie ou notre test d’adresses à votre
                   site
                 </SliceSubHeader>
@@ -304,7 +304,7 @@ export default function Home() {
 
               <ResponsiveItem>
                 <CartoImage src="/img/collectivite-iframe.jpg" alt="" />
-                <IFrameIntegrationTitle className="fr-mt-5w">
+                <IFrameIntegrationTitle className="fr-mt-5w" id="iframe">
                   2- Iframe test d’adresse
                 </IFrameIntegrationTitle>
                 <BlueParagraph>


### PR DESCRIPTION
Remet des ancres iframe-carte et iframe (formulaire de test d'adresse) qui ont sauté suite à la nouvelle page collectivités et exploitants.
![image](https://github.com/betagouv/france-chaleur-urbaine/assets/8938024/f39c2d54-3621-4ab8-aa0c-6e3039747c89)
