### PR TITLE
chore: increase db pool size

### DIFF
--- a/knexfile.ts
+++ b/knexfile.ts
@@ -15,7 +15,7 @@ export default {
   pool: {
     idleTimeoutMillis: 10000,
     min: 0,
-    max: 20,
+    max: 60,
   },
 } satisfies Knex.Config;
 


### PR DESCRIPTION
Il y a parfois des erreurs en prod sur des délais d'acquisition d'un client postgres, sachant que la carte utilise la BDD pour les tuiles, ça peut monter très rapidement pour des requêtes très courtes.
Ici on augmente à 60, sachant qu'il peut y avoir plusieurs instances (5 max pour le moment), et que la BDD permet 480. C'est une valeur raisonnable qui permet de laisser des connexions ouvertes pour s'y connecter à côté.