### PR TITLE
feat: intégration des couches friches et parkings

### DIFF
--- a/public/img/polygon-zonesPotentielChaud.svg
+++ b/public/img/polygon-zonesPotentielChaud.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 25 25"><path fill="rgba(176, 204, 78, 0.3)" stroke="rgba(176, 204, 78, 1)" stroke-width="3" d="m2 2 22 10v11H2V2Z"/></svg>

--- a/public/img/polygon-zonesPotentielFortChaud.svg
+++ b/public/img/polygon-zonesPotentielFortChaud.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 25 25"><path fill="rgba(68, 141, 96, 0.3)" stroke="rgba(68, 141, 96, 1)" stroke-width="3" d="m2 2 22 10v11H2V2Z"/></svg>

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -8,10 +8,10 @@ import {
 } from '@commander-js/extra-typings';
 import { logger } from '@helpers/logger';
 import {
-  DataType,
+  SourceId,
   DatabaseTileInfo,
   tilesInfo,
-  zDataType,
+  zSourceId,
 } from 'src/services/tiles.config';
 import db from 'src/db';
 import { readFile } from 'fs/promises';
@@ -50,7 +50,7 @@ program
 
 program
   .command('fill-tiles')
-  .argument('<network-id>', 'Network id', (v) => zDataType.parse(v))
+  .argument('<network-id>', 'Network id', (v) => zSourceId.parse(v))
   .argument('[zoomMin]', 'Minimum zoom', parseInt, 0)
   .argument('[zoomMax]', 'Maximum zoom', parseInt, 17)
   .argument('[withIndex]', 'With index', (v) => !!v, false)
@@ -93,7 +93,7 @@ program
 
 program
   .command('update-networks')
-  .argument('<network-id>', 'Network id', (v) => zDataType.parse(v))
+  .argument('<network-id>', 'Network id', (v) => zSourceId.parse(v))
   .argument('[zoomMin]', 'Minimum zoom', parseInt, 0)
   .argument('[zoomMax]', 'Maximum zoom', parseInt, 17)
   .argument('[withIndex]', 'With index', (v) => !!v, false)
@@ -123,8 +123,8 @@ function validateKnownAirtableBase(value: string): KnownAirtableBase {
   return value as KnownAirtableBase;
 }
 
