### PR TITLE
fix: include DSFR CSS always to fix initial FOUC

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,6 +4,7 @@ import {
   GoogleAdsMarkup,
   LinkedInMarkup,
 } from '@components/Markup';
+import '@gouvfr/dsfr/dist/dsfr.min.css';
 import '@gouvfr/dsfr/dist/utility/icons/icons-system/icons-system.min.css';
 import '@gouvfr/dsfr/dist/utility/icons/icons-editor/icons-editor.min.css';
 import '@gouvfr/dsfr/dist/utility/icons/icons-document/icons-document.min.css';


### PR DESCRIPTION
- Permet d'inclure le CSS du DSFR (tout...) dans le rendu initial de la page afin d'éviter le [FOUC](https://fr.wikipedia.org/wiki/FOUC).
- Augmente la taille à télécharger de 70ko, mais ça reste acceptable selon moi vu l'impact. Il y a toujours un FOUT (flash sur le texte), car les polices ne sont pas initialement chargées. Mais c'est moins dérangeant. 
- A priori, pas d'impact même le CSS est dupliqué car il est aussi importé par la lib react-dsfr

![image](https://github.com/betagouv/france-chaleur-urbaine/assets/8938024/38a97a16-442f-46de-bd55-15c58ac187e1)
:arrow_down: 
![image](https://github.com/betagouv/france-chaleur-urbaine/assets/8938024/dc8b0928-4a16-4b41-bc89-39a784939bfd)

