### PR TITLE
fix: fetch the user from the db in next auth middleware

### DIFF
--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -47,14 +47,25 @@ export const nextAuthOptions: AuthOptions = {
       return token;
     },
     async session({ session, token }) {
+      // update the last_connection date and return the latest user data
+      const [user] = await db('users')
+        .where({ email: session.user.email })
+        .update({ last_connection: new Date() })
+        .returning([
+          'id',
+          'email',
+          'role',
+          'gestionnaires',
+          'receive_new_demands',
+          'receive_old_demands',
+          'active',
+          'created_at',
+        ]);
+
       if (token) {
         return {
           ...session,
-          user: {
-            role: token.role,
-            email: token.email,
-            gestionnaires: token.gestionnaires,
-          },
+          user,
         } as Session;
       }
       return session;

--- a/src/pages/api/demands/[demandId].ts
+++ b/src/pages/api/demands/[demandId].ts
@@ -1,59 +1,39 @@
 import { updateDemand } from '@core/infrastructure/repository/manager';
-import type { NextApiRequest, NextApiResponse } from 'next';
-import { authenticatedUser } from 'src/services/api/authentication';
+import {
+  handleRouteErrors,
+  requirePutMethod,
+  validateObjectSchema,
+} from '@helpers/server';
+import type { NextApiRequest } from 'next';
 import { DEMANDE_STATUS } from 'src/types/enum/DemandSatus';
-import * as yup from 'yup';
+import { z } from 'zod';
 
-const updateDemandSchema = yup.object().shape({
-  'Prise de contact': yup.boolean().optional(),
-  Commentaire: yup.string().optional(),
-  Status: yup.string().optional().oneOf(Object.values(DEMANDE_STATUS)),
-});
-
-const dealErrors = (res: NextApiResponse, error: any) => {
-  if (error) {
-    console.error(error);
-    res.statusCode = 502;
-    return res.json({
-      message: error,
-      code: 'Internal Server Error',
-    });
-  }
+const zDemandUpdate = {
+  Status: z.nativeEnum(DEMANDE_STATUS).optional(),
+  'Prise de contact': z.boolean().optional(),
+  'Gestionnaire Distance au réseau': z.number().optional(),
+  'Gestionnaire Logement': z.number().optional(),
+  'Gestionnaire Conso': z.number().optional(),
+  Commentaire: z.string().optional(),
+  'Gestionnaire Affecté à': z.string().optional(),
 };
 
-export default async function demand(
-  req: NextApiRequest,
-  res: NextApiResponse
-) {
-  const { demandId } = req.query;
-  const user = await authenticatedUser(req, res);
-  if (!user) {
-    return res.status(204).json({});
+export type DemandUpdate = z.infer<z.ZodObject<typeof zDemandUpdate>>;
+
+export default handleRouteErrors(
+  async (req: NextApiRequest) => {
+    requirePutMethod(req);
+
+    const demandUpdate = await validateObjectSchema(req.body, zDemandUpdate);
+
+    const demand = await updateDemand(
+      req.user,
+      req.query.demandId as string,
+      demandUpdate
+    );
+    return demand;
+  },
+  {
+    requireAuthentication: ['gestionnaire'],
   }
-
-  if (req.method !== 'PUT') {
-    return res.status(501);
-  }
-  try {
-    const body = req.body;
-
-    if (!(await updateDemandSchema.isValid(body))) {
-      return res.status(400).send('Error');
-    }
-
-    const demand = await updateDemand(user, demandId as string, body);
-
-    const error = (demand as any)?.error;
-    if (error) {
-      dealErrors(res, error);
-    }
-    return res.status(200).json(demand);
-  } catch (error) {
-    console.error(error);
-    res.statusCode = 500;
-    return res.json({
-      message: 'internal server error',
-      code: 'Internal Server Error',
-    });
-  }
-}
+);

--- a/src/pages/api/eligibilityDemands.ts
+++ b/src/pages/api/eligibilityDemands.ts
@@ -1,61 +1,46 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
+import { handleRouteErrors, requireGetMethod } from '@helpers/server';
+import type { NextApiRequest } from 'next';
 import db from 'src/db';
-import { authenticatedUser } from 'src/services/api/authentication';
 import { EligibilityDemand } from 'src/types/EligibilityDemand';
-import { USER_ROLE } from 'src/types/enum/UserRole';
 
-export default async function eligibilityDemands(
-  req: NextApiRequest,
-  res: NextApiResponse
-) {
-  try {
-    const user = await authenticatedUser(req, res);
-    if (!user || user.role !== USER_ROLE.ADMIN) {
-      return res.status(204).json([]);
-    }
+export default handleRouteErrors(
+  async (req: NextApiRequest) => {
+    requireGetMethod(req);
 
-    if (req.method === 'GET') {
-      const demands = await db
-        .from('eligibility_demands')
-        .leftJoin(
-          'eligibility_tests',
-          'eligibility_demands.eligibility_test_id',
-          'eligibility_tests.id'
-        )
-        .select([
-          'email',
-          'eligibility_tests.id',
-          'eligibility_demands.created_at',
-          'version',
-          'addresses_count',
-          'error_count',
-          'eligibile_count',
-          'in_error',
-        ])
-        .orderBy('created_at', 'desc');
-      const demandsById: Record<string, EligibilityDemand> = {};
-      demands.forEach((demand) => {
-        const existingDemand = demandsById[demand.id];
-        if (existingDemand) {
-          existingDemand.emails.push(demand.email);
-        } else {
-          demandsById[demand.id] = {
-            ...demand,
-            email: undefined,
-            emails: [demand.email],
-          };
-        }
-      });
-      return res.status(200).json(Object.values(demandsById));
-    }
-
-    return res.status(501);
-  } catch (error) {
-    console.error(error);
-    res.statusCode = 500;
-    return res.json({
-      message: 'internal server error',
-      code: 'Internal Server Error',
+    const demands = await db
+      .from('eligibility_demands')
+      .leftJoin(
+        'eligibility_tests',
+        'eligibility_demands.eligibility_test_id',
+        'eligibility_tests.id'
+      )
+      .select([
+        'email',
+        'eligibility_tests.id',
+        'eligibility_demands.created_at',
+        'version',
+        'addresses_count',
+        'error_count',
+        'eligibile_count',
+        'in_error',
+      ])
+      .orderBy('created_at', 'desc');
+    const demandsById: Record<string, EligibilityDemand> = {};
+    demands.forEach((demand) => {
+      const existingDemand = demandsById[demand.id];
+      if (existingDemand) {
+        existingDemand.emails.push(demand.email);
+      } else {
+        demandsById[demand.id] = {
+          ...demand,
+          email: undefined,
+          emails: [demand.email],
+        };
+      }
     });
+    return Object.values(demandsById);
+  },
+  {
+    requireAuthentication: ['admin'],
   }
-}
+);

--- a/src/pages/api/users.ts
+++ b/src/pages/api/users.ts
@@ -1,31 +1,18 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
+import { handleRouteErrors, requireGetMethod } from '@helpers/server';
+import type { NextApiRequest } from 'next';
 import db from 'src/db';
-import { authenticatedUser } from 'src/services/api/authentication';
-import { USER_ROLE } from 'src/types/enum/UserRole';
 
-export default async function users(req: NextApiRequest, res: NextApiResponse) {
-  try {
-    const user = await authenticatedUser(req, res);
-    if (!user || user.role !== USER_ROLE.ADMIN) {
-      return res.status(204).json([]);
-    }
-
-    if (req.method === 'GET') {
-      const users = await db('users')
-        .select(['email', 'last_connection'])
-        .whereNotNull('last_connection')
-        .andWhere('active', true)
-        .orderBy('last_connection', 'desc');
-      return res.status(200).json(users);
-    }
-
-    return res.status(501);
-  } catch (error) {
-    console.error(error);
-    res.statusCode = 500;
-    return res.json({
-      message: 'internal server error',
-      code: 'Internal Server Error',
-    });
+export default handleRouteErrors(
+  async (req: NextApiRequest) => {
+    requireGetMethod(req);
+    const users = await db('users')
+      .select(['email', 'last_connection'])
+      .whereNotNull('last_connection')
+      .andWhere('active', true)
+      .orderBy('last_connection', 'desc');
+    return users;
+  },
+  {
+    requireAuthentication: ['admin'],
   }
-}
+);

--- a/src/services/api/authentication.ts
+++ b/src/services/api/authentication.ts
@@ -1,24 +1,6 @@
-import { nextAuthOptions } from '@pages/api/auth/[...nextauth]';
 import { NextApiRequest, NextApiResponse } from 'next';
-import { User, getServerSession } from 'next-auth';
 import db from 'src/db';
 import { ApiAccount } from 'src/types/ApiAccount';
-
-export const authenticatedUser = async (
-  req: NextApiRequest,
-  res: NextApiResponse
-): Promise<User | null> => {
-  const session = await getServerSession(req, res, nextAuthOptions);
-  if (!session) {
-    return null;
-  }
-
-  await db('users')
-    .where({ email: session.user.email })
-    .update({ last_connection: new Date() });
-
-  return session.user;
-};
 
 export const apiUser = async (
   req: NextApiRequest,

--- a/src/types/User.d.ts
+++ b/src/types/User.d.ts
@@ -1,7 +1,10 @@
 export interface User {
+  id: string;
+  email: string;
   role: USER_ROLE;
   gestionnaires: string[];
-  email: string;
   receive_new_demands: boolean;
   receive_old_demands: boolean;
+  active: boolean;
+  created_at: Date;
 }


### PR DESCRIPTION
- dans le callback session de next-auth, j'ai ajouté la récupération de l'utilisateur depuis postgres, via son email (stocké dans le cookie de session, avec d'autres données de l'utilisateur) + mise à jour de last_connection
- dans le helper handleErrors qui gère les erreurs et simplifie pas mal de choses, j'ai ajouté une option pour les routes qui demandent une authentification et/ou des permissions spécifiques (comme un rôle particulier)
- l'utilisateur de la session (à jour) est forwardé via req.user au cas où une route doive accéder à plus de choses, par exemple pour vérifier que les tags gestionnaires correspondent bien à la ressource accédée.
- j'ai revue la gestion des erreurs de quelques routes, et pour avoir des logs. :upside_down_face: 

J'ai testé sur ma base de dev airtable :
- Créé d'une ligne dans airtable FCU - Gestionnaires
- Synchronisation des users airtable -> postgres avec `npx tsx src/cron_jobs/manual-job.ts updateUsers`
- Login avec ce compte, et je vois 800 demandes,
- Modification des tags dans airtable
- Nouvelle synchronisation
- Rafraichissement de la page => le nombre de demandes change (en plus ou moins)
