### PR TITLE
feat: add param additionalLayers carte

### DIFF
--- a/src/components/IFrame/Map/IFrameMapIntegrationForm.tsx
+++ b/src/components/IFrame/Map/IFrameMapIntegrationForm.tsx
@@ -19,7 +19,7 @@ const selectableLayers = [
     key: 'futur_reseau',
   },
   {
-    label: 'Les périmètres de developpement prioritaire',
+    label: 'Les périmètres de développement prioritaire',
     key: 'pdp',
   },
   {

--- a/src/components/IFrame/Map/IFrameParametrization.tsx
+++ b/src/components/IFrame/Map/IFrameParametrization.tsx
@@ -75,7 +75,7 @@ const IFrameParametrization = () => {
           onClick={(e) => onCheckBoxClick(e as any, 'futur_reseau')}
         />
         <Checkbox
-          label="Les périmètres de developpement prioritaire"
+          label="Les périmètres de développement prioritaire"
           defaultChecked={true}
           onClick={(e) => onCheckBoxClick(e as any, 'pdp')}
         />

--- a/src/hooks/useInitialSearchParam.ts
+++ b/src/hooks/useInitialSearchParam.ts
@@ -1,0 +1,17 @@
+import { useSearchParams } from 'next/navigation';
+
+/**
+ * Returns the value of a search param.
+ * Works with SSR too.
+ */
+export default function useInitialSearchParam(key: string) {
+  // Not reactive, but available on the server and on page load
+  const initialSearchParams = useSearchParams();
+  return (
+    (typeof location !== 'object'
+      ? // SSR
+        initialSearchParams.get(key)
+      : // Components mounted after page load must use the current URL value
+        new URLSearchParams(location.search).get(key)) ?? null
+  );
+}

--- a/src/hooks/useURLParamOrLocalStorage.ts
+++ b/src/hooks/useURLParamOrLocalStorage.ts
@@ -1,5 +1,5 @@
-import { useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
+import useInitialSearchParam from './useInitialSearchParam';
 
 const LOCAL_STORAGE_KEY_PREFIX = '__FCU:App__-';
 
@@ -13,14 +13,7 @@ export default function useURLParamOrLocalStorage<T>(
   defaultValue: T,
   parseValue: (value: string) => T
 ): [T | null, (value: T) => void] {
-  // Not reactive, but available on the server and on page load
-  const initialSearchParams = useSearchParams();
-  const initialURLValue =
-    (typeof location !== 'object'
-      ? // SSR
-        initialSearchParams.get(urlKey)
-      : // Components mounted after page load must use the current URL value
-        new URLSearchParams(location.search).get(urlKey)) ?? null;
+  const initialURLValue = useInitialSearchParam(urlKey);
 
   const [paramValue, internalSetParamValue] = useState<T | null>(
     initialURLValue ? parseValue(initialURLValue) : null

--- a/src/pages/carte.tsx
+++ b/src/pages/carte.tsx
@@ -38,6 +38,7 @@ export const layerURLKeysToMapConfigPath = {
   batimentsFioulCollectif: 'batimentsFioulCollectif.show',
   batimentsRaccordes: 'batimentsRaccordes',
   zonesOpportunite: 'zonesOpportunite.show',
+  enrrMobilisables: 'enrrMobilisables.show',
   caracteristiquesBatiments: 'caracteristiquesBatiments',
 } as const satisfies { [key: string]: MapConfigurationProperty };
 


### PR DESCRIPTION
Sur la page /carte, nouveau paramètre `additionalLayers` pour afficher des couches par défaut. 

L'objectif est de partager via la communication un lien vers la carte avec une couche active quand on ajoute une nouvelle couche de données.

Il n'y avait pas de besoin de synchroniser la configuration de la carte dans l'URL pour le moment, donc c'est juste des couches supplémentaires affichées.