### PR TITLE
fix: corrections formulaire modif réseau

### DIFF
--- a/src/pages/api/modification-reseau.ts
+++ b/src/pages/api/modification-reseau.ts
@@ -33,7 +33,10 @@ const zModificationReseau = {
   reseauClasse: z.preprocess((val: any) => val[0], z.coerce.boolean()),
   maitreOuvrage: z.preprocess((val: any) => val[0], z.string()),
   gestionnaire: z.preprocess((val: any) => val[0], z.string()),
-  siteInternet: z.preprocess((val: any) => val[0], z.string().url()),
+  siteInternet: z.preprocess(
+    (val: any) => (val[0] === '' ? undefined : val[0]), // empty string or a valid URL
+    z.string().url().optional()
+  ),
   informationsComplementaires: z.preprocess(
     (val: any) => val[0],
     z.string().max(clientConfig.networkInfoFieldMaxCharacters)

--- a/src/pages/api/modification-reseau.ts
+++ b/src/pages/api/modification-reseau.ts
@@ -30,7 +30,16 @@ const zModificationReseau = {
   structure: z.preprocess((val: any) => val[0], z.string()),
   fonction: z.preprocess((val: any) => val[0], z.string()),
   email: z.preprocess((val: any) => val[0], z.string().email()),
-  reseauClasse: z.preprocess((val: any) => val[0], z.coerce.boolean()),
+  reseauClasse: z.preprocess((val: any) => {
+    switch (val[0]) {
+      case 'false':
+        return false;
+      case 'true':
+        return true;
+      default:
+        return val[0];
+    }
+  }, z.boolean()),
   maitreOuvrage: z.preprocess((val: any) => val[0], z.string()),
   gestionnaire: z.preprocess((val: any) => val[0], z.string()),
   siteInternet: z.preprocess(

--- a/src/pages/api/networks/search.ts
+++ b/src/pages/api/networks/search.ts
@@ -57,5 +57,9 @@ export default handleRouteErrors(async (req) => {
     .sort((a, b) =>
       a['Identifiant reseau'] < b['Identifiant reseau'] ? -1 : 1
     )
-    .slice(0, 10);
+    .slice(0, 10)
+    .map((network) => {
+      network.website_gestionnaire = network.website_gestionnaire.trim(); // type postgresql character... should be varying character
+      return network;
+    });
 });

--- a/src/pages/reseaux/modifier.tsx
+++ b/src/pages/reseaux/modifier.tsx
@@ -358,7 +358,6 @@ function ModifierReseauxPage() {
               onChange={(e) => setFormValue('gestionnaire', e.target.value)}
             />
             <TextInput
-              required
               type={'url' as any} // unsupported type by the dsfr lib
               label="Site internet du réseau"
               placeholder="https://www.monreseau.fr"
@@ -372,7 +371,6 @@ function ModifierReseauxPage() {
               caractères maximum)
             </Text>
             <TextInput
-              required
               textarea
               placeholder="Projets de verdissement ou de développement du réseau, puissance minimale requise pour le raccordement, ou toute autre information utile (cible grand public et professionnels)"
               value={formState.informationsComplementaires}


### PR DESCRIPTION
Corrige les problèmes ci-dessous :

Sur le formulaire de modification de la fiche réseau
- le champ Site internet ne doit pas être obligatoire (tous les réseaux n'ont pas de site internet, et on tient pas absolument à renvoyer vers des sites externes par ailleurs)- désolée j'avais pas fait attention à ça lors de la validation
- il ne doit pas non plus être obligatoire d’ajouter un texte, certaines personnes voudront juste modifier une info erronée

Quand on clique sur non classé au lieu de classé sur le formulaire de contact, cela n'est pas enregistré dans le airtable : la cache classé est toujours cochée