### PR TITLE
feat: impostures de profils

### DIFF
--- a/src/components/Admin/UserImpersonation.tsx
+++ b/src/components/Admin/UserImpersonation.tsx
@@ -1,0 +1,117 @@
+import {
+  Button,
+  Container,
+  Icon,
+  Select,
+  Tag,
+  TagGroup,
+} from '@dataesr/react-dsfr';
+import Heading from '@components/ui/Heading';
+import { fetchJSON, postFetchJSON } from '@utils/network';
+import { useEffect, useMemo, useState } from 'react';
+import Text from '@components/ui/Text';
+import Box from '@components/ui/Box';
+import { normalize } from '@utils/strings';
+
+interface TagOption {
+  label: string;
+  value: string;
+  searchValue: string;
+}
+
+const UserImpersonation = () => {
+  const [selectedTagsGestionnaires, setSelectedTagsGestionnaires] = useState<
+    string[]
+  >([]);
+  const [allTagsGestionnaires, setAllTagsGestionnaires] = useState<TagOption[]>(
+    []
+  );
+
+  useEffect(() => {
+    (async () => {
+      const tags = await fetchJSON<string[]>('/api/admin/tags-gestionnaires');
+      setAllTagsGestionnaires(
+        tags.sort(Intl.Collator().compare).map((tag) => ({
+          label: tag,
+          value: tag,
+          searchValue: normalize(tag),
+        }))
+      );
+    })();
+  }, []);
+
+  const selectTagsOptions = useMemo(() => {
+    return [
+      {
+        label: 'Sélectionner les tags gestionnaires',
+        value: '',
+        disabled: true,
+      },
+      ...allTagsGestionnaires,
+    ];
+  }, [allTagsGestionnaires]);
+
+  async function startImpersonation() {
+    try {
+      await postFetchJSON('/api/admin/impersonate', {
+        role: 'gestionnaire', // will probably change in the future
+        gestionnaires: selectedTagsGestionnaires,
+      });
+      // trigger a full reload
+      location.href = '/gestionnaire';
+    } catch (err) {
+      console.error('err', err);
+    }
+  }
+
+  return (
+    <Container>
+      <Box p="2w">
+        <Heading size="h3">
+          <Icon name="ri-spy-line" />
+          Impostures
+        </Heading>
+
+        <Text mb="2w">
+          Cette section permet de vous faire passer pour un profile gestionnaire
+          avec des tags particuliers à des fins de test.
+        </Text>
+
+        <TagGroup>
+          {selectedTagsGestionnaires.map((tag, index) => (
+            <Tag
+              closable
+              small
+              key={index}
+              /* @ts-expect-error problème avec la lib @dataesr/react-dsfr */
+              onClick={() => {
+                selectedTagsGestionnaires.splice(index, 1);
+                setSelectedTagsGestionnaires([...selectedTagsGestionnaires]);
+              }}
+            >
+              {tag}
+            </Tag>
+          ))}
+        </TagGroup>
+
+        <Box className="fr-col-xl-4 fr-col-md-6">
+          <Select
+            label="Tags gestionnaires"
+            options={selectTagsOptions}
+            onChange={(e) =>
+              setSelectedTagsGestionnaires([
+                ...selectedTagsGestionnaires,
+                e.target.value,
+              ])
+            }
+          />
+        </Box>
+        <Button className="fr-mt-2w" onClick={() => startImpersonation()}>
+          Lancer l'imposture
+        </Button>
+      </Box>
+    </Container>
+  );
+};
+
+export default UserImpersonation;

