### PR TITLE
fix: impacts nettoyage airtable

### DIFF
--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -7,7 +7,12 @@ import {
   InvalidArgumentError,
 } from '@commander-js/extra-typings';
 import { logger } from '@helpers/logger';
-import { DataType, tilesInfo, zDataType } from 'src/services/tiles.config';
+import {
+  DataType,
+  DatabaseTileInfo,
+  tilesInfo,
+  zDataType,
+} from 'src/services/tiles.config';
 import db from 'src/db';
 import { fillTiles } from './utils/tiles';
 
@@ -48,6 +53,7 @@ program
   .argument('[zoomMax]', 'Maximum zoom', parseInt, 17)
   .argument('[withIndex]', 'With index', (v) => !!v, false)
   .action(async (table, zoomMin, zoomMax, withIndex) => {
+    await db((tilesInfo[table] as DatabaseTileInfo).tiles).delete();
     await fillTiles(table, zoomMin, zoomMax, withIndex);
   });
 

--- a/scripts/downloadNetworks.ts
+++ b/scripts/downloadNetworks.ts
@@ -22,12 +22,10 @@ const getBooleanValue = (network: Record<FieldSet>, key: string) => {
 const valuesToUdpate = (table: DataType, network: Record<FieldSet>) => {
   if (table === 'network' || table === 'coldNetwork') {
     return {
-      commentaires: getValue(network, 'commentaires'),
       'Taux EnR&R': getValue(network, 'Taux EnR&R'),
       'Identifiant reseau': getValue(network, 'Identifiant reseau'),
       Gestionnaire: getValue(network, 'Gestionnaire'),
       communes: getValue(network, 'communes'),
-      date: getValue(network, 'date'),
       'contenu CO2': getValue(network, 'contenu CO2'),
       'contenu CO2 ACV': getValue(network, 'contenu CO2 ACV'),
       PM: getValue(network, 'PM'),

--- a/scripts/networks/download-network.ts
+++ b/scripts/networks/download-network.ts
@@ -13,6 +13,7 @@ const TypeArray: unique symbol = Symbol('array');
 const TypeBool: unique symbol = Symbol('bool');
 const TypeJSONArray: unique symbol = Symbol('json');
 const TypeNumber: unique symbol = Symbol('number');
+const TypePercentage: unique symbol = Symbol('percentage');
 const TypeString: unique symbol = Symbol('string');
 
 type Type =
@@ -20,6 +21,7 @@ type Type =
   | typeof TypeBool
   | typeof TypeJSONArray
   | typeof TypeNumber
+  | typeof TypePercentage
   | typeof TypeString;
 
 const conversionConfigReseauxDeChaleur = {
@@ -199,6 +201,10 @@ function convertAirtableValue(value: any, type: Type) {
     case TypeNumber:
       return value !== undefined && value !== null && value !== 'NULL'
         ? value
+        : null;
+    case TypePercentage:
+      return value !== undefined && value !== null && value !== 'NULL'
+        ? value * 100 // be compatible with number and text
         : null;
     case TypeString:
       return value !== undefined && value !== null && value !== 'NULL'

--- a/scripts/networks/download-network.ts
+++ b/scripts/networks/download-network.ts
@@ -28,11 +28,9 @@ const conversionConfigReseauxDeChaleur = {
   // id_fcu: TypeNumber,
   // id: TypeNumber,
   'Identifiant reseau': TypeString,
-  commentaires: TypeString, // à supprimer en prod car non utilisé
   'Taux EnR&R': TypeNumber,
   Gestionnaire: TypeString,
   communes: TypeString,
-  // date: TypeString, // à supprimer en prod car non utilisé
   'contenu CO2': TypeNumber,
   'contenu CO2 ACV': TypeNumber,
   PM: TypeNumber,

--- a/src/components/Map/components/MapPopupContent.tsx
+++ b/src/components/Map/components/MapPopupContent.tsx
@@ -184,12 +184,6 @@ const MapPopupContent = ({
             {network.nom_reseau && (
               <PopupTitle>{network.nom_reseau}</PopupTitle>
             )}
-            {network.commentaires && (
-              <>
-                <strong>{network.commentaires}</strong>
-                <br />
-              </>
-            )}
             <strong>Identifiant&nbsp;:</strong>&nbsp;
             {network['Identifiant reseau']
               ? network['Identifiant reseau']

--- a/src/db/migrations/20240131000000_cleanup_rdc_commentaires_date.ts
+++ b/src/db/migrations/20240131000000_cleanup_rdc_commentaires_date.ts
@@ -1,0 +1,9 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('reseaux_de_chaleur', (table) => {
+    table.dropColumns('commentaires', 'date');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {} // eslint-disable-line

--- a/src/services/tiles.config.ts
+++ b/src/services/tiles.config.ts
@@ -100,7 +100,6 @@ export const tilesInfo: Record<DataType, TileInfo> = {
       'id_fcu',
       'Taux EnR&R',
       'Gestionnaire',
-      'commentaires',
       'Identifiant reseau',
       'reseaux classes',
       'contenu CO2 ACV',


### PR DESCRIPTION
- Supprime les champs commentaires et date de la table network (réseau de chaleur). Ils étaient toujours vides.
- Corrige la commande yarn cli fill-tiles qui ne supprimait pas les tuiles au préalable (car update on conflicts ignore...). J'ai ajouté le delete all. Ça vaudra le coup d'améliorer le mécanisme pour ne pas tout supprimer et tout recréer.