### PR TITLE
fix: don't display 'potentiels de raccordements' on iframes

### DIFF
--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -43,6 +43,7 @@ const MapPage = () => {
         .filter(
           (legend) =>
             legend !== 'contributeButton' &&
+            legend !== 'statsByArea' &&
             legend !== 'proModeLegend' &&
             (typeof legend === 'string' ||
               displayLegendArray.includes(legendMapping[legend.id]))


### PR DESCRIPTION
Exemple : /map?legend=true&displayLegend=reseau_chaleur