### PR TITLE
fix: openapi schema CORS

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -152,6 +152,19 @@ module.exports = withBundleAnalyzer(
             source: '/:path*',
             headers: securityHeaders,
           },
+          {
+            source: '/openapi-schema.yaml',
+            headers: [
+              {
+                key: 'Access-Control-Allow-Methods',
+                value: 'GET, OPTIONS',
+              },
+              {
+                key: 'Access-Control-Allow-Origin',
+                value: '*',
+              },
+            ],
+          },
 
           // Attention: keep in sync with src/services/iframe.ts
           ...[


### PR DESCRIPTION
Modification afin d'autoriser le générateur de doc OpenAPI de api.gouv.fr d'accéder à notre schéma openapi.