### PR TITLE
feat: add requests logging

### DIFF
--- a/src/helpers/logger.ts
+++ b/src/helpers/logger.ts
@@ -2,7 +2,11 @@ import { createLogger, format, transports } from 'winston';
 
 export const logger = createLogger({
   level: 'info',
-  format: format.combine(format.timestamp(), format.json()),
+  format: format.combine(
+    format.timestamp(),
+    format((info) => ({ ...info, pid: process.pid }))(),
+    format.json()
+  ),
   transports: [new transports.Console({})],
 });
 

--- a/src/pages/api/map/[type]/[...tileCoordinates].ts
+++ b/src/pages/api/map/[type]/[...tileCoordinates].ts
@@ -11,26 +11,28 @@ export const config = {
   },
 };
 
-export default handleRouteErrors(async function handleRequest(
-  req: NextApiRequest,
-  res: NextApiResponse
-) {
-  const {
-    type,
-    tileCoordinates: [z, x, y],
-  } = await validateObjectSchema(req.query, {
-    type: zDataType,
-    tileCoordinates: zod.array(zod.coerce.number()).length(3),
-  });
-  const tiles = await getTiles(type, x, y, z);
+export default handleRouteErrors(
+  async function handleRequest(req: NextApiRequest, res: NextApiResponse) {
+    const {
+      type,
+      tileCoordinates: [z, x, y],
+    } = await validateObjectSchema(req.query, {
+      type: zDataType,
+      tileCoordinates: zod.array(zod.coerce.number()).length(3),
+    });
+    const tiles = await getTiles(type, x, y, z);
 
-  res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Origin', '*');
 
-  if (!tiles) {
-    res.status(204).end();
-    return;
+    if (!tiles) {
+      res.status(204).end();
+      return;
+    }
+
+    res.setHeader('Content-Type', 'application/protobuf');
+    res.status(200).send(tiles);
+  },
+  {
+    logRequest: false,
   }
-
-  res.setHeader('Content-Type', 'application/protobuf');
-  res.status(200).send(tiles);
-});
+);


### PR DESCRIPTION
Un petit log de la durée de traitement de chaque route pour avoir des informations si besoin.
Désactivé pour les requêtes de récupération des tuiles car pas intéressant (trop nombreuses et très rapides)


Toutes les routes n'utilisent pas encore `handleRouteErrors()`, mais ça viendra petit à petit avec l'uniformisation de la gestion des erreurs.