### PR TITLE
fix: anchor scrolling

### DIFF
--- a/src/components/ui/Link.tsx
+++ b/src/components/ui/Link.tsx
@@ -23,6 +23,7 @@ interface LinkProps extends SpacingProperties {
 
 /**
  * Renders a DSFR link that uses Next Link.
+ * Automatically use a 'a' element when the href contains an anchor to fix scrolling issues.
  * Can track analytics events.
  * Usage:
  *  <Link href="https://url.com" eventKey="Téléchargement|Tracés|carte">Télécharger un tracé</Link>
@@ -37,8 +38,10 @@ function Link({
   isExternal = false,
   ...props
 }: PropsWithChildren<LinkProps>) {
+  // when the href contains an anchor, use a classic link which works best with scrolling
+  const Tag = href.includes('#') ? 'a' : NextLink;
   return (
-    <NextLink
+    <Tag
       href={href}
       onClick={() => {
         if (eventKey) {
@@ -53,7 +56,7 @@ function Link({
       {...props}
     >
       {children}
-    </NextLink>
+    </Tag>
   );
 }
 export default Link;

--- a/src/pages/ressources/outils.tsx
+++ b/src/pages/ressources/outils.tsx
@@ -90,6 +90,7 @@ const OutilsPage = () => {
         <Link
           variant="secondary"
           href="https://api.gouv.fr/les-api/api-france-chaleur-urbaine"
+          isExternal
         >
           Accéder
         </Link>
@@ -109,6 +110,7 @@ const OutilsPage = () => {
           <Link
             variant="secondary"
             href="https://www.data.gouv.fr/fr/datasets/traces-des-reseaux-de-chaleur-et-de-froid/"
+            isExternal
           >
             Accéder
           </Link>


### PR DESCRIPTION
Corrige les liens vers des ancres, notamment à partir de la page outils vers le simulateur CO2, iframes, etc