### PR TITLE
feat: add form ids

### DIFF
--- a/src/components/EligibilityForm/components/ContactForm.tsx
+++ b/src/components/EligibilityForm/components/ContactForm.tsx
@@ -13,6 +13,7 @@ import ContactInformation, {
   validationSchemasContactInformation,
 } from './ContactInformation';
 import { ContactFormFooter } from './EligibilityForm.styled';
+import { AnalyticsFormId } from 'src/services/analytics';
 
 type ContactFormProps = {
   onSubmit: (values: FormikValues) => void;
@@ -59,7 +60,7 @@ export const ContactForm = ({
       onSubmit={handleSubmit}
     >
       {(formik) => (
-        <Form ref={formRef}>
+        <Form id={AnalyticsFormId.form_contact} ref={formRef}>
           <ContactInformation cardMode={cardMode} city={city} />
           <ContactConsent />
           <ContactFormFooter>

--- a/src/components/HeadSliceForm/HeadSliceForm.tsx
+++ b/src/components/HeadSliceForm/HeadSliceForm.tsx
@@ -32,6 +32,7 @@ import {
   Separator,
   SliceContactFormStyle,
 } from './HeadSliceForm.style';
+import { AnalyticsFormId } from 'src/services/analytics';
 
 type HeadBannerType = {
   bg?: string;
@@ -156,58 +157,62 @@ const HeadSlice = ({
       checkEligibility ? (
         <>
           {child}
-          {formLabel ? <FormLabel>{formLabel}</FormLabel> : undefined}
-          <CheckEligibilityFormLabel>
-            <SelectEnergy
-              name="heatingType"
-              selectOptions={energyInputsDefaultLabels}
-              onChange={(e) => setHeatingType(e.target.value)}
-              value={heatingType || ''}
+          <form id={AnalyticsFormId.form_test_adresse}>
+            {formLabel ? <FormLabel>{formLabel}</FormLabel> : undefined}
+            <CheckEligibilityFormLabel>
+              <SelectEnergy
+                name="heatingType"
+                selectOptions={energyInputsDefaultLabels}
+                onChange={(e) => setHeatingType(e.target.value)}
+                value={heatingType || ''}
+              />
+            </CheckEligibilityFormLabel>
+            <AddressAutocomplete
+              placeholder="Tapez ici votre adresse"
+              onAddressSelected={(address, suggestionItem) => {
+                setAddress(address);
+                setGeoAddress(suggestionItem);
+                return Promise.resolve();
+              }}
+              popoverClassName={'popover-search-form'}
             />
-          </CheckEligibilityFormLabel>
-          <AddressAutocomplete
-            placeholder="Tapez ici votre adresse"
-            onAddressSelected={(address, suggestionItem) => {
-              setAddress(address);
-              setGeoAddress(suggestionItem);
-              return Promise.resolve();
-            }}
-            popoverClassName={'popover-search-form'}
-          />
 
-          <FormWarningMessage show={!!(address && geoAddress && !heatingType)}>
-            {warningMessage}
-          </FormWarningMessage>
-
-          <LoaderWrapper show={!showWarning && loadingStatus === 'loading'}>
-            <Loader color="#fff" />
-          </LoaderWrapper>
-
-          <Buttons>
-            <Button
-              size="lg"
-              disabled={!address || !geoAddress || !heatingType}
-              onClick={testAddress}
+            <FormWarningMessage
+              show={!!(address && geoAddress && !heatingType)}
             >
-              Tester cette adresse
-            </Button>
+              {warningMessage}
+            </FormWarningMessage>
 
-            {withBulkEligibility && (
-              <>
-                <Separator />
-                <Button
-                  size="lg"
-                  secondary
-                  onClick={() => {
-                    setDisplayBulkEligibility(true);
-                    router.push('#test-liste');
-                  }}
-                >
-                  Ou tester une liste d’adresses
-                </Button>
-              </>
-            )}
-          </Buttons>
+            <LoaderWrapper show={!showWarning && loadingStatus === 'loading'}>
+              <Loader color="#fff" />
+            </LoaderWrapper>
+
+            <Buttons>
+              <Button
+                size="lg"
+                disabled={!address || !geoAddress || !heatingType}
+                onClick={testAddress}
+              >
+                Tester cette adresse
+              </Button>
+
+              {withBulkEligibility && (
+                <>
+                  <Separator />
+                  <Button
+                    size="lg"
+                    secondary
+                    onClick={() => {
+                      setDisplayBulkEligibility(true);
+                      router.push('#test-liste');
+                    }}
+                  >
+                    Ou tester une liste d’adresses
+                  </Button>
+                </>
+              )}
+            </Buttons>
+          </form>
         </>
       ) : (
         <>{child}</>

--- a/src/components/IFrame/Form/Eligibility.styles.ts
+++ b/src/components/IFrame/Form/Eligibility.styles.ts
@@ -25,7 +25,7 @@ export const Header = styled.div`
   }
 `;
 
-export const Form = styled.div`
+export const Form = styled.form`
   display: flex;
   flex-wrap: wrap;
   align-items: center;

--- a/src/components/IFrame/Form/Eligibility.tsx
+++ b/src/components/IFrame/Form/Eligibility.tsx
@@ -9,6 +9,7 @@ import { useState } from 'react';
 import { SuggestionItem } from 'src/types/Suggestions';
 import { Container, Form, Header } from './Eligibility.styles';
 import Image from 'next/image';
+import { AnalyticsFormId } from 'src/services/analytics';
 
 const Eligibility = () => {
   const [heatingType, setHeatingType] = useState('');
@@ -24,7 +25,7 @@ const Eligibility = () => {
           alt="logo france chaleur urbaine"
         />
       </Header>
-      <Form>
+      <Form id={AnalyticsFormId.form_test_adresse}>
         <CheckEligibilityFormLabel>
           <SelectEnergy
             name="heatingType"

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -88,6 +88,14 @@ Workflow du formulaire de test d'adresse :
 */
 
 /**
+ * These ids are used in Matomo to track Forms interactions.
+ */
+export enum AnalyticsFormId {
+  form_test_adresse = 'form_test_adresse',
+  form_contact = 'form_contact',
+}
+
+/**
  * List of all events tracked by analytics tools.
  */
 const trackingEvents = {


### PR DESCRIPTION
Ajout d'ids sur les formulaires de test d'adresse + contact (demandes) afin qu'Arnaud puisse paramétrer le suivi côté Matomo.
J'ai utilisé un enum TS car je n'ai pas surchargé le typage des ids HTML (trop de composants), sinon j'aurais simplement fait un string union type :grinning: 