### PR TITLE
feat: update opendata link (last update!)

### DIFF
--- a/src/components/Map/components/SimpleMapLegend.tsx
+++ b/src/components/Map/components/SimpleMapLegend.tsx
@@ -391,7 +391,8 @@ function SimpleMapLegend({
           </Link>
           <Link
             variant="primary"
-            href="./160224_Opendata_FCU.zip"
+            href="https://www.data.gouv.fr/fr/datasets/traces-des-reseaux-de-chaleur-et-de-froid/"
+            isExternal
             eventKey="Téléchargement|Tracés|carte"
             className="fr-btn--sm d-block"
             mx="auto"

--- a/src/pages/professionnels.tsx
+++ b/src/pages/professionnels.tsx
@@ -83,7 +83,7 @@ Gestionnaires de bâtiments tertiaires, bailleurs sociaux, bureaux d’étude, s
 
 :button-link[Voir la cartographie]{href="./carte"}
 
-:button-link[Télécharger les tracés]{href="./160224_Opendata_FCU.zip" eventKey="Téléchargement|Tracés|professionnels" download}
+:button-link[Télécharger les tracés]{href="https://www.data.gouv.fr/fr/datasets/traces-des-reseaux-de-chaleur-et-de-froid/" eventKey="Téléchargement|Tracés|professionnels" download}
 `}
           imgSrc="/img/rcu-carto.jpg"
           reverse


### PR DESCRIPTION
Plutôt que de créer un fichier qui serait mis à jour côté data.gouv, dupliqué à côté des versions historisées, on redirige maintenant sur la page de data.gouv et on sort l'archive du code.