--- a/src/components/Admin/UserImpersonation.tsx
+++ b/src/components/Admin/UserImpersonation.tsx
@@ -73,7 +73,7 @@ const UserImpersonation = () => {
         </Heading>
 
         <Text mb="2w">
-          Cette section permet de vous faire passer pour un profile gestionnaire
+          Cette section permet de vous faire passer pour un profil gestionnaire
           avec des tags particuliers à des fins de test.
         </Text>
 

--- a/src/components/Admin/UserImpersonation.tsx
+++ b/src/components/Admin/UserImpersonation.tsx
@@ -1,11 +1,4 @@
-import {
-  Button,
-  Container,
-  Icon,
-  Select,
-  Tag,
-  TagGroup,
-} from '@dataesr/react-dsfr';
+import { Button, Container, Icon, Select } from '@dataesr/react-dsfr';
 import Heading from '@components/ui/Heading';
 import { fetchJSON, postFetchJSON } from '@utils/network';
 import { useEffect, useMemo, useState } from 'react';
@@ -77,22 +70,20 @@ const UserImpersonation = () => {
           avec des tags particuliers à des fins de test.
         </Text>
 
-        <TagGroup>
-          {selectedTagsGestionnaires.map((tag, index) => (
-            <Tag
-              closable
-              small
-              key={index}
-              /* @ts-expect-error problème avec la lib @dataesr/react-dsfr */
-              onClick={() => {
-                selectedTagsGestionnaires.splice(index, 1);
-                setSelectedTagsGestionnaires([...selectedTagsGestionnaires]);
-              }}
-            >
-              {tag}
-            </Tag>
-          ))}
-        </TagGroup>
+        {selectedTagsGestionnaires.map((tag, index) => (
+          <button
+            key={index}
+            title="Retirer ce tag"
+            className="fr-tag fr-tag--sm fr-tag--dismiss fr-mr-1v"
+            onClick={() => {
+              selectedTagsGestionnaires.splice(index, 1);
+              setSelectedTagsGestionnaires([...selectedTagsGestionnaires]);
+            }}
+          >
+            {tag}
+            <Icon iconPosition="right" name="ri-close-line" size="lg" />
+          </button>
+        ))}
 
         <Box className="fr-col-xl-4 fr-col-md-6">
           <Select

--- a/src/components/shared/page/SimplePage.styles.tsx
+++ b/src/components/shared/page/SimplePage.styles.tsx
@@ -1,3 +1,4 @@
+import { ToolItem } from '@dataesr/react-dsfr';
 import styled from 'styled-components';
 
 /**
@@ -32,3 +33,14 @@ export const FullScreenItems = styled.div`
     display: none;
   }
 `;
+
+export const StopImpersonationButton = styled(ToolItem)`
+  background-color: var(--background-flat-error) !important;
+  color: white !important;
+  border-radius: 6px;
+`;
+
+// Permet au composant ToolItemGroup de retrouver ce ToolItem
+StopImpersonationButton.defaultProps = {
+  __TYPE: 'ToolItem',
+};

--- a/src/components/shared/page/SimplePage.tsx
+++ b/src/components/shared/page/SimplePage.tsx
@@ -35,7 +35,9 @@ import {
   FullScreenItems,
   FullScreenModeFirstLine,
   FullScreenModeNavLogo,
+  StopImpersonationButton,
 } from './SimplePage.styles';
+import { deleteFetchJSON } from '@utils/network';
 
 type PageMode = 'public' | 'public-fullscreen' | 'authenticated';
 
@@ -293,25 +295,49 @@ const PageHeader = (props: PageHeaderProps) => {
             ))}
           </NavItem>
         ))}
-        {/* potentiellement utiliser un préfixe et asPath */}
 
         {isFullScreenMode && (
           <FullScreenItems>
-            <Tool>
-              <ToolItemGroup>
-                {props.mode === 'authenticated' ? (
-                  <ToolItem onClick={() => signOut({ callbackUrl: '/' })}>
-                    Se déconnecter
-                  </ToolItem>
-                ) : (
+            {/* beware: do not try to simplify these blocs as @dataesr/react-dsfr won't let you use fragments! */}
+            {props.mode === 'authenticated' ? (
+              session?.impersonating ? (
+                <Tool>
+                  <ToolItemGroup>
+                    <StopImpersonationButton
+                      icon="ri-logout-box-r-line"
+                      onClick={async () => {
+                        await deleteFetchJSON('/api/admin/impersonate');
+                        location.reload();
+                      }}
+                    >
+                      Imposture en cours
+                    </StopImpersonationButton>
+
+                    <ToolItem onClick={() => signOut({ callbackUrl: '/' })}>
+                      Se déconnecter
+                    </ToolItem>
+                  </ToolItemGroup>
+                </Tool>
+              ) : (
+                <Tool>
+                  <ToolItemGroup>
+                    <ToolItem onClick={() => signOut({ callbackUrl: '/' })}>
+                      Se déconnecter
+                    </ToolItem>
+                  </ToolItemGroup>
+                </Tool>
+              )
+            ) : (
+              <Tool>
+                <ToolItemGroup>
                   <ToolItem
                     asLink={<Link href="/connexion" className="fr-link" />}
                   >
                     Espace gestionnaire
                   </ToolItem>
-                )}
-              </ToolItemGroup>
-            </Tool>
+                </ToolItemGroup>
+              </Tool>
+            )}
           </FullScreenItems>
         )}
       </HeaderNav>

--- a/src/pages/admin.tsx
+++ b/src/pages/admin.tsx
@@ -1,4 +1,5 @@
 import BulkEligibility from '@components/Admin/BulkEligibility';
+import UserImpersonation from '@components/Admin/UserImpersonation';
 import Users from '@components/Admin/Users';
 import SimplePage from '@components/shared/page/SimplePage';
 import { GetServerSideProps } from 'next';
@@ -8,6 +9,7 @@ import { USER_ROLE } from 'src/types/enum/UserRole';
 export default function AdminPage(): JSX.Element {
   return (
     <SimplePage title="France Chaleur Urbaine - Admin" mode="authenticated">
+      <UserImpersonation />
       <Users />
       <BulkEligibility />
     </SimplePage>

--- a/src/pages/api/admin/impersonate.ts
+++ b/src/pages/api/admin/impersonate.ts
@@ -1,0 +1,83 @@
+import {
+  handleRouteErrors,
+  invalidPermissionsError,
+  invalidRouteError,
+  requireAuthentication,
+  requireDeleteMethod,
+  validateObjectSchema,
+} from '@helpers/server';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { JWT, decode, encode } from 'next-auth/jwt';
+import { z } from 'zod';
+import { logger } from '@helpers/logger';
+
+export default handleRouteErrors(
+  async (req: NextApiRequest, res: NextApiResponse) => {
+    if (req.method === 'DELETE') {
+      requireDeleteMethod(req);
+      const session = await requireAuthentication(req, res, true);
+      if (!session.impersonating) {
+        throw invalidPermissionsError;
+      }
+
+      // remove the impersonation
+      const { impersonatedProfile, ...jwt } = await getSessionJWT(req);
+      await generateSessionJWT(res, jwt);
+      return;
+    } else if (req.method === 'POST') {
+      await requireAuthentication(req, res, ['admin']);
+
+      const impersonatedProfile = await validateObjectSchema(req.body, {
+        role: z.literal('gestionnaire'),
+        gestionnaires: z.array(z.string()),
+      });
+
+      logger.info('impersonating', {
+        ...impersonatedProfile,
+      });
+
+      const jwt = await getSessionJWT(req);
+      await generateSessionJWT(res, {
+        ...jwt,
+        impersonatedProfile,
+      });
+      return;
+    }
+    throw invalidRouteError;
+  }
+);
+
+/**
+ * Retrieve the Next Auth JWT.
+ */
+async function getSessionJWT(req: NextApiRequest): Promise<JWT> {
+  const currentJWT = req.cookies['next-auth.session-token'];
+  const decodedJWT = await decode({
+    secret: process.env.NEXTAUTH_SECRET as string,
+    token: currentJWT,
+  });
+  return decodedJWT as JWT;
+}
+
+/**
+ * Generate a new Next Auth JWT and update the session cookie.
+ */
+async function generateSessionJWT(
+  res: NextApiResponse,
+  payload: JWT
+): Promise<void> {
+  const newJWT = await encode({
+    secret: process.env.NEXTAUTH_SECRET as string,
+    token: payload,
+  });
+  // decode to retrieve the expiration date of the JWT
+  const decodedNewJWT = await decode({
+    secret: process.env.NEXTAUTH_SECRET as string,
+    token: newJWT,
+  });
+  const cookieExpirationDate = new Date((decodedNewJWT as any).exp * 1000);
+  res.setHeader(
+    'Set-Cookie',
+    `next-auth.session-token=${newJWT}; Path=/; Expires=${cookieExpirationDate.toUTCString()}; HttpOnly; SameSite=Lax`
+  );
+}

--- a/src/pages/api/admin/tags-gestionnaires.ts
+++ b/src/pages/api/admin/tags-gestionnaires.ts
@@ -1,0 +1,17 @@
+import { handleRouteErrors, requireGetMethod } from '@helpers/server';
+import type { NextApiRequest } from 'next';
+import db from 'src/db';
+
+export default handleRouteErrors(
+  async (req: NextApiRequest) => {
+    requireGetMethod(req);
+
+    const tags = await db('users')
+      .distinct(db.raw('unnest(gestionnaires) as gestionnaire'))
+      .orderBy('gestionnaire');
+    return tags.map(({ gestionnaire }) => gestionnaire);
+  },
+  {
+    requireAuthentication: ['admin'],
+  }
+);

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -65,7 +65,13 @@ export const nextAuthOptions: AuthOptions = {
       if (token) {
         return {
           ...session,
-          user,
+          user: {
+            ...user,
+
+            // if an impersonated profile exists, override the current profile data (role, gestionnaire)
+            ...(token.impersonatedProfile ?? {}),
+          },
+          ...(token.impersonatedProfile ? { impersonating: true } : {}),
         } as Session;
       }
       return session;

--- a/src/types/NextAuth.d.ts
+++ b/src/types/NextAuth.d.ts
@@ -4,6 +4,7 @@ import { USER_ROLE } from './enum/UserRole';
 declare module 'next-auth' {
   interface Session {
     user: User;
+    impersonating?: true;
   }
 
   interface User {
@@ -16,5 +17,14 @@ declare module 'next-auth' {
 declare module 'next' {
   interface NextApiRequest {
     user: User;
+  }
+}
+
+declare module 'next-auth/jwt' {
+  interface JWT {
+    impersonatedProfile?: {
+      role: 'gestionnaire';
+      gestionnaires: string[];
+    };
   }
 }

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -24,3 +24,19 @@ export const postFetchJSON = async <Data = any>(
   }
   return await res.json();
 };
+
+export const deleteFetchJSON = async <Data = any>(
+  url: string
+): Promise<Data> => {
+  const res = await fetch(url, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+  if (res.status !== 200) {
+    // improvement idea: retrieve the message if status 400 or defaults to unknown message
+    throw new Error('failed to load data');
+  }
+  return await res.json();
+};

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -9,3 +9,15 @@ export function prettyFormatNumber(
       ).replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
     : null;
 }
+
+/**
+ * Normalize a string (lower case and remove accents).
+ */
+export function normalize(string: string | undefined | null): string {
+  return string === null || string === undefined
+    ? ''
+    : string
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '');
+}


### PR DESCRIPTION
Un admin peut maintenant se faire passer pour un utilisateur gestionnaire avec les tags gestionnaire qu'il souhaite. Permet de se passer de tous les comptes de ville et reproduire des cas particuliers sans avoir à créer de compte.

![image](https://github.com/betagouv/france-chaleur-urbaine/assets/8938024/719c0149-e743-4fa1-97c9-47a975e02abf)
![image](https://github.com/betagouv/france-chaleur-urbaine/assets/8938024/bb5ceb84-3593-41fa-8434-6f4332cda79f)

Le fonctionnement est le suivant :
- L'utilisateur (admin) envoie une requête à l'API avec le role (uniquement gestionnaire) et les tags souhaités.
- Une nouvelle session est générée et contient l'information d'imposture du profil.
- Dans les middlewares / callbacks next auth, si cette information est présente, alors on remplace les données de l'utilisateur par celles-ci, de sorte qu'elles soient disponibles partout comme si l'utilisateur avait rééllement changé de profil.
- Côté UI, on sait néanmoins qu'on est en mode imposture avec une propriété *impersonating* à *true* au niveau de la session.
- Si on choisit d'arrêter l'imposture, une nouvelle session est générée sans l'imposture cette fois, donc l'utilisateur retrouve son profil d'origine (administrateur).