### PR TITLE
fix: matomo csp and page stats

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -19,6 +19,7 @@ const csp = {
     "'sha256-3I33qFPfa/PLrN/3rrrC4vJBjmKYiuXWQ+ZfnHiEWmo='",
     "'sha256-ksltjYbI6Uoozfn80t6ROvA1rBbTP9X8qGPGwHmWBpA='",
     "'sha256-6SC04Y6nNQLzwzyqa3SfGlAJoGLEAasou2bnNnkusvM='",
+    "'sha256-H2mRU+3M13HkAJfH6/b74hVw3UOtytXrVI3MuPwDTj0='", // matomo https://stats.beta.gouv.fr/ 83
     'https://stats.data.gouv.fr',
     'https://stats.beta.gouv.fr',
     'https://static.axept.io',

--- a/src/components/Statistics/Statistics.tsx
+++ b/src/components/Statistics/Statistics.tsx
@@ -30,8 +30,10 @@ type ReturnApiStatAirtable = {
 
 const getYearsList = () => {
   const years = [];
-  const currentYear = new Date().getFullYear();
-  for (let year = 2022; year <= currentYear; year++) {
+  const date = new Date();
+  date.setMonth(date.getMonth() - 1);
+  const currentYearPreviousMonth = date.getFullYear();
+  for (let year = 2022; year <= currentYearPreviousMonth; year++) {
     years.push(year.toString());
   }
   return years;
@@ -103,11 +105,10 @@ const getFormattedData = (
   if (!data) {
     return [];
   }
-  const returnData = Array.from({ length: 12 }, (n, i) =>
-    new Array(yearsList.length + 1)
-      .fill(monthToString[i], 0, 1)
-      .fill(null, 1, 3)
-  );
+  const returnData = Array.from({ length: 12 }, (n, i) => [
+    monthToString[i],
+    ...new Array(yearsList.length).fill(null),
+  ]);
   let notEmpty = false;
   yearsList.forEach((year: string, i) => {
     monthToString.forEach((month: string, j) => {


### PR DESCRIPTION
- Dès qu'on change qqch sur l'URL de matomo ou l'id du site, il faut mettre à jour la CSP policy :grimacing: 
- L'année 2024 avec des valeurs vides fait planter la page stats. Comme on affiche a priori le mois précédent, j'ai masqué l'année 2024 pour l'instant. Le bug reviendra peut-être en février (sûrement en fait comme il n'y aura pas de nouvelles données sur stats.data.gouv.fr...)