-function validateNetworkId(value: string): DataType {
-  const tileInfo = tilesInfo[value as DataType];
+function validateNetworkId(value: string): SourceId {
+  const tileInfo = tilesInfo[value as SourceId];
   if (!tileInfo || !(tileInfo as any).airtable) {
     throw new InvalidArgumentError(
       `invalid network id "${value}", expected any of ${Object.keys(
@@ -132,5 +132,5 @@ function validateNetworkId(value: string): DataType {
       )}.`
     );
   }
-  return value as DataType;
+  return value as SourceId;
 }

--- a/scripts/copyLocalTableToRemote.sh
+++ b/scripts/copyLocalTableToRemote.sh
@@ -1,0 +1,48 @@
+#!/bin/bash -e
+
+usage() {
+  echo "Usage: copyLocalTableToRemote.sh <dev|prod> <table_name>"
+  echo "Used to synchronize a local table with a remote table (dropped and recreated each sync)"
+  echo "Use the env variable SCALINGO_TUNNEL_ARGS=\"-i $HOME/.ssh/keys/path_to_keys_ed\" if your SSH key is not ~/.ssh/id_rsa"
+}
+
+env=$1
+table=$2
+if [[ $env != "dev" && $env != "prod" ]]; then
+  usage
+  exit 1
+fi
+
+if [[ "$table" = "" ]]; then
+  usage
+  exit 1
+fi
+
+# export depuis BDD locale
+pg_dump postgres://postgres:postgres_fcu@localhost:5432 --format=c --no-owner -t ${table} >/tmp/table.dump
+
+if [[ $env = "prod" ]]; then
+  SCALINGO_APP=france-chaleur-urbaine
+else
+  SCALINGO_APP=france-chaleur-urbaine-dev
+fi
+
+echo "> Synchronisation de la table locale '$table' vers l'environnement $env..."
+
+# ouvre un tunnel vers BDD cible
+scalingo -a $SCALINGO_APP db-tunnel $SCALINGO_TUNNEL_ARGS SCALINGO_POSTGRESQL_URL &
+sleep 4
+
+# import vers BDD cible
+POSTGRESQL_URL=$(scalingo -a $SCALINGO_APP env-get SCALINGO_POSTGRESQL_URL)
+export PGUSER=$(expr $POSTGRESQL_URL : '.*/\([^:]*\):.*')
+export PGPASSWORD=$(expr $POSTGRESQL_URL : '.*:\([^@]*\)@.*')
+
+# drop if exists
+psql postgres://localhost:10000 -c "drop table if exists ${table};"
+pg_restore --no-owner -d postgres://localhost:10000 /tmp/table.dump
+
+# ferme le tunnel
+kill %1
+
+echo "> Synchronisation terminée sur $env pour la table '$table'"

--- a/scripts/copyLocalTableToRemote.sh
+++ b/scripts/copyLocalTableToRemote.sh
@@ -1,13 +1,15 @@
 #!/bin/bash -e
 
 usage() {
-  echo "Usage: copyLocalTableToRemote.sh <dev|prod> <table_name>"
+  echo "Usage: copyLocalTableToRemote.sh <dev|prod> <table_name> [--data-only]"
   echo "Used to synchronize a local table with a remote table (dropped and recreated each sync)"
+  echo "Use --data-only to perform a zero downtime update (in a transaction)"
   echo "Use the env variable SCALINGO_TUNNEL_ARGS=\"-i $HOME/.ssh/keys/path_to_keys_ed\" if your SSH key is not ~/.ssh/id_rsa"
 }
 
 env=$1
 table=$2
+options=$3
 if [[ $env != "dev" && $env != "prod" ]]; then
   usage
   exit 1
@@ -18,8 +20,16 @@ if [[ "$table" = "" ]]; then
   exit 1
 fi
 
+if [[ $options == "--data-only" ]] ; then
+  dataonly=true
+fi
+
 # export depuis BDD locale
-pg_dump postgres://postgres:postgres_fcu@localhost:5432 --format=c --no-owner -t ${table} >/tmp/table.dump
+if [[ $dataonly = "true" ]]; then
+  pg_dump postgres://postgres:postgres_fcu@localhost:5432/postgres --data-only -t $table >/tmp/table.dump.sql
+else
+  pg_dump postgres://postgres:postgres_fcu@localhost:5432/postgres --format=c --no-owner -t $table >/tmp/table.dump
+fi
 
 if [[ $env = "prod" ]]; then
   SCALINGO_APP=france-chaleur-urbaine
@@ -38,9 +48,14 @@ POSTGRESQL_URL=$(scalingo -a $SCALINGO_APP env-get SCALINGO_POSTGRESQL_URL)
 export PGUSER=$(expr $POSTGRESQL_URL : '.*/\([^:]*\):.*')
 export PGPASSWORD=$(expr $POSTGRESQL_URL : '.*:\([^@]*\)@.*')
 
-# drop if exists
-psql postgres://localhost:10000 -c "drop table if exists ${table};"
-pg_restore --no-owner -d postgres://localhost:10000 /tmp/table.dump
+# copie des données
+if [[ $dataonly = "true" ]]; then
+  # noter le delete plutôt que truncate pour ne pas locker la table et bloquer les requêtes
+  psql -v ON_ERROR_STOP=1 postgres://localhost:10000 --single-transaction -c "delete from $table;" -f /tmp/table.dump.sql
+else
+  pg_restore --no-owner --clean --if-exists -d postgres://localhost:10000 /tmp/table.dump
+fi
+
 
 # ferme le tunnel
 kill %1

--- a/scripts/fillTiles.ts
+++ b/scripts/fillTiles.ts
@@ -1,4 +1,4 @@
-import { DataType } from '../src/services/tiles.config';
+import { SourceId } from '../src/services/tiles.config';
 import { fillTiles } from './utils/tiles';
 
 if (process.argv.length !== 5 && process.argv.length !== 6) {
@@ -14,7 +14,7 @@ const zoomMax = process.argv[4];
 const index = process.argv[5];
 
 fillTiles(
-  table as DataType,
+  table as SourceId,
   parseInt(zoomMin),
   parseInt(zoomMax),
   index !== undefined

--- a/scripts/networks/download-network.ts
+++ b/scripts/networks/download-network.ts
@@ -3,7 +3,7 @@ import { Record } from 'airtable';
 import db from 'src/db';
 import base from 'src/db/airtable';
 import {
-  DataType,
+  SourceId,
   DatabaseTileInfo,
   tilesInfo,
 } from 'src/services/tiles.config';
@@ -132,7 +132,7 @@ const conversionConfigAutres = {
 /**
  * Synchronise les données d'une table réseau dans Airtable vers la table correspondante dans Postgres.
  */
-export const downloadNetwork = async (table: DataType) => {
+export const downloadNetwork = async (table: SourceId) => {
   const tileInfo = tilesInfo[table] as DatabaseTileInfo;
   if (!tileInfo || !tileInfo.airtable) {
     throw new Error(`${table} not managed`);
@@ -248,7 +248,7 @@ export const downloadNetwork = async (table: DataType) => {
  * Les noms de colonne sont identiques, seuls les types sont corrigés et nettoyés.
  */
 function convertEntityFromAirtableToPostgres(
-  type: DataType,
+  type: SourceId,
   airtableNetwork: Record<FieldSet>
 ) {
   const conversionConfig =

--- a/scripts/utils/tiles.ts
+++ b/scripts/utils/tiles.ts
@@ -3,7 +3,7 @@ import vtpbf from 'vt-pbf';
 import db from 'src/db';
 import {
   DatabaseTileInfo,
-  DataType,
+  SourceId,
   preTable,
   tilesInfo,
 } from 'src/services/tiles.config';
@@ -83,7 +83,7 @@ const tileToEnvelope = (x: number, y: number, z: number) => {
 };
 
 export const fillTiles = async (
-  table: DataType,
+  table: SourceId,
   zoomMin: number,
   zoomMax: number,
   withIndex: boolean

--- a/src/components/Map/Map.style.tsx
+++ b/src/components/Map/Map.style.tsx
@@ -308,10 +308,9 @@ export const PopupTitle = styled.h3`
   margin-bottom: 8px;
 `;
 
-export const PopupType = styled.span`
+export const PopupType = styled.div`
   color: #78818d;
   font-size: 0.75rem;
   font-weight: bold;
   text-transform: uppercase;
-  padding-bottom: 1em;
 `;

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -67,7 +67,6 @@ import {
 } from 'src/services/Map/map-configuration';
 import {
   LayerId,
-  SourceId,
   applyMapConfigurationToLayers,
   buildMapLayers,
   layerSymbolsImagesURLs,
@@ -77,6 +76,7 @@ import useRouterReady from '@hooks/useRouterReady';
 import MapSearchForm from './components/MapSearchForm';
 import CardSearchDetails from './components/CardSearchDetails';
 import { layersWithDynamicContentPopup } from './components/DynamicMapPopupContent';
+import { SourceId } from 'src/services/tiles.config';
 
 const mapSettings = {
   defaultLongitude: 2.3,

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -429,6 +429,14 @@ const Map = ({
       { layer: 'energy', key: 'energy' },
       { layer: 'batimentsRaccordes', key: 'raccordement' },
       {
+        layer: 'enrrMobilisables-friches',
+        key: 'enrrMobilisables-friche',
+      },
+      {
+        layer: 'enrrMobilisables-parkings',
+        key: 'enrrMobilisables-parking',
+      },
+      {
         layer: 'enrrMobilisables-datacenter',
         key: 'enrrMobilisables-datacenter',
       },

--- a/src/components/Map/components/DynamicMapPopupContent.tsx
+++ b/src/components/Map/components/DynamicMapPopupContent.tsx
@@ -413,7 +413,7 @@ const ENRRMobilisableSolaireThermiqueParkingPopupContent = ({
 }) => {
   return (
     <section>
-      <PopupTitle className="fr-mr-3w">Parking</PopupTitle>
+      <PopupType className="fr-mr-3w">Parking</PopupType>
       <PopupProperty label="Surface" value={parking.surfm2} unit="m²" />
     </section>
   );

--- a/src/components/Map/components/DynamicMapPopupContent.tsx
+++ b/src/components/Map/components/DynamicMapPopupContent.tsx
@@ -7,6 +7,8 @@ import {
   Datacenter,
   Industrie,
   InstallationElectrogene,
+  SolaireThermiqueFriche,
+  SolaireThermiqueParking,
   StationDEpuration,
   UniteDIncineration,
 } from 'src/types/layers/enrr_mobilisables';
@@ -21,6 +23,8 @@ export const layersWithDynamicContentPopup = [
   'enrrMobilisables-installations-electrogenes',
   'enrrMobilisables-stations-d-epuration',
   'enrrMobilisables-unites-d-incineration',
+  'enrrMobilisables-friches',
+  'enrrMobilisables-parkings',
 ] as const satisfies ReadonlyArray<LayerId>;
 
 export function isDynamicPopupContent(
@@ -45,7 +49,9 @@ type ENRRMobilisablePopupContentType =
   | ENRRMobilisableIndustriePopupContentType
   | ENRRMobilisableInstallationsElectrogenesPopupContentType
   | ENRRMobilisableStationsDEpurationPopupContentType
-  | ENRRMobilisableUniteDIncinerationPopupContentType;
+  | ENRRMobilisableUniteDIncinerationPopupContentType
+  | ENRRMobilisableFrichePopupContentType
+  | ENRRMobilisableParkingPopupContentType;
 
 type ENRRMobilisableDatacenterPopupContentType = {
   type: 'enrrMobilisables-datacenter';
@@ -66,6 +72,14 @@ type ENRRMobilisableStationsDEpurationPopupContentType = {
 type ENRRMobilisableUniteDIncinerationPopupContentType = {
   type: 'enrrMobilisables-unites-d-incineration';
   properties: UniteDIncineration;
+};
+type ENRRMobilisableFrichePopupContentType = {
+  type: 'enrrMobilisables-friches';
+  properties: SolaireThermiqueFriche;
+};
+type ENRRMobilisableParkingPopupContentType = {
+  type: 'enrrMobilisables-parkings';
+  properties: SolaireThermiqueParking;
 };
 
 /**
@@ -116,6 +130,18 @@ const DynamicPopupContent = ({
       return (
         <ENRRMobilisableUniteDIncinerationPopupContent
           uniteDIncineration={content.properties}
+        />
+      );
+    case 'enrrMobilisables-friches':
+      return (
+        <ENRRMobilisableSolaireThermiqueFrichePopupContent
+          friche={content.properties}
+        />
+      );
+    case 'enrrMobilisables-parkings':
+      return (
+        <ENRRMobilisableSolaireThermiqueParkingPopupContent
+          parking={content.properties}
         />
       );
     default:
@@ -343,7 +369,9 @@ const PopupProperty = <T,>({
     {isDefined(value)
       ? isDefined(formatter)
         ? formatter(value)
-        : `${value} ${unit ?? ''}`
+        : `${typeof value === 'number' ? prettyFormatNumber(value) : value} ${
+            unit ?? ''
+          }`
       : 'Non connu'}
     <br />
   </>
@@ -363,3 +391,30 @@ const QualiteLabel = ({ value }: { value: string | number }) => (
       ''}
   </Text>
 );
+
+const ENRRMobilisableSolaireThermiqueFrichePopupContent = ({
+  friche,
+}: {
+  friche: SolaireThermiqueFriche;
+}) => {
+  return (
+    <section>
+      <PopupType className="fr-mr-3w">Friche</PopupType>
+      <PopupTitle className="fr-mr-3w">{friche.site_nom}</PopupTitle>
+      <PopupProperty label="Surface" value={friche.surf_site} unit="m²" />
+    </section>
+  );
+};
+
+const ENRRMobilisableSolaireThermiqueParkingPopupContent = ({
+  parking,
+}: {
+  parking: SolaireThermiqueParking;
+}) => {
+  return (
+    <section>
+      <PopupTitle className="fr-mr-3w">Parking</PopupTitle>
+      <PopupProperty label="Surface" value={parking.surfm2} unit="m²" />
+    </section>
+  );
+};

--- a/src/components/Map/components/IconPolygon.tsx
+++ b/src/components/Map/components/IconPolygon.tsx
@@ -1,0 +1,35 @@
+import {
+  SpacingProperties,
+  spacingsToClasses,
+} from '@components/ui/helpers/spacings';
+import { ratioToHex } from '@utils/strings';
+
+interface IconPolygonProps extends SpacingProperties {
+  stroke: `#${string}`;
+  fillOpacity?: number;
+}
+
+const IconPolygon = ({
+  stroke,
+  fillOpacity = 0.3,
+  ...props
+}: IconPolygonProps) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 25 25"
+      className={`${spacingsToClasses(props)}`}
+    >
+      <path
+        fill={`${stroke}${ratioToHex(fillOpacity)}`}
+        stroke={stroke}
+        stroke-width="3"
+        d="m2 2 22 10v11H2V2Z"
+      />
+    </svg>
+  );
+};
+
+export default IconPolygon;

--- a/src/components/Map/components/SimpleMapLegend.tsx
+++ b/src/components/Map/components/SimpleMapLegend.tsx
@@ -37,6 +37,11 @@ import {
   PotentielsRaccordementButton,
   SingleCheckbox,
 } from './SimpleMapLegend.style';
+import IconPolygon from './IconPolygon';
+import {
+  themeDefSolaireThermiqueFriches,
+  themeDefSolaireThermiqueParkings,
+} from 'src/services/Map/businessRules/enrrMobilisables';
 
 const consommationsGazLegendColor = '#D9D9D9';
 const consommationsGazUsageLegendOpacity = 0.53;
@@ -1219,6 +1224,74 @@ function SimpleMapLegend({
                   px="1v"
                 >
                   Installations électrogènes
+                </Text>
+              </Box>
+
+              <Box display="flex">
+                <SingleCheckbox
+                  id="friches"
+                  checked={
+                    mapConfiguration.enrrMobilisables
+                      .showSolaireThermiqueFriches
+                  }
+                  onChange={() =>
+                    toggleLayer('enrrMobilisables.showSolaireThermiqueFriches')
+                  }
+                  trackingEvent="Carto|Solaire thermique - friches"
+                />
+
+                <IconPolygon
+                  stroke={themeDefSolaireThermiqueFriches.color}
+                  fillOpacity={themeDefSolaireThermiqueFriches.opacity}
+                  mt="1v"
+                />
+
+                <Text
+                  as="label"
+                  htmlFor="friches"
+                  fontSize="14px"
+                  lineHeight="18px"
+                  className="fr-col"
+                  fontWeight="bold"
+                  cursor="pointer"
+                  pt="1v"
+                  px="1v"
+                >
+                  Solaire thermique - friches
+                </Text>
+              </Box>
+
+              <Box display="flex">
+                <SingleCheckbox
+                  id="parkings"
+                  checked={
+                    mapConfiguration.enrrMobilisables
+                      .showSolaireThermiqueParkings
+                  }
+                  onChange={() =>
+                    toggleLayer('enrrMobilisables.showSolaireThermiqueParkings')
+                  }
+                  trackingEvent="Carto|Solaire thermique - parkings"
+                />
+
+                <IconPolygon
+                  stroke={themeDefSolaireThermiqueParkings.color}
+                  fillOpacity={themeDefSolaireThermiqueParkings.opacity}
+                  mt="1v"
+                />
+
+                <Text
+                  as="label"
+                  htmlFor="parkings"
+                  fontSize="14px"
+                  lineHeight="18px"
+                  className="fr-col"
+                  fontWeight="bold"
+                  cursor="pointer"
+                  pt="1v"
+                  px="1v"
+                >
+                  Solaire thermique - parkings
                 </Text>
               </Box>
             </DeactivatableBox>

--- a/src/components/Map/components/SimpleMapLegend.tsx
+++ b/src/components/Map/components/SimpleMapLegend.tsx
@@ -42,6 +42,10 @@ import {
   themeDefSolaireThermiqueFriches,
   themeDefSolaireThermiqueParkings,
 } from 'src/services/Map/businessRules/enrrMobilisables';
+import {
+  themeDefZonePotentielChaud,
+  themeDefZonePotentielFortChaud,
+} from 'src/services/Map/businessRules/zonePotentielChaud';
 
 const consommationsGazLegendColor = '#D9D9D9';
 const consommationsGazUsageLegendOpacity = 0.53;
@@ -855,12 +859,10 @@ function SimpleMapLegend({
               trackingEvent="Carto|Zones d'opportunité"
             />
 
-            <Image
-              src="/img/polygon-zonesPotentielFortChaud.svg"
-              alt=""
-              height="16"
-              width="16"
-              className="fr-mt-1v"
+            <IconPolygon
+              stroke={themeDefZonePotentielFortChaud.fill.color}
+              fillOpacity={themeDefZonePotentielFortChaud.fill.opacity}
+              mt="1v"
             />
 
             <Text
@@ -929,12 +931,10 @@ function SimpleMapLegend({
                   trackingEvent="Carto|Zones à potentiel chaud"
                 />
 
-                <Image
-                  src="/img/polygon-zonesPotentielChaud.svg"
-                  alt=""
-                  height="16"
-                  width="16"
-                  className="fr-mt-1v"
+                <IconPolygon
+                  stroke={themeDefZonePotentielChaud.fill.color}
+                  fillOpacity={themeDefZonePotentielChaud.fill.opacity}
+                  mt="1v"
                 />
 
                 <Text
@@ -964,12 +964,10 @@ function SimpleMapLegend({
                   trackingEvent="Carto|Zones à potentiel fort chaud"
                 />
 
-                <Image
-                  src="/img/polygon-zonesPotentielFortChaud.svg"
-                  alt=""
-                  height="16"
-                  width="16"
-                  className="fr-mt-1v"
+                <IconPolygon
+                  stroke={themeDefZonePotentielFortChaud.fill.color}
+                  fillOpacity={themeDefZonePotentielFortChaud.fill.opacity}
+                  mt="1v"
                 />
 
                 <Text

--- a/src/components/Map/map-layers.ts
+++ b/src/components/Map/map-layers.ts
@@ -25,6 +25,10 @@ import {
 
 import { ENERGY_TYPE, ENERGY_USED } from 'src/types/enum/EnergyType';
 import { MapConfiguration } from 'src/services/Map/map-configuration';
+import {
+  themeDefSolaireThermiqueFriches,
+  themeDefSolaireThermiqueParkings,
+} from 'src/services/Map/businessRules/enrrMobilisables';
 
 export const tileSourcesMaxZoom = 17;
 
@@ -241,6 +245,8 @@ export type SourceId =
   | 'energy' // batiments collectifs chauffés au fioul / gas
   | 'raccordements' // bâtiments raccordés
   | 'enrrMobilisables'
+  | 'enrrMobilisables-friches'
+  | 'enrrMobilisables-parkings'
   | 'zonesPotentielChaud'
   | 'zonesPotentielFortChaud'
   | 'buildings'; // caractéristiques des bâtiments
@@ -262,6 +268,10 @@ export type LayerId =
   | 'enrrMobilisables-installations-electrogenes'
   | 'enrrMobilisables-stations-d-epuration'
   | 'enrrMobilisables-unites-d-incineration'
+  | 'enrrMobilisables-friches'
+  | 'enrrMobilisables-friches-contour'
+  | 'enrrMobilisables-parkings'
+  | 'enrrMobilisables-parkings-contour'
   | 'zonesPotentielChaud'
   | 'zonesPotentielChaud-contour'
   | 'zonesPotentielFortChaud'
@@ -459,6 +469,88 @@ export function buildMapLayers(
               intermediateTileLayersMinZoom + 0.2 + 1,
               themeDefBuildings.opacity,
             ],
+          },
+        },
+      ],
+    },
+
+    // --------------------------------------------
+    // ---      Friches solaire thermique       ---
+    // --------------------------------------------
+    {
+      sourceId: 'enrrMobilisables-friches',
+      source: {
+        type: 'vector',
+        tiles: [
+          `${location.origin}/api/map/enrrMobilisables-friches/{z}/{x}/{y}`,
+        ],
+        promoteId: 'GmlID',
+        maxzoom: tileSourcesMaxZoom,
+        attribution:
+          '<a href="https://reseaux-chaleur.cerema.fr/espace-documentaire/enrezo" target="_blank">Cerema</a>',
+      },
+      layers: [
+        {
+          id: 'enrrMobilisables-friches',
+          source: 'enrrMobilisables-friches',
+          'source-layer': 'layer',
+          minzoom: tileLayersMinZoom,
+          type: 'fill',
+          paint: {
+            'fill-color': themeDefSolaireThermiqueFriches.color,
+            'fill-opacity': themeDefSolaireThermiqueFriches.opacity,
+          },
+        },
+        {
+          id: 'enrrMobilisables-friches-contour',
+          source: 'enrrMobilisables-friches',
+          'source-layer': 'layer',
+          minzoom: tileLayersMinZoom,
+          type: 'line',
+          paint: {
+            'line-color': themeDefSolaireThermiqueFriches.color,
+            'line-width': 2,
+          },
+        },
+      ],
+    },
+
+    // --------------------------------------------
+    // ---      Parkings de plus de 500m²       ---
+    // --------------------------------------------
+    {
+      sourceId: 'enrrMobilisables-parkings',
+      source: {
+        type: 'vector',
+        tiles: [
+          `${location.origin}/api/map/enrrMobilisables-parkings/{z}/{x}/{y}`,
+        ],
+        promoteId: 'GmlID',
+        maxzoom: tileSourcesMaxZoom,
+        attribution:
+          '<a href="https://reseaux-chaleur.cerema.fr/espace-documentaire/enrezo" target="_blank">Cerema</a>',
+      },
+      layers: [
+        {
+          id: 'enrrMobilisables-parkings',
+          source: 'enrrMobilisables-parkings',
+          'source-layer': 'layer',
+          minzoom: tileLayersMinZoom,
+          type: 'fill',
+          paint: {
+            'fill-color': themeDefSolaireThermiqueParkings.color,
+            'fill-opacity': themeDefSolaireThermiqueParkings.opacity,
+          },
+        },
+        {
+          id: 'enrrMobilisables-parkings-contour',
+          source: 'enrrMobilisables-parkings',
+          'source-layer': 'layer',
+          minzoom: tileLayersMinZoom,
+          type: 'line',
+          paint: {
+            'line-color': themeDefSolaireThermiqueParkings.color,
+            'line-width': 2,
           },
         },
       ],
@@ -934,6 +1026,30 @@ export function applyMapConfigurationToLayers(
     config.proMode &&
       config.enrrMobilisables.show &&
       config.enrrMobilisables.showUnitesDIncineration
+  );
+  setLayerVisibility(
+    'enrrMobilisables-friches',
+    config.proMode &&
+      config.enrrMobilisables.show &&
+      config.enrrMobilisables.showSolaireThermiqueFriches
+  );
+  setLayerVisibility(
+    'enrrMobilisables-friches-contour',
+    config.proMode &&
+      config.enrrMobilisables.show &&
+      config.enrrMobilisables.showSolaireThermiqueFriches
+  );
+  setLayerVisibility(
+    'enrrMobilisables-parkings',
+    config.proMode &&
+      config.enrrMobilisables.show &&
+      config.enrrMobilisables.showSolaireThermiqueParkings
+  );
+  setLayerVisibility(
+    'enrrMobilisables-parkings-contour',
+    config.proMode &&
+      config.enrrMobilisables.show &&
+      config.enrrMobilisables.showSolaireThermiqueParkings
   );
   setLayerVisibility(
     'zonesPotentielChaud',

--- a/src/components/Map/map-layers.ts
+++ b/src/components/Map/map-layers.ts
@@ -29,6 +29,7 @@ import {
   themeDefSolaireThermiqueFriches,
   themeDefSolaireThermiqueParkings,
 } from 'src/services/Map/businessRules/enrrMobilisables';
+import { SourceId } from 'src/services/tiles.config';
 
 export const tileSourcesMaxZoom = 17;
 
@@ -233,23 +234,6 @@ type CustomLayerSpecification = LayerSpecification & {
     'icon-image'?: LayerSymbolImage;
   };
 };
-
-// = id passé en URL de l'API
-export type SourceId =
-  | 'network' // réseaux de chaud
-  | 'zoneDP' // zones de développement prioritaire
-  | 'futurNetwork' // réseaux de chaleur en construction
-  | 'coldNetwork' // réseaux de froid
-  | 'demands' // demandes d'éligibilité
-  | 'gas' // consommations de gaz
-  | 'energy' // batiments collectifs chauffés au fioul / gas
-  | 'raccordements' // bâtiments raccordés
-  | 'enrrMobilisables'
-  | 'enrrMobilisables-friches'
-  | 'enrrMobilisables-parkings'
-  | 'zonesPotentielChaud'
-  | 'zonesPotentielFortChaud'
-  | 'buildings'; // caractéristiques des bâtiments
 
 export type LayerId =
   | 'reseauxDeChaleur-avec-trace'

--- a/src/pages/api/map/[type]/[...tileCoordinates].ts
+++ b/src/pages/api/map/[type]/[...tileCoordinates].ts
@@ -1,7 +1,7 @@
 import { handleRouteErrors, validateObjectSchema } from '@helpers/server';
 import { NextApiRequest, NextApiResponse } from 'next';
 import getTiles from 'src/services/tiles';
-import { zDataType } from 'src/services/tiles.config';
+import { zSourceId } from 'src/services/tiles.config';
 import zod from 'zod';
 
 // disable the warning for this route as many tiles are bigger than the default 4MB threshold
@@ -17,7 +17,7 @@ export default handleRouteErrors(
       type,
       tileCoordinates: [z, x, y],
     } = await validateObjectSchema(req.query, {
-      type: zDataType,
+      type: zSourceId,
       tileCoordinates: zod.array(zod.coerce.number()).length(3),
     });
     const tiles = await getTiles(type, x, y, z);

--- a/src/services/Map/businessRules/enrrMobilisables.ts
+++ b/src/services/Map/businessRules/enrrMobilisables.ts
@@ -1,0 +1,9 @@
+export const themeDefSolaireThermiqueFriches = {
+  color: '#dc958e',
+  opacity: 0.7,
+} as const;
+
+export const themeDefSolaireThermiqueParkings = {
+  color: '#d0643e',
+  opacity: 0.7,
+} as const;

--- a/src/services/Map/businessRules/zonePotentielChaud.ts
+++ b/src/services/Map/businessRules/zonePotentielChaud.ts
@@ -1,6 +1,6 @@
 export const themeDefZonePotentielChaud = {
   fill: { color: '#b0cc4e', opacity: 0.3 },
-};
+} as const;
 export const themeDefZonePotentielFortChaud = {
   fill: { color: '#448d60', opacity: 0.3 },
-};
+} as const;

--- a/src/services/Map/map-configuration.ts
+++ b/src/services/Map/map-configuration.ts
@@ -31,6 +31,8 @@ export type MapConfiguration = {
     showInstallationsElectrogenes: boolean;
     showStationsDEpuration: boolean;
     showUnitesDIncineration: boolean;
+    showSolaireThermiqueFriches: boolean;
+    showSolaireThermiqueParkings: boolean;
   };
   zonesOpportunite: {
     show: boolean;
@@ -71,6 +73,8 @@ const emptyMapConfiguration: MapConfiguration = {
     showInstallationsElectrogenes: true,
     showStationsDEpuration: true,
     showUnitesDIncineration: true,
+    showSolaireThermiqueFriches: true,
+    showSolaireThermiqueParkings: true,
   },
   zonesOpportunite: {
     show: false,

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -231,6 +231,18 @@ const trackingEvents = {
   "Carto|Unités d'incinération|Désactive": {
     matomo: ['Carto', "Unités d'incinération", 'Désactive'],
   },
+  'Carto|Solaire thermique - friches|Active': {
+    matomo: ['Carto', 'Solaire thermique - friches', 'Active'],
+  },
+  'Carto|Solaire thermique - friches|Désactive': {
+    matomo: ['Carto', 'Solaire thermique - friches', 'Désactive'],
+  },
+  'Carto|Solaire thermique - parkings|Active': {
+    matomo: ['Carto', 'Solaire thermique - parkings', 'Active'],
+  },
+  'Carto|Solaire thermique - parkings|Désactive': {
+    matomo: ['Carto', 'Solaire thermique - parkings', 'Désactive'],
+  },
   "Carto|Zones d'opportunité|Active": {
     matomo: ['Carto', "Zones d'opportunité", 'Active'],
   },

--- a/src/services/tiles.config.ts
+++ b/src/services/tiles.config.ts
@@ -22,26 +22,26 @@ export type DatabaseTileInfo = BasicTileInfo & {
 
 export type TileInfo = AirtableTileInfo | DatabaseTileInfo;
 
-// FIXME supprimer ce type et harmoniser avec SourceId
-export const dataTypes = [
-  'network',
-  'gas',
-  'energy',
-  'zoneDP',
-  'raccordements',
-  'demands',
-  'buildings',
-  'futurNetwork',
-  'coldNetwork',
+// = id passé en URL de l'API
+export const sourceIds = [
+  'network', // réseaux de chaud
+  'zoneDP', // zones de développement prioritaire
+  'futurNetwork', // réseaux de chaleur en construction
+  'coldNetwork', // réseaux de froid
+  'demands', // demandes d'éligibilité
+  'gas', // consommations de gaz
+  'energy', // batiments collectifs chauffés au fioul / gas
+  'raccordements', // bâtiments raccordés
   'enrrMobilisables',
   'enrrMobilisables-friches',
   'enrrMobilisables-parkings',
   'zonesPotentielChaud',
   'zonesPotentielFortChaud',
+  'buildings', // caractéristiques des bâtiments
 ] as const;
 
-export const zDataType = z.enum(dataTypes);
-export type DataType = z.infer<typeof zDataType>;
+export const zSourceId = z.enum(sourceIds);
+export type SourceId = z.infer<typeof zSourceId>;
 
 const bnbFields = `
   id as id,
@@ -74,7 +74,7 @@ export const preTable: (region: string) => Record<string, string> = (
     `,
 });
 
-export const tilesInfo: Record<DataType, TileInfo> = {
+export const tilesInfo: Record<SourceId, TileInfo> = {
   demands: {
     source: 'airtable',
     table: Airtable.UTILISATEURS,

--- a/src/services/tiles.config.ts
+++ b/src/services/tiles.config.ts
@@ -22,6 +22,7 @@ export type DatabaseTileInfo = BasicTileInfo & {
 
 export type TileInfo = AirtableTileInfo | DatabaseTileInfo;
 
+// FIXME supprimer ce type et harmoniser avec SourceId
 export const dataTypes = [
   'network',
   'gas',
@@ -33,6 +34,8 @@ export const dataTypes = [
   'futurNetwork',
   'coldNetwork',
   'enrrMobilisables',
+  'enrrMobilisables-friches',
+  'enrrMobilisables-parkings',
   'zonesPotentielChaud',
   'zonesPotentielFortChaud',
 ] as const;
@@ -210,6 +213,24 @@ export const tilesInfo: Record<DataType, TileInfo> = {
   enrrMobilisables: {
     source: 'database',
     tiles: 'enrr_mobilisables_tiles',
+    table: '', // useless
+    properties: [], // useless
+    sourceLayer: '', // useless
+    id: '', // useless
+    extraWhere: (query) => query, // useless
+  },
+  'enrrMobilisables-friches': {
+    source: 'database',
+    tiles: 'enrr_mobilisables_friches_tiles',
+    table: '', // useless
+    properties: [], // useless
+    sourceLayer: '', // useless
+    id: '', // useless
+    extraWhere: (query) => query, // useless
+  },
+  'enrrMobilisables-parkings': {
+    source: 'database',
+    tiles: 'enrr_mobilisables_parkings_tiles',
     table: '', // useless
     properties: [], // useless
     sourceLayer: '', // useless

--- a/src/services/tiles.ts
+++ b/src/services/tiles.ts
@@ -2,13 +2,13 @@ import geojsonvt from 'geojson-vt';
 import db from 'src/db';
 import base from 'src/db/airtable';
 import vtpbf from 'vt-pbf';
-import { AirtableTileInfo, DataType, tilesInfo } from './tiles.config';
+import { AirtableTileInfo, SourceId, tilesInfo } from './tiles.config';
 import { tileSourcesMaxZoom } from '@components/Map/map-layers';
 
 const debug = !!(process.env.API_DEBUG_MODE || null);
 
 let airtableDayCached = 0;
-const airtableTiles: Partial<Record<DataType, any>> = {
+const airtableTiles: Partial<Record<SourceId, any>> = {
   demands: null,
 };
 
@@ -63,7 +63,7 @@ const cacheAirtableTiles = () => {
         );
       getObjectIndexFromAirtable(tileInfo)
         .then((result) => {
-          airtableTiles[type as DataType] = result;
+          airtableTiles[type as SourceId] = result;
           debug &&
             console.info(
               `Indexing tiles for ${type} from airtable ${tileInfo.table} done`
@@ -83,7 +83,7 @@ const cacheAirtableTiles = () => {
 
 cacheAirtableTiles();
 
-const getTiles = async (type: DataType, x: number, y: number, z: number) => {
+const getTiles = async (type: SourceId, x: number, y: number, z: number) => {
   const tileInfo = tilesInfo[type];
   if (tileInfo.source === 'database') {
     const result = await db(tileInfo.tiles)

--- a/src/types/layers/enrr_mobilisables.ts
+++ b/src/types/layers/enrr_mobilisables.ts
@@ -54,3 +54,25 @@ export interface UniteDIncineration {
   type_inst: string;
   qualite_xy: number;
 }
+
+export interface SolaireThermiqueFriche {
+  GmlID: string;
+  comm_insee: string;
+  'db_gd5kj.hsu_pnjyu.solaire_thermique_friches_solaire_thermique_friches.fid': number;
+  site_id: string;
+  site_nom: string;
+  source_nom: string;
+  st_area_shape_: number;
+  st_length_shape_: number;
+  surf_site: number;
+  urba_zone_: string;
+}
+
+export interface SolaireThermiqueParking {
+  GmlID: string;
+  TYPE: string;
+  'db_gd5kj.hsu_pnjyu.parkings_sup500m2_parkings_sup500m2.fid': number;
+  st_area_shape_: number;
+  st_length_shape_: number;
+  surfm2: number;
+}

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -21,3 +21,15 @@ export function normalize(string: string | undefined | null): string {
         .normalize('NFD')
         .replace(/[\u0300-\u036f]/g, '');
 }
+
+/**
+ * Converts a ratio number between 0 and 1 to its hexadecimal notation.
+ */
+export function ratioToHex(ratio: number): string {
+  if (ratio < 0 || ratio > 1) {
+    throw new Error(`invalid input: ${ratio}`);
+  }
+
+  const hex = Math.floor(ratio * 255).toString(16);
+  return `${hex.length === 1 ? '0' : ''}${hex}`;
+}


### PR DESCRIPTION
- 2 nouvelles couches dans la section ENRR mobilisables, propices à l'installations de panneaux photovoltaïques (récupérées et intégrées de la même façon que les autres ENRR) :
  - friches
  - parkings de + de 500m² 
- Un composant IconPolygon qui prend une couleur en paramètre, car le comportement est identique à d'autres couches de zone (zones d'opportunités).
- Petit refacto sur DataType qui est en fait un SourceId (potentiellement même TileSourceId...)
- Nouveau script que j'ai utilisé pour synchroniser ~en mode bourrin~ mes 2 tables locales vers l'env de dev ~(ça drop complètement). J'imagine qu'un jour, on aura intérêt à avoir un script qui fait ça mais en renommant tout bien sans risque de downtime sur la table cible)~. Il y a 2 modes, un pour créer aussi la structure, l'autre pour ne copier que les données (et vider aupréalable) dans une transaction. Je te fais une démo la semaine prochaine @cspriet  ! :smiley: 

![image](https://github.com/betagouv/france-chaleur-urbaine/assets/8938024/ffc8caa7-1239-42bc-8186-3d5950fbd89f)
