### PR TITLE
refactor: improve matomo error handling

### DIFF
--- a/src/components/Statistics/Statistics.tsx
+++ b/src/components/Statistics/Statistics.tsx
@@ -122,24 +122,13 @@ const getFormattedData = (
 };
 
 const Statistics = () => {
-  const { data: rawDataActions, error: errorDataActions } = useSWR<any>(
+  const { data: dataActions, error: errorDataActions } = useSWR<any>(
     '/api/statistiques/actions',
     fetchJSON,
     {
       onError: (err) => console.warn('errorDataActions >>', err),
     }
   );
-
-  const dataActions = useMemo(() => {
-    if (
-      !rawDataActions ||
-      rawDataActions?.results?.error ||
-      rawDataActions?.result === 'error'
-    ) {
-      return null;
-    }
-    return rawDataActions.results;
-  }, [rawDataActions]);
 
   const formatedDataEligibilityTest = getFormattedData(
     dataActions,
@@ -156,24 +145,13 @@ const Statistics = () => {
     }
   );
 
-  const { data: rawDataVisits, error: errorVisits } = useSWR<any>(
+  const { data: dataVisits, error: errorVisits } = useSWR<any>(
     '/api/statistiques/visits',
     fetchJSON,
     {
       onError: (err) => console.warn('errorVisits >>', err),
     }
   );
-  const dataVisits = useMemo(() => {
-    if (
-      !rawDataVisits ||
-      rawDataVisits?.results?.error ||
-      rawDataVisits?.result === 'error'
-    ) {
-      return null;
-    }
-
-    return rawDataVisits.results;
-  }, [rawDataVisits]);
 
   const formatedDataVisits = getFormattedData(
     dataVisits,
@@ -261,24 +239,13 @@ const Statistics = () => {
     }
   );
 
-  const { data: rawDataVisitsMap, error: errorVisitsMap } = useSWR<any>(
+  const { data: dataVisitsMap, error: errorVisitsMap } = useSWR<any>(
     '/api/statistiques/visitsMap',
     fetchJSON,
     {
       onError: (err) => console.warn('errorVisitsMap >>', err),
     }
   );
-
-  const dataVisitsMap = useMemo(() => {
-    if (
-      !rawDataVisitsMap ||
-      rawDataVisitsMap?.results?.error ||
-      rawDataVisitsMap?.result === 'error'
-    ) {
-      return null;
-    }
-    return rawDataVisitsMap.results;
-  }, [rawDataVisitsMap]);
 
   const formatedDataVisitsMap = getFormattedData(
     dataVisitsMap,

--- a/src/components/Statistics/Statistics.tsx
+++ b/src/components/Statistics/Statistics.tsx
@@ -21,6 +21,7 @@ import statistics from '@data/statistics';
 import HoverableIcon from '@components/Hoverable/HoverableIcon';
 import Link from 'next/link';
 import { fetchJSON } from '@utils/network';
+import { MatomoMonthStat } from 'src/services/matomo_types';
 
 type ReturnApiStatAirtable = {
   date: string;
@@ -69,7 +70,7 @@ const graphOptions = {
 };
 
 const getFormattedDataSum = (
-  formatedData: any[][],
+  formatedData: number[][],
   startYear?: number,
   startMonth?: number
 ) => {
@@ -92,10 +93,14 @@ const getFormattedDataSum = (
   return nbTotal;
 };
 
-const getFormattedData = (
-  data: any,
-  getValueFonction: (year: string, monthIndex: number, entry: any) => any
-) => {
+const getFormattedData = <Data,>(
+  data: Data[] | undefined,
+  getValueFonction: (
+    year: string,
+    monthIndex: number,
+    entry: Data
+  ) => number | undefined | null
+): number[][] => {
   if (!data) {
     return [];
   }
@@ -106,7 +111,7 @@ const getFormattedData = (
   let notEmpty = false;
   yearsList.forEach((year: string, i) => {
     monthToString.forEach((month: string, j) => {
-      data.find((entry: any) => {
+      data.find((entry) => {
         const value = getValueFonction(year, j, entry);
         if (value) {
           notEmpty = true;
@@ -122,17 +127,15 @@ const getFormattedData = (
 };
 
 const Statistics = () => {
-  const { data: dataActions, error: errorDataActions } = useSWR<any>(
-    '/api/statistiques/actions',
-    fetchJSON,
-    {
-      onError: (err) => console.warn('errorDataActions >>', err),
-    }
-  );
+  const { data: dataActions, error: errorDataActions } = useSWR<
+    MatomoMonthStat[]
+  >('/api/statistiques/actions', fetchJSON, {
+    onError: (err) => console.warn('errorDataActions >>', err),
+  });
 
   const formatedDataEligibilityTest = getFormattedData(
     dataActions,
-    (year: string, monthIndex: number, entry: any) => {
+    (year: string, monthIndex: number, entry) => {
       const [entryYear, entryMonth] = entry?.date?.split('-') || ['YYYY', 'MM'];
       if (parseInt(entryMonth) - 1 === monthIndex && entryYear === year) {
         return (
@@ -145,7 +148,7 @@ const Statistics = () => {
     }
   );
 
-  const { data: dataVisits, error: errorVisits } = useSWR<any>(
+  const { data: dataVisits, error: errorVisits } = useSWR<MatomoMonthStat[]>(
     '/api/statistiques/visits',
     fetchJSON,
     {
@@ -155,7 +158,7 @@ const Statistics = () => {
 
   const formatedDataVisits = getFormattedData(
     dataVisits,
-    (year: string, monthIndex: number, entry: any) => {
+    (year: string, monthIndex: number, entry) => {
       const [entryYear, entryMonth] = entry?.date?.split('-') || ['YYYY', 'MM'];
       if (parseInt(entryMonth) - 1 === monthIndex && entryYear === year) {
         return entry.value;
@@ -186,7 +189,7 @@ const Statistics = () => {
   );
   const formatedDataCountContact = getFormattedData(
     dataCountContact,
-    (year: string, monthIndex: number, entry: any) => {
+    (year: string, monthIndex: number, entry) => {
       const [entryYear, entryMonth] = entry?.date?.split('-') || ['YYYY', 'MM'];
       if (
         parseInt(entryMonth) - 1 === monthIndex &&
@@ -223,7 +226,7 @@ const Statistics = () => {
   );
   const formatedDataCountBulkContact = getFormattedData(
     dataCountBulkContact,
-    (year: string, monthIndex: number, entry: any) => {
+    (year: string, monthIndex: number, entry) => {
       const [entryYear, entryMonth] = entry?.period?.split('-') || [
         'YYYY',
         'MM',
@@ -239,17 +242,15 @@ const Statistics = () => {
     }
   );
 
-  const { data: dataVisitsMap, error: errorVisitsMap } = useSWR<any>(
-    '/api/statistiques/visitsMap',
-    fetchJSON,
-    {
-      onError: (err) => console.warn('errorVisitsMap >>', err),
-    }
-  );
+  const { data: dataVisitsMap, error: errorVisitsMap } = useSWR<
+    MatomoMonthStat[]
+  >('/api/statistiques/visitsMap', fetchJSON, {
+    onError: (err) => console.warn('errorVisitsMap >>', err),
+  });
 
   const formatedDataVisitsMap = getFormattedData(
     dataVisitsMap,
-    (year: string, monthIndex: number, entry: any) => {
+    (year: string, monthIndex: number, entry) => {
       const [entryYear, entryMonth] = entry?.date?.split('-') || ['YYYY', 'MM'];
       if (parseInt(entryMonth) - 1 === monthIndex && entryYear === year) {
         return entry.value;
@@ -299,7 +300,7 @@ const Statistics = () => {
     let nbTotal = 0;
     let nbTotalEligible = 0;
     dataActions &&
-      dataActions.forEach((entry: any) => {
+      dataActions.forEach((entry) => {
         if (entry) {
           nbTotal +=
             (entry['Formulaire de test - Adresse Inéligible'] ?? 0) +
@@ -320,7 +321,7 @@ const Statistics = () => {
   const totalDownload = useMemo(() => {
     let nbTotal = 0;
     dataActions &&
-      dataActions.forEach((entry: any) => {
+      dataActions.forEach((entry) => {
         if (entry) {
           nbTotal += entry['Tracés'] ? entry['Tracés'] : 0;
         }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -27,6 +27,7 @@ import { PasswordService } from 'src/services/password';
 import { createGlobalStyle } from 'styled-components';
 import { clientConfig } from 'src/client-config';
 import { useAnalytics } from 'src/services/analytics';
+import { SWRConfig, SWRConfiguration } from 'swr';
 
 const og = {
   // TODO: USE https://www.screenshotmachine.com/website-screenshot-api.php
@@ -116,6 +117,10 @@ const DsfrFixUp: any = createGlobalStyle` // TODO: Wait Fix from @types/styled-c
   }
 `;
 
+const swrConfig: SWRConfiguration = {
+  revalidateOnFocus: false,
+};
+
 function MyApp({
   Component,
   pageProps,
@@ -201,9 +206,11 @@ function MyApp({
           {/* <!-- Meta Tags Generated via https://www.opengraph.xyz --> */}
         </Head>
 
-        <SessionProvider session={pageProps.session}>
-          <Component {...pageProps} />
-        </SessionProvider>
+        <SWRConfig value={swrConfig}>
+          <SessionProvider session={pageProps.session}>
+            <Component {...pageProps} />
+          </SessionProvider>
+        </SWRConfig>
       </ServicesContext.Provider>
     </>
   );

--- a/src/pages/api/statistiques/actions.ts
+++ b/src/pages/api/statistiques/actions.ts
@@ -62,5 +62,5 @@ export default handleRouteErrors(async () => {
     results = results ? actionsFromDB.concat(results) : actionsFromDB;
   }
 
-  return { results };
+  return results;
 });

--- a/src/pages/api/statistiques/actions.ts
+++ b/src/pages/api/statistiques/actions.ts
@@ -1,57 +1,17 @@
 import db from 'src/db';
-import { fetchFromMatomo } from '../../../services/matomo';
+import { bulkFetchRangeFromMatomo } from '../../../services/matomo';
 import { handleRouteErrors } from '@helpers/server';
 import { STAT_KEY, STAT_METHOD, STAT_PERIOD } from 'src/types/enum/MatomoStats';
+import { MatomoActionMetrics } from 'src/services/matomo_types';
 
 export default handleRouteErrors(async () => {
-  const currentDate = new Date();
-  const month = currentDate.getMonth();
-  const year = currentDate.getFullYear();
-  const display = 12 * (year - 2024) + month;
-  currentDate.setMonth(currentDate.getMonth() - 1);
-  currentDate.setDate(1);
-  let results;
-
-  if (display >= 1) {
-    const actionsFromMatomo = await fetchFromMatomo(
-      {
-        method: 'Events.getAction',
-        period: 'month',
-      },
-      Array(display)
-        .fill(null)
-        .map((v, i) => {
-          const baseDate = new Date(currentDate.toDateString());
-          baseDate.setMonth(baseDate.getMonth() - i);
-          const date = `${baseDate.getFullYear()}-${(baseDate.getMonth() + 1)
-            .toString()
-            .padStart(2, '0')}-${baseDate
-            .getDate()
-            .toString()
-            .padStart(2, '0')}`;
-          return {
-            date,
-          };
-        }),
-      true
-    );
-    if (actionsFromMatomo.error) {
-      return { results: actionsFromMatomo };
-    }
-    if (actionsFromMatomo?.values) {
-      results = actionsFromMatomo?.values.map((arr: any[], i: number) =>
-        arr.reduce(
-          (acc, entry) => {
-            return {
-              ...acc,
-              [entry.label]: entry.nb_events,
-            };
-          },
-          { date: actionsFromMatomo?.filters[i].date }
-        )
-      );
-    }
-  }
+  let results = await bulkFetchRangeFromMatomo<MatomoActionMetrics>(
+    {
+      method: 'Events.getAction',
+      period: 'month',
+    },
+    (entry) => ({ [entry.label]: entry.nb_events })
+  );
 
   // Saved from previous Matomo
   const actionsFromDB = await db('matomo_stats as s')
@@ -62,31 +22,31 @@ export default handleRouteErrors(async () => {
         ) as date`
       ),
       db.raw(
-        `(SELECT s1.value 
+        `(SELECT s1.value
         FROM public.matomo_stats as s1
         WHERE s1.stat_label = 'Formulaire de test - Adresse Éligible'
         AND s1.date = s.date) as "Formulaire de test - Adresse Éligible"`
       ),
       db.raw(
-        `(SELECT s2.value 
+        `(SELECT s2.value
         FROM public.matomo_stats as s2
         WHERE s2.stat_label = 'Formulaire de test - Carte - Adresse Éligible'
         AND s2.date = s.date) as "Formulaire de test - Carte - Adresse Éligible"`
       ),
       db.raw(
-        `(SELECT s3.value 
+        `(SELECT s3.value
         FROM public.matomo_stats as s3
         WHERE s3.stat_label = 'Formulaire de test - Adresse Inéligible'
         AND s3.date = s.date) as "Formulaire de test - Adresse Inéligible"`
       ),
       db.raw(
-        `(SELECT s4.value 
+        `(SELECT s4.value
         FROM public.matomo_stats as s4
         WHERE s4.stat_label = 'Formulaire de test - Carte - Adresse Inéligible'
         AND s4.date = s.date) as "Formulaire de test - Carte - Adresse Inéligible"`
       ),
       db.raw(
-        `(SELECT s5.value 
+        `(SELECT s5.value
         FROM public.matomo_stats as s5
         WHERE s5.stat_label = 'Tracés'
         AND s5.date = s.date) as "Tracés"`

--- a/src/pages/api/statistiques/visits.ts
+++ b/src/pages/api/statistiques/visits.ts
@@ -28,5 +28,5 @@ export default handleRouteErrors(async () => {
   if (visitsFromDB) {
     results = results ? visitsFromDB.concat(results) : visitsFromDB;
   }
-  return { results };
+  return results;
 });

--- a/src/pages/api/statistiques/visits.ts
+++ b/src/pages/api/statistiques/visits.ts
@@ -1,59 +1,16 @@
 import db from 'src/db';
-import { fetchFromMatomo } from '../../../services/matomo';
+import { bulkFetchRangeFromMatomo } from '../../../services/matomo';
 import { handleRouteErrors } from '@helpers/server';
 import { STAT_KEY, STAT_METHOD, STAT_PERIOD } from 'src/types/enum/MatomoStats';
+import { MatomoUniqueVisitorsMetrics } from 'src/services/matomo_types';
 
 export default handleRouteErrors(async () => {
-  const currentDate = new Date();
-  const month = currentDate.getMonth();
-  const year = currentDate.getFullYear();
-  const display = 12 * (year - 2024) + month;
-  currentDate.setMonth(currentDate.getMonth() - 1);
-  currentDate.setDate(1);
-  let results;
+  let results = await bulkFetchRangeFromMatomo<MatomoUniqueVisitorsMetrics>({
+    method: 'VisitsSummary.getUniqueVisitors',
+    period: 'month',
+  });
 
-  if (display >= 1) {
-    const visitsFromMatomo = await fetchFromMatomo(
-      {
-        method: 'VisitsSummary.getUniqueVisitors',
-        period: 'month',
-      },
-      Array(display)
-        .fill(null)
-        .map((v, i) => {
-          const baseDate = new Date(currentDate.toDateString());
-          baseDate.setMonth(baseDate.getMonth() - i);
-          const date = `${baseDate.getFullYear()}-${(baseDate.getMonth() + 1)
-            .toString()
-            .padStart(2, '0')}-${baseDate
-            .getDate()
-            .toString()
-            .padStart(2, '0')}`;
-          return {
-            date,
-          };
-        }),
-      true
-    );
-
-    if (visitsFromMatomo.error) {
-      return { results: visitsFromMatomo };
-    }
-
-    if (visitsFromMatomo?.values) {
-      results =
-        visitsFromMatomo?.values
-          .map(
-            (data: any, i: number) =>
-              data.result !== 'error' && {
-                date: visitsFromMatomo.filters[i].date,
-                ...data,
-              }
-          )
-          .reverse() ?? [];
-    }
-  }
-
+  //Saved from previous Matomo
   const visitsFromDB = await db('matomo_stats')
     .select(
       db.raw(

--- a/src/pages/api/statistiques/visitsMap.ts
+++ b/src/pages/api/statistiques/visitsMap.ts
@@ -39,5 +39,5 @@ export default handleRouteErrors(async () => {
     results = results ? visitsFromDB.concat(results) : visitsFromDB;
   }
 
-  return { results };
+  return results;
 });

--- a/src/pages/api/statistiques/visitsMap.ts
+++ b/src/pages/api/statistiques/visitsMap.ts
@@ -1,5 +1,5 @@
 import db from 'src/db';
-import { fetchFromMatomo } from '../../../services/matomo';
+import { bulkFetchRangeFromMatomo } from '../../../services/matomo';
 import { handleRouteErrors } from '@helpers/server';
 import {
   STAT_KEY,
@@ -7,58 +7,17 @@ import {
   STAT_PARAMS,
   STAT_PERIOD,
 } from 'src/types/enum/MatomoStats';
+import { MatomoPageMetrics } from 'src/services/matomo_types';
 
 export default handleRouteErrors(async () => {
-  const currentDate = new Date();
-  const month = currentDate.getMonth();
-  const year = currentDate.getFullYear();
-  const display = 12 * (year - 2024) + month;
-  currentDate.setMonth(currentDate.getMonth() - 1);
-  currentDate.setDate(1);
-  let results;
-
-  if (display >= 1) {
-    const visitsFromMatomo = await fetchFromMatomo(
-      {
-        method: 'Actions.getPageUrl',
-        pageUrl: '/carte',
-        period: 'month',
-      },
-      Array(display)
-        .fill(null)
-        .map((v, i) => {
-          const baseDate = new Date(currentDate.toDateString());
-          baseDate.setMonth(baseDate.getMonth() - i);
-          const date = `${baseDate.getFullYear()}-${(baseDate.getMonth() + 1)
-            .toString()
-            .padStart(2, '0')}-${baseDate
-            .getDate()
-            .toString()
-            .padStart(2, '0')}`;
-          return {
-            date,
-          };
-        }),
-      true
-    );
-
-    if (visitsFromMatomo.error) {
-      return { results: visitsFromMatomo };
-    }
-    if (visitsFromMatomo?.values) {
-      results = visitsFromMatomo?.values.map((arr: any[], i: number) =>
-        arr.reduce(
-          (acc, entry) => {
-            return {
-              ...acc,
-              value: entry.nb_visits,
-            };
-          },
-          { date: visitsFromMatomo?.filters[i].date }
-        )
-      );
-    }
-  }
+  let results = await bulkFetchRangeFromMatomo<MatomoPageMetrics>(
+    {
+      method: 'Actions.getPageUrl',
+      pageUrl: '/carte',
+      period: 'month',
+    },
+    (entry) => ({ value: entry.nb_visits })
+  );
 
   //Saved from previous Matomo
   const visitsFromDB = await db('matomo_stats')

--- a/src/services/matomo.ts
+++ b/src/services/matomo.ts
@@ -1,13 +1,8 @@
+import { MatomoErrorResult } from './matomo_types';
+
 const MATOMO_URL = process.env.NEXT_PUBLIC_MATOMO_URL;
 const MATOMO_TOKEN = process.env.MATOMO_TOKEN;
 const MATOMO_ID_SITE = process.env.NEXT_PUBLIC_MATOMO_SITE_ID;
-
-const matomoRequestDefaultConfig = {
-  token_auth: MATOMO_TOKEN,
-  idSite: MATOMO_ID_SITE,
-  format: 'JSON',
-  module: 'API',
-};
 
 type ConfigType = Record<string, unknown>;
 
@@ -16,54 +11,93 @@ const configToURI = (config: ConfigType) =>
     .map(([key, value]) => `${key}=${value}`)
     .join('&');
 
-const getMatomoRequest = (
+const buildMatomoURL = (
   config: ConfigType = {},
   bulkConfig: ConfigType[] = []
 ) => {
-  const computedBulkConfig =
-    bulkConfig.length > 0
-      ? bulkConfig.reduce(
-          (acc, configEntry: ConfigType, i: number) => ({
-            ...acc,
-            [`urls[${i}]`]: encodeURIComponent(
-              configToURI({ ...config, ...configEntry })
-            ),
-          }),
-          { method: 'API.getBulkRequest' }
-        )
-      : {};
-
-  const computedConfig = {
-    ...matomoRequestDefaultConfig,
-    ...config,
-    ...computedBulkConfig,
+  const queryParams = {
+    token_auth: MATOMO_TOKEN,
+    idSite: MATOMO_ID_SITE,
+    format: 'JSON',
+    module: 'API',
+    method: 'API.getBulkRequest',
+    ...bulkConfig.reduce(
+      (acc, configEntry: ConfigType, i: number) => ({
+        ...acc,
+        [`urls[${i}]`]: encodeURIComponent(
+          configToURI({ ...config, ...configEntry })
+        ),
+      }),
+      {}
+    ),
   };
-  return `${MATOMO_URL}?${configToURI(computedConfig)}`;
+  return `${MATOMO_URL}?${configToURI(queryParams)}`;
 };
 
-const requestOptions: RequestInit = {
-  method: 'GET',
-  redirect: 'follow',
-};
+export const bulkFetchRangeFromMatomo = async <Result>(
+  config: ConfigType,
+  reducer?: (entry: Result) => object
+): Promise<(Result & { date: string })[]> => {
+  const months = generateMonthsToNow();
 
-export const fetchFromMatomo = async (
-  config: ConfigType = {},
-  bulkConfig: ConfigType[] = [],
-  sendFilter?: boolean
-) => {
-  try {
-    const response = await fetch(
-      getMatomoRequest(config, bulkConfig),
-      requestOptions
-    );
-
-    return sendFilter
-      ? { values: await response.json(), filters: bulkConfig }
-      : response.json();
-  } catch (err) {
-    return {
-      error: 'failed to load data',
-      debug: err,
-    };
+  const response = await fetch(
+    buildMatomoURL(
+      config,
+      months.map((date) => ({
+        date,
+      }))
+    )
+  );
+  if (!response.ok) {
+    throw new Error(`invalid matomo status: ${response.status}`);
   }
+
+  const bulkResults: Result[][] | MatomoErrorResult[] = await response.json();
+  // consider failure if the first bulk result is an error
+  if (isMatomoErrorResult(bulkResults)) {
+    throw new Error(
+      `matomo error: ${(bulkResults[0] as MatomoErrorResult).message}`
+    );
+  }
+
+  return bulkResults.map((bulkResult, i) => ({
+    date: months[i],
+    ...(reducer
+      ? bulkResult.reduce((acc, entry) => {
+          return {
+            ...acc,
+            ...reducer(entry),
+          };
+        }, {} as any)
+      : bulkResult),
+  }));
 };
+
+function isMatomoErrorResult<Result>(
+  bulkResults: Result[][] | MatomoErrorResult[]
+): bulkResults is MatomoErrorResult[] {
+  return (bulkResults[0] as any).result === 'error';
+}
+
+/**
+ * Génère les dates par mois de janvier 2024 jusqu'à aujourd'hui.
+ */
+export function generateMonthsToNow(): string[] {
+  const currentDate = new Date();
+  const month = currentDate.getMonth();
+  const year = currentDate.getFullYear();
+  const display = 12 * (year - 2024) + month;
+  currentDate.setMonth(currentDate.getMonth() - 1);
+  currentDate.setDate(1);
+  const months = Array(display)
+    .fill(null)
+    .map((v, i) => {
+      const baseDate = new Date(currentDate.toDateString());
+      baseDate.setMonth(baseDate.getMonth() - i);
+      const date = `${baseDate.getFullYear()}-${(baseDate.getMonth() + 1)
+        .toString()
+        .padStart(2, '0')}-${baseDate.getDate().toString().padStart(2, '0')}`;
+      return date;
+    });
+  return months;
+}

--- a/src/services/matomo_types.ts
+++ b/src/services/matomo_types.ts
@@ -1,0 +1,44 @@
+// fetchFromMatomo Events.getAction https://stats.data.gouv.fr?token_auth=AAAAAAAAAAAAAAAA&idSite=192&format=JSON&module=API&method=API.getBulkRequest&period=month&urls[0]=method%3DEvents.getAction%26period%3Dmonth%26date%3D2024-01-01
+export interface MatomoActionMetrics {
+  label: string;
+  nb_visits: number;
+  nb_events: number;
+  nb_events_with_value: number;
+  sum_event_value: number;
+  min_event_value: number;
+  max_event_value: boolean;
+  sum_daily_nb_uniq_visitors: number;
+  avg_event_value: number;
+  segment: string;
+  idsubdatatable?: number;
+}
+
+// fetchFromMatomo Actions.getPageUrl https://stats.data.gouv.fr?token_auth=AAAAAAAAAAAAAAAA&idSite=192&format=JSON&module=API&method=API.getBulkRequest&pageUrl=/carte&period=month&urls[0]=method%3DActions.getPageUrl%26pageUrl%3D%2Fcarte%26period%3Dmonth%26date%3D2024-01-01
+export interface MatomoPageMetrics {
+  label: string;
+  nb_visits: number;
+  nb_hits: number;
+  sum_time_spent: number;
+  entry_nb_visits: number;
+  entry_nb_actions: number;
+  entry_sum_visit_length: number;
+  entry_bounce_count: number;
+  exit_nb_visits: number;
+  sum_daily_nb_uniq_visitors: number;
+  sum_daily_entry_nb_uniq_visitors: number;
+  sum_daily_exit_nb_uniq_visitors: number;
+  avg_time_on_page: number;
+  bounce_rate: string;
+  exit_rate: string;
+  url: string;
+}
+
+// fetchFromMatomo VisitsSummary.getUniqueVisitors https://stats.data.gouv.fr?token_auth=AAAAAAAAAAAAAAAA&idSite=192&format=JSON&module=API&method=API.getBulkRequest&period=month&urls[0]=method%3DVisitsSummary.getUniqueVisitors%26period%3Dmonth%26date%3D2024-01-01
+export interface MatomoUniqueVisitorsMetrics {
+  value: number;
+}
+
+export interface MatomoErrorResult {
+  result: 'error';
+  message: string;
+}

--- a/src/services/matomo_types.ts
+++ b/src/services/matomo_types.ts
@@ -42,3 +42,7 @@ export interface MatomoErrorResult {
   result: 'error';
   message: string;
 }
+
+export type MatomoMonthStat = Record<string, number | null> & {
+  date: string;
+};


### PR DESCRIPTION
Une petite PR pour proposer une simplification du code pour les statistiques, majoritairement côté API. Il y a 3 commits que tu peux regarder à la suite.
- le 1er supprime la duplication (un peu trop poussée) entre les 3 routes qui utilisent matomo (notamment la génération de la liste des mois)
  - j'ai regroupé la logique client d'API matomo dans src/services/matomo.ts qui fait toujours des bulk requests (ainsi, on a toujours un tableau de résultats).
- le 2e supprime la propriété results sans doute héritée / inspirée de l'API matomo. Maintenant le résultat (tableau) est directement envoyé
- le 3e simplifie la gestion des erreurs côté UI et ajoute du typage (un minimum car beaucoup d'objets ont des noms de propriétés dynamiques).
  - côté erreurs : si l'API retourne une erreur (statut !== 200), data est toujours undefined et error vaut l'erreur, donc le graph concerné s'affiche en erreur. La vérification intermédiaire des données pour vérifier data.results.error etc a été supprimée.
 
Note : je suis pas trop fan du useSWR qui redéclenche plein de requêtes dès qu'on alt tab. Est-ce que ça te dirait de supprimer ce comportement ?