### PR TITLE
fix: remove faker deprecation warning

### DIFF
--- a/src/core/infrastructure/repository/manager.ts
+++ b/src/core/infrastructure/repository/manager.ts
@@ -172,7 +172,7 @@ export const getDemands = async (user: User): Promise<Demand[]> => {
             Nom: faker.person.lastName(),
             Prénom: faker.person.firstName(),
             Mail: faker.internet.email(),
-            Téléphone: faker.phone.number('0#########'),
+            Téléphone: `0${faker.string.numeric(9)}`,
           }) as Demand
       )
     : filteredRecords.map(


### PR DESCRIPTION
Evite d'avoir ce warning répété pour chaque demande quand on accède à la page gestionnaire.

> [@faker-js/faker]: faker.phone.number(format) is deprecated since v8.1 and will be removed in v9.0. Please use faker.phone.number(), faker.string.numeric() or faker.helpers.fromRegExp() instead.

