### PR TITLE
style: arrange la couleur d'un label page exploitants

### DIFF
--- a/src/components/ui/Text.tsx
+++ b/src/components/ui/Text.tsx
@@ -9,6 +9,7 @@ const legacyColors = {
   lightblue: '#4550E5',
   purple: 'var(--blue-france-main-525)',
   darkblue: 'var(--blue-france-sun-113-625)',
+  darkerblue: '#000074',
   lightgrey: '#78818D',
 } as const;
 

--- a/src/pages/collectivites-et-exploitants.tsx
+++ b/src/pages/collectivites-et-exploitants.tsx
@@ -40,6 +40,7 @@ import NetworkSearchInput from '@components/Network/NetworkSearchInput';
 import { useState } from 'react';
 import { NetworkSearchResult } from './api/networks/search';
 import Box from '@components/ui/Box';
+import Text from '@components/ui/Text';
 
 const collectivitesCards = {
   role: issues.role,
@@ -260,7 +261,9 @@ export default function CollectivitesEtExploitantsPage() {
               <NetworkSearchInput
                 className={selectedNetwork ? '' : 'fr-col'} // expand the text input only
                 label={
-                  <Box mt="2w">Voir la fiche actuelle de votre réseau</Box>
+                  <Text mt="2w" legacyColor="darkerblue">
+                    Voir la fiche actuelle de votre réseau
+                  </Text>
                 }
                 value={networkSearchTerm}
                 onChange={(value) => {


### PR DESCRIPTION
Un oubli parmi les nombreux retours de la PR des modifs de réseau, qui m'est revenu ce matin à la démo de Florence.

Permet de passer de 
![image](https://github.com/betagouv/france-chaleur-urbaine/assets/8938024/6ebbe94a-bba2-4f9b-9a29-340ba6552000)
à 
![image](https://github.com/betagouv/france-chaleur-urbaine/assets/8938024/7b482e33-6a70-49a2-ad65-c780394d5463)
