### PR TITLE
feat:  revue style page actu

### DIFF
--- a/src/pages/actus/[slug].tsx
+++ b/src/pages/actus/[slug].tsx
@@ -1,25 +1,33 @@
 import MarkdownWrapper from '@components/MarkdownWrapper';
 import SimplePage from '@components/shared/page/SimplePage';
-import Slice from '@components/Slice';
+import Box from '@components/ui/Box';
+import Heading from '@components/ui/Heading';
+import Link from '@components/ui/Link';
+import Text from '@components/ui/Text';
 import { getArticle } from '@data/contents';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-import { createGlobalStyle } from 'styled-components';
+import { Article } from 'src/types/Article';
+import styled from 'styled-components';
 
-const GlobalStyle = createGlobalStyle`
-  .markdown-actu {
-    img {
-      max-width: 100%;
-    }
+const ArticleContentWrapper = styled(Box)`
+  img {
+    max-width: 100%;
   }
   a {
     word-break: break-word;
   }
 `;
 
+const ThemeTagItem = styled.li`
+  background-color: var(--blue-france-sun-113-625) !important;
+  color: white !important;
+  line-height: 1.8em !important;
+`;
+
 const Article = () => {
   const router = useRouter();
-  const [content, setContent] = useState('');
+  const [article, setArticle] = useState<Article | null>(null);
 
   useEffect(() => {
     if (!router.query.slug) {
@@ -28,18 +36,67 @@ const Article = () => {
 
     const article = getArticle(router.query.slug as string);
     if (article) {
-      setContent(article.content);
+      setArticle(article);
     } else {
       router.push('/actus');
     }
-  }, [router]);
+  }, [router.query]);
+
+  const lines = article?.content?.split('\n') ?? [];
+  const title = lines.slice(0, 1)?.[0]?.substring(1); // remove the hashtag
+  const content = lines.slice(1).join('\n');
 
   return (
-    <SimplePage currentPage="/ressources">
-      <GlobalStyle />
-      <Slice padding={8}>
-        <MarkdownWrapper value={content} className="markdown-actu" />
-      </Slice>
+    <SimplePage currentPage="/ressources" title={title}>
+      <Box className="fr-container fr-mb-n2w fr-mb-md-n4w">
+        <nav
+          role="navigation"
+          className="fr-breadcrumb"
+          aria-label="Vous êtes ici"
+        >
+          <ol className="fr-breadcrumb__list">
+            <li>
+              <Link className="fr-breadcrumb__link" href="/">
+                Accueil
+              </Link>
+            </li>
+            <li>
+              <Link className="fr-breadcrumb__link" href="/actus">
+                Nos actualités
+              </Link>
+            </li>
+            <li>
+              <a className="fr-breadcrumb__link" aria-current="page">
+                {title}
+              </a>
+            </li>
+          </ol>
+        </nav>
+      </Box>
+
+      <Box backgroundColor="blue-cumulus-950-100">
+        <Box maxWidth="1000px" mx="auto" pt="8w" pb="4w" px="2w">
+          <Heading size="h1" color="blue-france" mb="0">
+            {title}
+          </Heading>
+
+          <Text className="fr-icon-arrow-right-line" my="2w">
+            Publié le {article?.publishedDate.toLocaleDateString('fr-FR')}
+          </Text>
+
+          <ul className="fr-tags-group">
+            {article?.themes.map((theme, index) => (
+              <ThemeTagItem key={index} className="fr-tag">
+                {theme}
+              </ThemeTagItem>
+            ))}
+          </ul>
+        </Box>
+      </Box>
+
+      <ArticleContentWrapper pt="5w" pb="10w" className="fr-container">
+        <MarkdownWrapper value={content} />
+      </ArticleContentWrapper>
     </SimplePage>
   );
 };


### PR DESCRIPTION
Basé pour le moment sur #747 pour avoir les thèmes par actualité et ne contient en réalité qu'un seul [commit](https://github.com/betagouv/france-chaleur-urbaine/pull/748/commits/709df58bc1f4a2608434d829846f131e77ef8646?w=1) (avant des potentiels retours).

Transforme ça :
![image](https://github.com/betagouv/france-chaleur-urbaine/assets/8938024/73c306e4-02de-4aa7-9938-3c056d671e0e)


en ça :
![image](https://github.com/betagouv/france-chaleur-urbaine/assets/8938024/6ff7d1bb-faae-4903-b89c-b8c61dafad0b)
