### PR TITLE
feat: rerevert st_distance => st_dwithin

### DIFF
--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -6,4 +6,5 @@ export const clientConfig = {
     facebookPixelId: process.env.NEXT_PUBLIC_FACEBOOK_PIXEL_ID,
     linkInPartnerId: process.env.NEXT_PUBLIC_LINKEDIN_PARTNER_ID,
   },
+  summaryAreaSizeLimit: 5, // km²
 };

--- a/src/components/Map/components/SummaryBoxes.tsx
+++ b/src/components/Map/components/SummaryBoxes.tsx
@@ -22,7 +22,7 @@ import {
   ZoneInfosWrapper,
 } from './SummaryBoxes.style';
 import ZoneInfo from './ZoneInfo';
-import { SUMMARY_AREA_SIZE_LIMIT } from 'src/config';
+import { clientConfig } from 'src/client-config';
 import { trackEvent } from 'src/services/analytics';
 
 const getConso = (consos: GasSummary[]) => {
@@ -75,7 +75,7 @@ const SummaryBoxes = ({
 
   useEffect(() => {
     setSummary(undefined);
-    if (bounds && size && size < SUMMARY_AREA_SIZE_LIMIT) {
+    if (bounds && size && size < clientConfig.summaryAreaSizeLimit) {
       trackEvent('Carto|Zone définie');
       zoneIndex.current += 1;
       const currentZoneIndex = zoneIndex.current;
@@ -182,7 +182,7 @@ const SummaryBoxes = ({
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 @ts-ignore: to fix in react-dsfr */}
               <Tab label="Extraire des données sur les bâtiments">
-                {size && size > SUMMARY_AREA_SIZE_LIMIT ? (
+                {size && size > clientConfig.summaryAreaSizeLimit ? (
                   <Explanation>
                     <span>
                       La zone définie est trop grande ({size.toFixed(2)} km²),

--- a/src/components/Map/components/SummaryBoxes.tsx
+++ b/src/components/Map/components/SummaryBoxes.tsx
@@ -22,6 +22,7 @@ import {
   ZoneInfosWrapper,
 } from './SummaryBoxes.style';
 import ZoneInfo from './ZoneInfo';
+import { SUMMARY_AREA_SIZE_LIMIT } from 'src/config';
 import { trackEvent } from 'src/services/analytics';
 
 const getConso = (consos: GasSummary[]) => {
@@ -74,7 +75,7 @@ const SummaryBoxes = ({
 
   useEffect(() => {
     setSummary(undefined);
-    if (bounds && size && size < 5) {
+    if (bounds && size && size < SUMMARY_AREA_SIZE_LIMIT) {
       trackEvent('Carto|Zone définie');
       zoneIndex.current += 1;
       const currentZoneIndex = zoneIndex.current;
@@ -136,7 +137,7 @@ const SummaryBoxes = ({
           trackEvent('Carto|Zone mise à jour');
           const geometry = data.features[0].geometry as Polygon;
           setBounds(geometry.coordinates[0]);
-          setSize(turfArea(data) / 1000_000);
+          setSize(turfArea(data) / 1_000_000);
         } else if (data.features[0].geometry.type === 'LineString') {
           trackEvent('Carto|Tracé mis à jour');
           setLines(
@@ -181,7 +182,7 @@ const SummaryBoxes = ({
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 @ts-ignore: to fix in react-dsfr */}
               <Tab label="Extraire des données sur les bâtiments">
-                {size && size > 5 ? (
+                {size && size > SUMMARY_AREA_SIZE_LIMIT ? (
                   <Explanation>
                     <span>
                       La zone définie est trop grande ({size.toFixed(2)} km²),

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,1 +1,0 @@
-export const SUMMARY_AREA_SIZE_LIMIT = 5; // km²

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,1 @@
+export const SUMMARY_AREA_SIZE_LIMIT = 5; // km²

--- a/src/pages/api/map/summary.ts
+++ b/src/pages/api/map/summary.ts
@@ -8,7 +8,7 @@ import turfArea from '@turf/area';
 import { lineString, polygon } from '@turf/helpers';
 import turfLength from '@turf/length';
 import { NextApiRequest, NextApiResponse } from 'next';
-import { SUMMARY_AREA_SIZE_LIMIT } from 'src/config';
+import { clientConfig } from 'src/client-config';
 import { withCors } from 'src/services/api/cors';
 import { EXPORT_FORMAT } from 'src/types/enum/ExportFormat';
 import { z } from 'zod';
@@ -19,11 +19,11 @@ const polygonSummary = async (
   res: NextApiResponse
 ) => {
   const size = turfArea(polygon([coordinates])) / 1_000_000;
-  if (size > SUMMARY_AREA_SIZE_LIMIT) {
+  if (size > clientConfig.summaryAreaSizeLimit) {
     return res
       .status(400)
       .send(
-        `Cannot compute stats on area bigger than ${SUMMARY_AREA_SIZE_LIMIT} km²`
+        `Cannot compute stats on area bigger than ${clientConfig.summaryAreaSizeLimit} km²`
       );
   }
   if (req.method === 'GET') {

--- a/src/pages/api/map/summary.ts
+++ b/src/pages/api/map/summary.ts
@@ -8,6 +8,7 @@ import turfArea from '@turf/area';
 import { lineString, polygon } from '@turf/helpers';
 import turfLength from '@turf/length';
 import { NextApiRequest, NextApiResponse } from 'next';
+import { SUMMARY_AREA_SIZE_LIMIT } from 'src/config';
 import { withCors } from 'src/services/api/cors';
 import { EXPORT_FORMAT } from 'src/types/enum/ExportFormat';
 import { z } from 'zod';
@@ -17,11 +18,13 @@ const polygonSummary = async (
   req: NextApiRequest,
   res: NextApiResponse
 ) => {
-  const size = turfArea(polygon([coordinates]));
-  if (size > 5_000_000) {
+  const size = turfArea(polygon([coordinates])) / 1_000_000;
+  if (size > SUMMARY_AREA_SIZE_LIMIT) {
     return res
       .status(400)
-      .send('Cannot compute stats on area bigger than 5 km²');
+      .send(
+        `Cannot compute stats on area bigger than ${SUMMARY_AREA_SIZE_LIMIT} km²`
+      );
   }
   if (req.method === 'GET') {
     const data = await getPolygonSummary(coordinates);


### PR DESCRIPTION
:warning: A merger après la révision BDNB 2022 sur dev pour s'assurer que l'export est ok aussi. (actuellement les colonnes n'ont pas les bons noms)

L'empire contre attaque avec le st_dwithin qui revient.
- J'ai supprimé les transformations inutiles vers le srid 2154 quand les geom le sont déjà.
- Il y a seulement la geom_adresse qui est en lat lon (4326), et j'y ai mis un commentaire pour spécifier le srid d'origine.
J- 'ai remanié un peu la limite de surface pour avoir une seule config. J'ai mis ça dans un fichier src/config.ts ne sachant pas où le mettre.
Idéalement, j'aimerais bien mieux distinguer ce qui est côté front, côté back, et ce qui est partagé entre les 2. Affaire à suivre... :smile: 

J'ai testé le summary des bâtiments et l'export en local avec la BDD de prod et en local buildé avec la BDD de prod. Tout fonctionne bien...

reste à faire :
- [x] attendre que la branche BDNB 2022 soit mergée #651 
- [x] ajouter le logger pour la route summary / export, afin d'avoir la requête complète et non tronquée, après avoir mergé #661 
- [x] merger #668 pour le logger

