### PR TITLE
feat: filtres réseaux de chaleur

### DIFF
--- a/docs/génération_tuiles_réseaux_de_chaleur.md
+++ b/docs/génération_tuiles_réseaux_de_chaleur.md
@@ -1,0 +1,144 @@
+# Génération des tuiles des réseaux de chaleur
+
+Processus légèrement différent du fill-tiles classique étant donné qu'on a besoin de précalculer certaines données.
+
+```sh
+# générer un fichier geojson depuis la table reseaux_de_chaleur
+psql postgres://postgres:postgres_fcu@localhost:5432/postgres -c "COPY (
+    SELECT jsonb_build_object(
+        'type',     'FeatureCollection',
+        'features', jsonb_agg(feature)
+    )
+    FROM (
+        SELECT jsonb_build_object(
+            'id',         id_fcu,
+            'type',       'Feature',
+            'geometry',   ST_AsGeoJSON(ST_ForcePolygonCCW(ST_Transform(geom,4326)))::jsonb,
+            'properties', json_build_object(
+              'id_fcu', \"id_fcu\",
+              'Taux EnR&R', \"Taux EnR&R\",
+              'Gestionnaire', \"Gestionnaire\",
+              'Identifiant reseau', \"Identifiant reseau\",
+              'reseaux classes', \"reseaux classes\",
+              'contenu CO2 ACV', \"contenu CO2 ACV\",
+              'nom_reseau', \"nom_reseau\",
+              'livraisons_totale_MWh', \"livraisons_totale_MWh\",
+              'nb_pdl', \"nb_pdl\",
+              'has_trace', \"has_trace\",
+              'PM', \"PM\",
+              'annee_creation', \"annee_creation\",
+              'energie_ratio_biomasse', \"energie_ratio_biomasse\",
+              'energie_ratio_geothermie', \"energie_ratio_geothermie\",
+              'energie_ratio_uve', \"energie_ratio_uve\",
+              'energie_ratio_chaleurIndustrielle', \"energie_ratio_chaleurIndustrielle\",
+              'energie_ratio_solaireThermique', \"energie_ratio_solaireThermique\",
+              'energie_ratio_pompeAChaleur', \"energie_ratio_pompeAChaleur\",
+              'energie_ratio_gaz', \"energie_ratio_gaz\",
+              'energie_ratio_fioul', \"energie_ratio_fioul\",
+              'energie_majoritaire', CASE
+                WHEN greatest(
+                    \"energie_ratio_biomasse\",
+                    \"energie_ratio_geothermie\",
+                    \"energie_ratio_uve\",
+                    \"energie_ratio_chaleurIndustrielle\",
+                    \"energie_ratio_solaireThermique\",
+                    \"energie_ratio_pompeAChaleur\",
+                    \"energie_ratio_gaz\",
+                    \"energie_ratio_fioul\"
+                ) = \"energie_ratio_biomasse\" THEN 'biomasse'
+                WHEN greatest(
+                    \"energie_ratio_biomasse\",
+                    \"energie_ratio_geothermie\",
+                    \"energie_ratio_uve\",
+                    \"energie_ratio_chaleurIndustrielle\",
+                    \"energie_ratio_solaireThermique\",
+                    \"energie_ratio_pompeAChaleur\",
+                    \"energie_ratio_gaz\",
+                    \"energie_ratio_fioul\"
+                ) = \"energie_ratio_geothermie\" THEN 'geothermie'
+                WHEN greatest(
+                    \"energie_ratio_biomasse\",
+                    \"energie_ratio_geothermie\",
+                    \"energie_ratio_uve\",
+                    \"energie_ratio_chaleurIndustrielle\",
+                    \"energie_ratio_solaireThermique\",
+                    \"energie_ratio_pompeAChaleur\",
+                    \"energie_ratio_gaz\",
+                    \"energie_ratio_fioul\"
+                ) = \"energie_ratio_uve\" THEN 'uve'
+                WHEN greatest(
+                    \"energie_ratio_biomasse\",
+                    \"energie_ratio_geothermie\",
+                    \"energie_ratio_uve\",
+                    \"energie_ratio_chaleurIndustrielle\",
+                    \"energie_ratio_solaireThermique\",
+                    \"energie_ratio_pompeAChaleur\",
+                    \"energie_ratio_gaz\",
+                    \"energie_ratio_fioul\"
+                ) = \"energie_ratio_chaleurIndustrielle\" THEN 'chaleurIndustrielle'
+                WHEN greatest(
+                    \"energie_ratio_biomasse\",
+                    \"energie_ratio_geothermie\",
+                    \"energie_ratio_uve\",
+                    \"energie_ratio_chaleurIndustrielle\",
+                    \"energie_ratio_solaireThermique\",
+                    \"energie_ratio_pompeAChaleur\",
+                    \"energie_ratio_gaz\",
+                    \"energie_ratio_fioul\"
+                ) = \"energie_ratio_solaireThermique\" THEN 'solaireThermique'
+                WHEN greatest(
+                    \"energie_ratio_biomasse\",
+                    \"energie_ratio_geothermie\",
+                    \"energie_ratio_uve\",
+                    \"energie_ratio_chaleurIndustrielle\",
+                    \"energie_ratio_solaireThermique\",
+                    \"energie_ratio_pompeAChaleur\",
+                    \"energie_ratio_gaz\",
+                    \"energie_ratio_fioul\"
+                ) = \"energie_ratio_pompeAChaleur\" THEN 'pompeAChaleur'
+                WHEN greatest(
+                    \"energie_ratio_biomasse\",
+                    \"energie_ratio_geothermie\",
+                    \"energie_ratio_uve\",
+                    \"energie_ratio_chaleurIndustrielle\",
+                    \"energie_ratio_solaireThermique\",
+                    \"energie_ratio_pompeAChaleur\",
+                    \"energie_ratio_gaz\",
+                    \"energie_ratio_fioul\"
+                ) = \"energie_ratio_gaz\" THEN 'gaz'
+                WHEN greatest(
+                    \"energie_ratio_biomasse\",
+                    \"energie_ratio_geothermie\",
+                    \"energie_ratio_uve\",
+                    \"energie_ratio_chaleurIndustrielle\",
+                    \"energie_ratio_solaireThermique\",
+                    \"energie_ratio_pompeAChaleur\",
+                    \"energie_ratio_gaz\",
+                    \"energie_ratio_fioul\"
+                ) = \"energie_ratio_fioul\" THEN 'fioul'
+              END
+            )
+        ) AS feature
+        FROM (
+          SELECT
+            *,
+            (\"prod_MWh_biomasse_solide\") / COALESCE(NULLIF(\"production_totale_MWh\", 0), 1) as \"energie_ratio_biomasse\",
+            (\"prod_MWh_geothermie\") / COALESCE(NULLIF(\"production_totale_MWh\", 0), 1) as \"energie_ratio_geothermie\",
+            (\"prod_MWh_dechets_internes\" + \"prod_MWh_UIOM\") / COALESCE(NULLIF(\"production_totale_MWh\", 0), 1) as \"energie_ratio_uve\",
+            (\"prod_MWh_chaleur_industiel\") / COALESCE(NULLIF(\"production_totale_MWh\", 0), 1) as \"energie_ratio_chaleurIndustrielle\",
+            (\"prod_MWh_solaire_thermique\") / COALESCE(NULLIF(\"production_totale_MWh\", 0), 1) as \"energie_ratio_solaireThermique\",
+            (\"prod_MWh_PAC\") / COALESCE(NULLIF(\"production_totale_MWh\", 0), 1) as \"energie_ratio_pompeAChaleur\",
+            (\"prod_MWh_gaz_naturel\") / COALESCE(NULLIF(\"production_totale_MWh\", 0), 1) as \"energie_ratio_gaz\",
+            (\"prod_MWh_fioul_domestique\" + \"prod_MWh_fioul_lourd\") / COALESCE(NULLIF(\"production_totale_MWh\", 0), 1) as \"energie_ratio_fioul\"
+          FROM reseaux_de_chaleur rdc
+        ) row
+    ) features
+) TO STDOUT" | sed -e 's/\\\\"/\\"/g' > reseaux_de_chaleur.geojson
+
+# générer les tuiles à partir du fichier geojson
+yarn cli generate-tiles-from-file reseaux_de_chaleur.geojson reseaux_de_chaleur_tiles
+
+# synchronisation avec la BDD de dev ou prod
+./scripts/copyLocalTableToRemote.sh dev reseaux_de_chaleur_tiles --data-only
+# ./scripts/copyLocalTableToRemote.sh prod reseaux_de_chaleur_tiles --data-only
+```

--- a/docs/import_reseau_chaleur.md
+++ b/docs/import_reseau_chaleur.md
@@ -14,9 +14,10 @@
 
 3. Mise à jour des données sur les réseaux depuis Airtable
     - Si la table des réseaux a été mise à jour lors de l'étape précédente : `yarn cli update-networks network`
-    - Sinon 
+    - Sinon
         - `yarn cli download-network network`
     - Normalement ce script complète la table *zones_et_reseaux_en_construction* et regénère la table *zones_et_reseaux_en_construction_tiles*
+    - /!\\ Note : pour les **réseaux de chaleur**, il faut [générer les tuiles différemment](./génération_tuiles_réseaux_de_chaleur.md).
 
 4. Si mauvaise mise à jour des tiles : mise à jour de la table *reseaux_de_chaleur_tiles*
     - Vider la table (sans la supprimer)

--- a/src/components/Cities/Networks.tsx
+++ b/src/components/Cities/Networks.tsx
@@ -91,8 +91,8 @@ const Networks = ({
             reseauxDeChaleur: {
               show: true,
             },
-            filtreIdentifiantReseau: network
-              ? [network['Identifiant reseau']] // FIXME peut-être prendre networksData.identifiant aussi ?
+            filtreIdentifiantReseau: networksData.identifiant
+              ? [networksData.identifiant]
               : [],
           })}
         />

--- a/src/components/Cities/Networks.tsx
+++ b/src/components/Cities/Networks.tsx
@@ -8,7 +8,7 @@ import { NetworkContainer, NetworkColumn } from './Networks.styles';
 import Slice from '@components/Slice';
 import { createMapConfiguration } from 'src/services/Map/map-configuration';
 
-type NetworskData = {
+type NetworksData = {
   isClassed: boolean;
   identifiant?: string;
   heatedPlaces?: string;
@@ -20,7 +20,7 @@ const Networks = ({
   network,
   cityCoord,
 }: {
-  networksData: NetworskData;
+  networksData: NetworksData;
   network?: Network;
   cityCoord: [number, number];
 }) => {
@@ -90,18 +90,11 @@ const Networks = ({
           initialMapConfiguration={createMapConfiguration({
             reseauxDeChaleur: {
               show: true,
-              tauxENRR: [0, 100],
             },
+            filtreIdentifiantReseau: network
+              ? [network['Identifiant reseau']] // FIXME peut-être prendre networksData.identifiant aussi ?
+              : [],
           })}
-          filter={
-            network
-              ? [
-                  '==',
-                  ['get', 'Identifiant reseau'],
-                  network?.['Identifiant reseau'],
-                ]
-              : ['literal', true]
-          }
         />
       </NetworkColumn>
     </NetworkContainer>

--- a/src/components/Cities/Networks.tsx
+++ b/src/components/Cities/Networks.tsx
@@ -88,7 +88,10 @@ const Networks = ({
           initialCenter={cityCoord}
           initialZoom={11}
           initialMapConfiguration={createMapConfiguration({
-            reseauxDeChaleur: true,
+            reseauxDeChaleur: {
+              show: true,
+              tauxENRR: [0, 100],
+            },
           })}
           filter={
             network

--- a/src/components/EligibilityForm/EligibilityFormContact.tsx
+++ b/src/components/EligibilityForm/EligibilityFormContact.tsx
@@ -136,7 +136,9 @@ const EligibilityFormContact = ({
                 withoutLogo
                 initialCenter={addressData.geoAddress?.geometry.coordinates}
                 initialMapConfiguration={createMapConfiguration({
-                  reseauxDeChaleur: true,
+                  reseauxDeChaleur: {
+                    show: true,
+                  },
                   reseauxEnConstruction: true,
                   zonesDeDeveloppementPrioritaire: true,
                 })}
@@ -158,7 +160,9 @@ const EligibilityFormContact = ({
                     withoutLogo
                     initialCenter={addressData.geoAddress?.geometry.coordinates}
                     initialMapConfiguration={createMapConfiguration({
-                      reseauxDeChaleur: true,
+                      reseauxDeChaleur: {
+                        show: true,
+                      },
                       reseauxEnConstruction: true,
                       zonesDeDeveloppementPrioritaire: true,
                     })}

--- a/src/components/Manager/Manager.tsx
+++ b/src/components/Manager/Manager.tsx
@@ -463,7 +463,9 @@ const Manager = () => {
                   initialCenter={centerPin ? centerPin : firstCenterPin}
                   initialZoom={initialZoom}
                   initialMapConfiguration={createMapConfiguration({
-                    reseauxDeChaleur: true,
+                    reseauxDeChaleur: {
+                      show: true,
+                    },
                     reseauxEnConstruction: true,
                     zonesDeDeveloppementPrioritaire: true,
                   })}

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -77,6 +77,7 @@ import MapSearchForm from './components/MapSearchForm';
 import CardSearchDetails from './components/CardSearchDetails';
 import { layersWithDynamicContentPopup } from './components/DynamicMapPopupContent';
 import { SourceId } from 'src/services/tiles.config';
+import { isDevModeEnabled } from './components/DevModeIcon';
 
 const mapSettings = {
   defaultLongitude: 2.3,
@@ -255,7 +256,7 @@ const Map = ({
     if (!selectedFeature) {
       return;
     }
-    if ((window as any).devMode) {
+    if (isDevModeEnabled()) {
       console.log('map-click', selectedFeature); // eslint-disable-line no-console
     }
 

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -50,11 +50,7 @@ import {
   MapboxStyleDefinition,
   MapboxStyleSwitcherControl,
 } from './StyleSwitcher';
-import {
-  ExpressionSpecification,
-  MapGeoJSONFeature,
-  MapLibreEvent,
-} from 'maplibre-gl';
+import { MapGeoJSONFeature, MapLibreEvent } from 'maplibre-gl';
 import { trackEvent } from 'src/services/analytics';
 import debounce from '@utils/debounce';
 import SimpleMapLegend, {
@@ -169,7 +165,6 @@ const Map = ({
   proMode,
   setProMode,
   popupType = MapPopupType.DEFAULT,
-  filter,
   pinsList,
   initialCenter,
   initialZoom,
@@ -191,7 +186,6 @@ const Map = ({
   proMode?: boolean;
   setProMode?: (proMode: boolean) => void;
   popupType?: MapPopupType;
-  filter?: ExpressionSpecification; // layer filter used to filter networks of a company
   pinsList?: MapMarkerInfos[];
   initialCenter?: [number, number];
   initialZoom?: number;
@@ -531,9 +525,7 @@ const Map = ({
       e.isSourceLoaded &&
       e.tile
     ) {
-      const network = router.query.network as string;
-
-      buildMapLayers(network, filter).forEach((spec) => {
+      buildMapLayers(mapConfiguration).forEach((spec) => {
         if (map.getSource(spec.sourceId)) {
           return;
         }

--- a/src/components/Map/components/DevModeIcon.tsx
+++ b/src/components/Map/components/DevModeIcon.tsx
@@ -1,0 +1,47 @@
+import Box from '@components/ui/Box';
+import { Button } from '@dataesr/react-dsfr';
+import { usePersistedState } from '@hooks';
+import { useMemo, useState } from 'react';
+
+declare let window: Window & {
+  devModeEnabled?: boolean;
+};
+
+export function isDevModeEnabled(): boolean {
+  return !!window.devModeEnabled;
+}
+
+function DevModeIcon() {
+  const [devModeAttempts, setDevModeAttempts] = useState(0);
+  const [devMode, setDevMode] = usePersistedState('devMode', false, {
+    beforeStorage: (v: any) => !!v,
+  });
+
+  function tryEnableDevMode() {
+    setDevModeAttempts(devModeAttempts + 1);
+    if (devModeAttempts === 4) {
+      setDevMode(true);
+    }
+    setTimeout(() => {
+      setDevModeAttempts(0);
+    }, 5000);
+  }
+
+  useMemo(() => {
+    window.devModeEnabled = devMode;
+  }, [devMode]);
+
+  return devMode ? (
+    <Button
+      tertiary
+      size="sm"
+      icon="ri-close-line"
+      onClick={() => setDevMode(false)}
+      title="Désactiver le mode développeur"
+    />
+  ) : (
+    <Box width="24px" height="24px" onClick={tryEnableDevMode} />
+  );
+}
+
+export default DevModeIcon;

--- a/src/components/Map/components/IconPolygon.tsx
+++ b/src/components/Map/components/IconPolygon.tsx
@@ -25,7 +25,7 @@ const IconPolygon = ({
       <path
         fill={`${stroke}${ratioToHex(fillOpacity)}`}
         stroke={stroke}
-        stroke-width="3"
+        strokeWidth="3"
         d="m2 2 22 10v11H2V2Z"
       />
     </svg>

--- a/src/components/Map/components/RangeFilter.tsx
+++ b/src/components/Map/components/RangeFilter.tsx
@@ -30,7 +30,7 @@ const RangeFilter = ({
   return (
     <Box mx="1w" position="relative" {...props}>
       <Box display="flex" alignItems="center" mt="1w">
-        <Text lineHeight="18px" fontWeight="bold" mr="1w">
+        <Text size="sm" lineHeight="18px" fontWeight="bold" mr="1w">
           {label}
         </Text>
 

--- a/src/components/Map/components/RangeFilter.tsx
+++ b/src/components/Map/components/RangeFilter.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { ReactNode } from 'react';
 
 import { Handles, Rail, Slider, Tracks } from 'react-compound-slider';
 
@@ -6,6 +6,8 @@ import { Handle, SliderRail, Track } from '@components/Slider/Components';
 import { Interval } from '@utils/interval';
 import Box from '@components/ui/Box';
 import Text from '@components/ui/Text';
+import { SimpleTooltip } from '@components/ui/Tooltip';
+import Icon from '@components/ui/Icon';
 
 interface RangeFilterProps {
   label: string;
@@ -13,6 +15,7 @@ interface RangeFilterProps {
   domain: Interval;
   onChange: (values: Interval) => void;
   unit?: string;
+  tooltip?: string | ReactNode;
 }
 
 const RangeFilter = ({
@@ -21,13 +24,24 @@ const RangeFilter = ({
   domain,
   onChange,
   unit = '',
+  tooltip,
   ...props
 }: RangeFilterProps) => {
   return (
-    <Box mx="1w" {...props}>
-      <Text lineHeight="18px" fontWeight="bold" mt="1w">
-        {label}
-      </Text>
+    <Box mx="1w" position="relative" {...props}>
+      <Box display="flex" alignItems="center" mt="1w">
+        <Text lineHeight="18px" fontWeight="bold" mr="1w">
+          {label}
+        </Text>
+
+        {tooltip && (
+          <SimpleTooltip
+            icon={<Icon size="1x" name="ri-information-fill" cursor="help" />}
+          >
+            {tooltip}
+          </SimpleTooltip>
+        )}
+      </Box>
 
       <Box position="relative" mt="2w" mx="1w" {...props}>
         {/* Space needed for margins to work */}

--- a/src/components/Map/components/RangeFilter.tsx
+++ b/src/components/Map/components/RangeFilter.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+
+import { Handles, Rail, Slider, Tracks } from 'react-compound-slider';
+
+import { Handle, SliderRail, Track } from '@components/Slider/Components';
+import { Interval } from '@utils/interval';
+import Box from '@components/ui/Box';
+import Text from '@components/ui/Text';
+
+interface RangeFilterProps {
+  label: string;
+  value: Interval;
+  domain: Interval;
+  onChange: (values: Interval) => void;
+  unit?: string;
+}
+
+const RangeFilter = ({
+  label,
+  value,
+  domain,
+  onChange,
+  unit = '',
+  ...props
+}: RangeFilterProps) => {
+  return (
+    <Box mx="1w" {...props}>
+      <Text lineHeight="18px" fontWeight="bold" mt="1w">
+        {label}
+      </Text>
+
+      <Box position="relative" mt="2w" mx="1w" {...props}>
+        {/* Space needed for margins to work */}
+        <Box minHeight="1px" />
+        <Slider
+          mode={2}
+          step={1}
+          domain={domain}
+          values={value}
+          onChange={(newValue) => {
+            onChange(newValue as Interval);
+          }}
+        >
+          <Rail>
+            {({ getRailProps }) => <SliderRail getRailProps={getRailProps} />}
+          </Rail>
+          <Handles>
+            {({ handles, getHandleProps }) => (
+              <>
+                {handles.map((handle) => (
+                  <Handle
+                    key={handle.id}
+                    handle={handle}
+                    domain={domain}
+                    getHandleProps={getHandleProps}
+                  />
+                ))}
+              </>
+            )}
+          </Handles>
+          <Tracks left={false} right={false}>
+            {({ tracks, getTrackProps }) => (
+              <>
+                {tracks.map(({ id, source, target }) => (
+                  <Track
+                    key={id}
+                    source={source}
+                    target={target}
+                    getTrackProps={getTrackProps}
+                  />
+                ))}
+              </>
+            )}
+          </Tracks>
+        </Slider>
+      </Box>
+
+      <Box display="flex" justifyContent="space-between" mt="2w">
+        <Box
+          backgroundColor="#f3f6f9"
+          borderRadius="6px"
+          p="1w"
+          fontSize="12px"
+        >
+          min&nbsp;:{' '}
+          <b>
+            {value[0]} {unit}
+          </b>
+        </Box>
+
+        <Box
+          backgroundColor="#f3f6f9"
+          borderRadius="6px"
+          p="1w"
+          fontSize="12px"
+        >
+          max&nbsp;:{' '}
+          <b>
+            {value[1]} {unit}
+          </b>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default RangeFilter;

--- a/src/components/Map/components/ScaleLegend.tsx
+++ b/src/components/Map/components/ScaleLegend.tsx
@@ -13,25 +13,28 @@ import { Handle, SliderRail, Track } from '../../Slider/Components';
 import { ScaleMaxLabel, ScaleMinLabel } from '../../Slider/Components.styles';
 import { maxIconSize, minIconSize } from '../map-layers';
 
-const ScaleLegend: React.FC<{
+interface ScaleLegendProps {
   label: string;
   color?: string;
+  showColor?: boolean;
   circle?: boolean;
   framed?: boolean;
   domain: [number, number];
   defaultValues?: [number, number];
   onChange: (values: [number, number]) => void;
   className?: string;
-}> = ({
+}
+const ScaleLegend = ({
   label,
   framed,
   color: defaultColor,
+  showColor = true,
   circle,
   domain,
   onChange,
   defaultValues,
   className,
-}) => {
+}: ScaleLegendProps) => {
   const [values, setValues] = useState(defaultValues || domain);
   const minLabel = `${values[0] === domain[0] && domain[0] !== 0 ? '< ' : ''}${
     values[0]
@@ -43,18 +46,20 @@ const ScaleLegend: React.FC<{
       <ScaleLegendHeader>{label}</ScaleLegendHeader>
 
       <ScaleLegendBody>
-        <ScaleLabelLegend
-          bgColor={defaultColor + '88'}
-          size={minIconSize}
-          circle={circle}
-        />
+        {showColor && (
+          <ScaleLabelLegend
+            bgColor={defaultColor + '88'}
+            size={minIconSize}
+            circle={circle}
+          />
+        )}
 
         <ScaleSlider>
           <Slider
             mode={2}
             step={1}
             domain={domain}
-            values={defaultValues || domain}
+            values={values}
             onChange={(newValues) => {
               setValues(newValues as [number, number]);
               onChange([
@@ -102,11 +107,13 @@ const ScaleLegend: React.FC<{
             max : <b>{maxLabel}</b>
           </ScaleMaxLabel>
         </ScaleSlider>
-        <ScaleLabelLegend
-          bgColor={defaultColor + '88'}
-          size={maxIconSize}
-          circle={circle}
-        />
+        {showColor && (
+          <ScaleLabelLegend
+            bgColor={defaultColor + '88'}
+            size={maxIconSize}
+            circle={circle}
+          />
+        )}
       </ScaleLegendBody>
     </ScaleLegendWrapper>
   );

--- a/src/components/Map/components/SimpleMapLegend.tsx
+++ b/src/components/Map/components/SimpleMapLegend.tsx
@@ -4,7 +4,7 @@ import ModalCarteFrance from './ModalCarteFrance';
 import Text from '@components/ui/Text';
 import { trackEvent } from 'src/services/analytics';
 import Image from 'next/image';
-import { Button } from '@dataesr/react-dsfr';
+import { Button, Select } from '@dataesr/react-dsfr';
 import Link from '@components/ui/Link';
 import Icon from '@components/ui/Icon';
 import { LegendSeparator } from '../Map.style';
@@ -24,6 +24,7 @@ import {
   MapConfigurationProperty,
   defaultMapConfiguration,
   emissionCO2MaxInterval,
+  filtresEnergies,
   percentageMaxInterval,
   periodeConstructionMaxInterval,
   prixMoyenMaxInterval,
@@ -51,6 +52,7 @@ import {
   themeDefZonePotentielFortChaud,
 } from 'src/services/Map/businessRules/zonePotentielChaud';
 import DevModeIcon from './DevModeIcon';
+import RangeFilter from './RangeFilter';
 
 const consommationsGazLegendColor = '#D9D9D9';
 const consommationsGazUsageLegendOpacity = 0.53;
@@ -85,6 +87,7 @@ interface SimpleMapLegendProps {
 
 const expansions = [
   'reseauxDeChaleur',
+  'reseauxDeChaleurEnergies',
   'consommationsGaz',
   'batimentsGazCollectif',
   'batimentsFioulCollectif',
@@ -183,44 +186,124 @@ function SimpleMapLegend({
             données sont disponibles.
           </Text>
 
-          <ScaleLegend
-            className="fr-mx-3w"
+          <Box mx="1w">
+            <Text lineHeight="18px" fontWeight="bold" my="1w">
+              Énergies majoritaires
+            </Text>
+            <Select
+              selected={mapConfiguration.reseauxDeChaleur.energieMajoritaire}
+              options={[
+                {
+                  label: "Type d'énergie",
+                  value: undefined as any,
+                },
+                ...filtresEnergies.map(({ label, confKey }) => ({
+                  label,
+                  value: confKey,
+                })),
+              ]}
+              onChange={(e) => {
+                mapConfiguration.reseauxDeChaleur.energieMajoritaire =
+                  e.target.value;
+                onMapConfigurationChange({ ...mapConfiguration });
+              }}
+            />
+          </Box>
+
+          {!sectionsExpansions['reseauxDeChaleurEnergies'] && (
+            <Button
+              className="d-block fr-ml-auto fr-mr-1w fr-px-1w"
+              hasBorder={false}
+              size="sm"
+              onClick={() => toggleSectionExpansion('reseauxDeChaleurEnergies')}
+              title="Afficher plus de détail"
+            >
+              Plus d'options
+            </Button>
+          )}
+
+          <CollapsibleBox
+            expand={!!sectionsExpansions['reseauxDeChaleurEnergies']}
+          >
+            <Box
+              backgroundColor="grey-975-75"
+              borderRadius="10px"
+              mt="1w"
+              mx="1w"
+              pt="1w"
+            >
+              <Button
+                className="d-block fr-ml-auto"
+                hasBorder={false}
+                size="sm"
+                onClick={() =>
+                  toggleSectionExpansion('reseauxDeChaleurEnergies')
+                }
+                title="Masquer le détail"
+              >
+                <Icon size="lg" name="ri-close-line" />
+              </Button>
+              <DeactivatableBox
+                disabled={!mapConfiguration.reseauxDeChaleur.show}
+              >
+                {filtresEnergies.map((filtreEnergie) => (
+                  <RangeFilter
+                    key={filtreEnergie.confKey}
+                    label={filtreEnergie.label}
+                    domain={percentageMaxInterval}
+                    value={
+                      mapConfiguration.reseauxDeChaleur[
+                        `energie_ratio_${filtreEnergie.confKey}`
+                      ]
+                    }
+                    onChange={(values) =>
+                      updateScaleInterval(
+                        `reseauxDeChaleur.energie_ratio_${filtreEnergie.confKey}`,
+                        values
+                      )
+                    }
+                    unit="%"
+                  />
+                ))}
+              </DeactivatableBox>
+            </Box>
+          </CollapsibleBox>
+
+          <LegendSeparator />
+          <RangeFilter
             label="Taux d’EnR&R"
-            showColor={false}
             domain={percentageMaxInterval}
-            defaultValues={mapConfiguration.reseauxDeChaleur.tauxENRR}
+            value={mapConfiguration.reseauxDeChaleur.tauxENRR}
             onChange={(values) =>
               updateScaleInterval('reseauxDeChaleur.tauxENRR', values)
             }
+            unit="%"
           />
-          <ScaleLegend
-            className="fr-mx-3w"
+          <LegendSeparator />
+          <RangeFilter
             label="Émission de CO2"
-            showColor={false}
             domain={emissionCO2MaxInterval}
-            defaultValues={mapConfiguration.reseauxDeChaleur.emissionCO2}
+            value={mapConfiguration.reseauxDeChaleur.emissionCO2}
             onChange={(values) =>
               updateScaleInterval('reseauxDeChaleur.emissionCO2', values)
             }
+            unit="g.CO2/kWh"
           />
-          <ScaleLegend
-            className="fr-mx-3w"
+          <LegendSeparator />
+          <RangeFilter
             label="Prix moyen"
-            showColor={false}
             domain={prixMoyenMaxInterval}
-            defaultValues={mapConfiguration.reseauxDeChaleur.prixMoyen}
+            value={mapConfiguration.reseauxDeChaleur.prixMoyen}
             onChange={(values) =>
               updateScaleInterval('reseauxDeChaleur.prixMoyen', values)
             }
+            unit="€TTC/MWh"
           />
-          <ScaleLegend
-            className="fr-mx-3w"
+          <LegendSeparator />
+          <RangeFilter
             label="Période de construction"
-            showColor={false}
             domain={periodeConstructionMaxInterval}
-            defaultValues={
-              mapConfiguration.reseauxDeChaleur.periodeConstruction
-            }
+            value={mapConfiguration.reseauxDeChaleur.periodeConstruction}
             onChange={(values) =>
               updateScaleInterval(
                 'reseauxDeChaleur.periodeConstruction',

--- a/src/components/Map/components/SimpleMapLegend.tsx
+++ b/src/components/Map/components/SimpleMapLegend.tsx
@@ -23,6 +23,10 @@ import {
   MapConfiguration,
   MapConfigurationProperty,
   defaultMapConfiguration,
+  emissionCO2MaxInterval,
+  percentageMaxInterval,
+  periodeConstructionMaxInterval,
+  prixMoyenMaxInterval,
 } from 'src/services/Map/map-configuration';
 import { setProperty, toggleBoolean } from '@utils/core';
 import CollapsibleBox from '@components/ui/CollapsibleBox';
@@ -79,6 +83,7 @@ interface SimpleMapLegendProps {
 }
 
 const expansions = [
+  'reseauxDeChaleur',
   'consommationsGaz',
   'batimentsGazCollectif',
   'batimentsFioulCollectif',
@@ -138,9 +143,27 @@ function SimpleMapLegend({
 
   return (
     <>
-      <Text fontSize="14px" lineHeight="18px" fontWeight="bold" mx="2w">
-        {legendTitle || 'Réseaux de chaleur et de froid'}
-      </Text>
+      <Box display="flex" alignItems="center">
+        <Text
+          fontSize="14px"
+          lineHeight="18px"
+          fontWeight="bold"
+          ml="2w"
+          className="fr-col"
+        >
+          {legendTitle || 'Réseaux de chaleur et de froid'}
+        </Text>
+
+        <Button
+          className="fr-px-1w"
+          hasBorder={false}
+          size="sm"
+          onClick={() => toggleSectionExpansion('reseauxDeChaleur')}
+          title="Afficher/Masquer le détail"
+        >
+          <Icon size="lg" name="ri-equalizer-line" />
+        </Button>
+      </Box>
       <Text
         fontSize="13px"
         lineHeight="18px"
@@ -151,11 +174,68 @@ function SimpleMapLegend({
         Cliquez sur un réseau pour connaître ses caractéristiques
       </Text>
 
+      <CollapsibleBox expand={!!sectionsExpansions['reseauxDeChaleur']}>
+        <DeactivatableBox disabled={!mapConfiguration.reseauxDeChaleur.show}>
+          <LegendSeparator />
+          <Text size="xs" lineHeight="15px" fontStyle="italic" mx="2w">
+            Filtres uniquement sur les réseaux de chaleur, pour lesquels les
+            données sont disponibles.
+          </Text>
+
+          <ScaleLegend
+            className="fr-mx-3w"
+            label="Taux d’EnR&R"
+            showColor={false}
+            domain={percentageMaxInterval}
+            defaultValues={mapConfiguration.reseauxDeChaleur.tauxENRR}
+            onChange={(values) =>
+              updateScaleInterval('reseauxDeChaleur.tauxENRR', values)
+            }
+          />
+          <ScaleLegend
+            className="fr-mx-3w"
+            label="Émission de CO2"
+            showColor={false}
+            domain={emissionCO2MaxInterval}
+            defaultValues={mapConfiguration.reseauxDeChaleur.emissionCO2}
+            onChange={(values) =>
+              updateScaleInterval('reseauxDeChaleur.emissionCO2', values)
+            }
+          />
+          <ScaleLegend
+            className="fr-mx-3w"
+            label="Prix moyen"
+            showColor={false}
+            domain={prixMoyenMaxInterval}
+            defaultValues={mapConfiguration.reseauxDeChaleur.prixMoyen}
+            onChange={(values) =>
+              updateScaleInterval('reseauxDeChaleur.prixMoyen', values)
+            }
+          />
+          <ScaleLegend
+            className="fr-mx-3w"
+            label="Période de construction"
+            showColor={false}
+            domain={periodeConstructionMaxInterval}
+            defaultValues={
+              mapConfiguration.reseauxDeChaleur.periodeConstruction
+            }
+            onChange={(values) =>
+              updateScaleInterval(
+                'reseauxDeChaleur.periodeConstruction',
+                values
+              )
+            }
+          />
+        </DeactivatableBox>
+        <LegendSeparator />
+      </CollapsibleBox>
+
       {enabledFeatures.includes('reseauxDeChaleur') && (
         <Box display="flex">
           <SingleCheckbox
             id="reseauxDeChaleur"
-            checked={mapConfiguration.reseauxDeChaleur}
+            checked={mapConfiguration.reseauxDeChaleur.show}
             onChange={() => toggleLayer('reseauxDeChaleur')}
             trackingEvent="Carto|Réseaux chaleur"
           />

--- a/src/components/Map/components/SimpleMapLegend.tsx
+++ b/src/components/Map/components/SimpleMapLegend.tsx
@@ -184,7 +184,7 @@ function SimpleMapLegend({
           </Text>
 
           <Box mx="1w">
-            <Text lineHeight="18px" fontWeight="bold" my="1w">
+            <Text size="sm" lineHeight="18px" fontWeight="bold" my="1w">
               Énergie majoritaire
             </Text>
             <Select

--- a/src/components/Map/components/SimpleMapLegend.tsx
+++ b/src/components/Map/components/SimpleMapLegend.tsx
@@ -23,11 +23,8 @@ import {
   MapConfiguration,
   MapConfigurationProperty,
   defaultMapConfiguration,
-  emissionsCO2MaxInterval,
   filtresEnergies,
   percentageMaxInterval,
-  anneeConstructionMaxInterval,
-  prixMoyenMaxInterval,
 } from 'src/services/Map/map-configuration';
 import { setProperty, toggleBoolean } from '@utils/core';
 import CollapsibleBox from '@components/ui/CollapsibleBox';
@@ -282,7 +279,7 @@ function SimpleMapLegend({
           <LegendSeparator />
           <RangeFilter
             label="Émissions de CO2"
-            domain={emissionsCO2MaxInterval}
+            domain={mapConfiguration.reseauxDeChaleur.limits.emissionsCO2}
             value={mapConfiguration.reseauxDeChaleur.emissionsCO2}
             onChange={(values) =>
               updateScaleInterval('reseauxDeChaleur.emissionsCO2', values)
@@ -293,7 +290,7 @@ function SimpleMapLegend({
           <LegendSeparator />
           <RangeFilter
             label="Prix moyen de la chaleur"
-            domain={prixMoyenMaxInterval}
+            domain={mapConfiguration.reseauxDeChaleur.limits.prixMoyen}
             value={mapConfiguration.reseauxDeChaleur.prixMoyen}
             onChange={(values) =>
               updateScaleInterval('reseauxDeChaleur.prixMoyen', values)
@@ -304,7 +301,7 @@ function SimpleMapLegend({
           <LegendSeparator />
           <RangeFilter
             label="Année de construction"
-            domain={anneeConstructionMaxInterval}
+            domain={mapConfiguration.reseauxDeChaleur.limits.anneeConstruction}
             value={mapConfiguration.reseauxDeChaleur.anneeConstruction}
             onChange={(values) =>
               updateScaleInterval('reseauxDeChaleur.anneeConstruction', values)

--- a/src/components/Map/components/SimpleMapLegend.tsx
+++ b/src/components/Map/components/SimpleMapLegend.tsx
@@ -50,6 +50,7 @@ import {
   themeDefZonePotentielChaud,
   themeDefZonePotentielFortChaud,
 } from 'src/services/Map/businessRules/zonePotentielChaud';
+import DevModeIcon from './DevModeIcon';
 
 const consommationsGazLegendColor = '#D9D9D9';
 const consommationsGazUsageLegendOpacity = 0.53;
@@ -1492,7 +1493,14 @@ function SimpleMapLegend({
       {enabledFeatures.includes('sources') && (
         <>
           <LegendSeparator />
-          <Box mt="n2w" mx="2w" mb="2w">
+          <Box
+            mt="n2w"
+            mx="2w"
+            mb="2w"
+            display="flex"
+            alignItems="center"
+            gap="16px"
+          >
             <Link
               href="/documentation/carto_sources.pdf"
               isExternal
@@ -1502,6 +1510,7 @@ function SimpleMapLegend({
                 Sources
               </Text>
             </Link>
+            <DevModeIcon />
           </Box>
         </>
       )}

--- a/src/components/Map/components/SimpleMapLegend.tsx
+++ b/src/components/Map/components/SimpleMapLegend.tsx
@@ -23,10 +23,10 @@ import {
   MapConfiguration,
   MapConfigurationProperty,
   defaultMapConfiguration,
-  emissionCO2MaxInterval,
+  emissionsCO2MaxInterval,
   filtresEnergies,
   percentageMaxInterval,
-  periodeConstructionMaxInterval,
+  anneeConstructionMaxInterval,
   prixMoyenMaxInterval,
 } from 'src/services/Map/map-configuration';
 import { setProperty, toggleBoolean } from '@utils/core';
@@ -152,7 +152,7 @@ function SimpleMapLegend({
           fontSize="14px"
           lineHeight="18px"
           fontWeight="bold"
-          ml="2w"
+          ml="1w"
           className="fr-col"
         >
           {legendTitle || 'Réseaux de chaleur et de froid'}
@@ -173,7 +173,7 @@ function SimpleMapLegend({
         lineHeight="18px"
         fontWeight="lightbold"
         fontStyle="italic"
-        mx="2w"
+        mx="1w"
       >
         Cliquez sur un réseau pour connaître ses caractéristiques
       </Text>
@@ -181,21 +181,21 @@ function SimpleMapLegend({
       <CollapsibleBox expand={!!sectionsExpansions['reseauxDeChaleur']}>
         <DeactivatableBox disabled={!mapConfiguration.reseauxDeChaleur.show}>
           <LegendSeparator />
-          <Text size="xs" lineHeight="15px" fontStyle="italic" mx="2w">
-            Filtres uniquement sur les réseaux de chaleur, pour lesquels les
-            données sont disponibles.
+          <Text size="xs" lineHeight="15px" fontStyle="italic" mx="1w">
+            Filtres uniquement sur les réseaux de chaleur existants, pour
+            lesquels les données sont disponibles.
           </Text>
 
           <Box mx="1w">
             <Text lineHeight="18px" fontWeight="bold" my="1w">
-              Énergies majoritaires
+              Énergie majoritaire
             </Text>
             <Select
               selected={mapConfiguration.reseauxDeChaleur.energieMajoritaire}
               options={[
                 {
                   label: "Type d'énergie",
-                  value: undefined as any,
+                  value: '',
                 },
                 ...filtresEnergies.map(({ label, confKey }) => ({
                   label,
@@ -204,7 +204,7 @@ function SimpleMapLegend({
               ]}
               onChange={(e) => {
                 mapConfiguration.reseauxDeChaleur.energieMajoritaire =
-                  e.target.value;
+                  e.target.value === '' ? undefined : e.target.value;
                 onMapConfigurationChange({ ...mapConfiguration });
               }}
             />
@@ -281,34 +281,33 @@ function SimpleMapLegend({
           />
           <LegendSeparator />
           <RangeFilter
-            label="Émission de CO2"
-            domain={emissionCO2MaxInterval}
-            value={mapConfiguration.reseauxDeChaleur.emissionCO2}
+            label="Émissions de CO2"
+            domain={emissionsCO2MaxInterval}
+            value={mapConfiguration.reseauxDeChaleur.emissionsCO2}
             onChange={(values) =>
-              updateScaleInterval('reseauxDeChaleur.emissionCO2', values)
+              updateScaleInterval('reseauxDeChaleur.emissionsCO2', values)
             }
-            unit="g.CO2/kWh"
+            unit="gCO2/kWh"
+            tooltip="Émissions en analyse du cycle de vie (directes et indirectes)"
           />
           <LegendSeparator />
           <RangeFilter
-            label="Prix moyen"
+            label="Prix moyen de la chaleur"
             domain={prixMoyenMaxInterval}
             value={mapConfiguration.reseauxDeChaleur.prixMoyen}
             onChange={(values) =>
               updateScaleInterval('reseauxDeChaleur.prixMoyen', values)
             }
             unit="€TTC/MWh"
+            tooltip="La comparaison avec le prix d'autres modes de chauffage n’est pertinente qu’en coût global annuel, en intégrant les coûts d’exploitation, de maintenance et d’investissement, amortis sur la durée de vie des installations."
           />
           <LegendSeparator />
           <RangeFilter
-            label="Période de construction"
-            domain={periodeConstructionMaxInterval}
-            value={mapConfiguration.reseauxDeChaleur.periodeConstruction}
+            label="Année de construction"
+            domain={anneeConstructionMaxInterval}
+            value={mapConfiguration.reseauxDeChaleur.anneeConstruction}
             onChange={(values) =>
-              updateScaleInterval(
-                'reseauxDeChaleur.periodeConstruction',
-                values
-              )
+              updateScaleInterval('reseauxDeChaleur.anneeConstruction', values)
             }
           />
         </DeactivatableBox>

--- a/src/components/Map/map-layers.ts
+++ b/src/components/Map/map-layers.ts
@@ -741,7 +741,7 @@ export function buildMapLayers(
         {
           id: 'reseauxDeChaleur-avec-trace',
           source: 'network',
-          'source-layer': 'layer', // FIXME voir si on conserve la layer 'outline' d'origine
+          'source-layer': 'layer',
           minzoom: tileLayersMinZoom,
           ...outlineLayerStyle,
           filter: [
@@ -755,7 +755,7 @@ export function buildMapLayers(
         {
           id: 'reseauxDeChaleur-sans-trace',
           source: 'network',
-          'source-layer': 'layer', // FIXME voir si on conserve la layer 'outline' d'origine
+          'source-layer': 'layer',
           minzoom: tileLayersMinZoom,
           ...outlineCenterLayerStyle,
           filter: [

--- a/src/components/Map/map-layers.ts
+++ b/src/components/Map/map-layers.ts
@@ -971,8 +971,14 @@ export function applyMapConfigurationToLayers(
     'consommationsGaz',
     config.proMode && config.consommationsGaz.show
   );
-  setLayerVisibility('reseauxDeChaleur-avec-trace', config.reseauxDeChaleur);
-  setLayerVisibility('reseauxDeChaleur-sans-trace', config.reseauxDeChaleur);
+  setLayerVisibility(
+    'reseauxDeChaleur-avec-trace',
+    config.reseauxDeChaleur.show
+  );
+  setLayerVisibility(
+    'reseauxDeChaleur-sans-trace',
+    config.reseauxDeChaleur.show
+  );
   setLayerVisibility(
     'batimentsRaccordes',
     config.proMode && config.batimentsRaccordes
@@ -1108,4 +1114,32 @@ export function applyMapConfigurationToLayers(
       ],
     ]
   );
+
+  map.setFilter('reseauxDeChaleur-avec-trace', [
+    'all',
+    ['==', ['get', 'has_trace'], true],
+    getReseauxDeChaleurFilter(config.reseauxDeChaleur),
+  ]);
+  map.setFilter('reseauxDeChaleur-sans-trace', [
+    'all',
+    ['==', ['get', 'has_trace'], false],
+    getReseauxDeChaleurFilter(config.reseauxDeChaleur),
+  ]);
+}
+
+function getReseauxDeChaleurFilter(
+  conf: MapConfiguration['reseauxDeChaleur']
+): ExpressionSpecification {
+  return [
+    'all',
+    ['>=', ['get', 'Taux EnR&R'], conf.tauxENRR[0]],
+    ['<=', ['get', 'Taux EnR&R'], conf.tauxENRR[1]],
+    ['>=', ['get', 'contenu CO2 ACV'], conf.emissionCO2[0] / 1000],
+    ['<=', ['get', 'contenu CO2 ACV'], conf.emissionCO2[1] / 1000],
+    // FIXME: pas encore dispo dans les tuiles
+    // ['>=', ['get', 'PM'], conf.prixMoyen[0]],
+    // ['<=', ['get', 'PM'], conf.prixMoyen[1]],
+    // ['>=', ['get', 'annee_construction'], conf.periodeConstruction[0]],
+    // ['<=', ['get', 'annee_construction'], conf.periodeConstruction[1]],
+  ];
 }

--- a/src/components/Map/map-layers.ts
+++ b/src/components/Map/map-layers.ts
@@ -26,10 +26,10 @@ import {
 import { ENERGY_TYPE, ENERGY_USED } from 'src/types/enum/EnergyType';
 import {
   MapConfiguration,
-  emissionCO2MaxInterval,
+  emissionsCO2MaxInterval,
   filtresEnergies,
   percentageMaxInterval,
-  periodeConstructionMaxInterval,
+  anneeConstructionMaxInterval,
   prixMoyenMaxInterval,
 } from 'src/services/Map/map-configuration';
 import {
@@ -401,7 +401,6 @@ export function buildMapLayers(
           filter: [
             'all',
             ['==', ['get', 'is_zone'], true],
-            ...buildReseauxDeChaleurFilters(config.reseauxDeChaleur),
             ...buildFiltreGestionnaire(config.filtreGestionnaire),
           ],
           type: 'fill',
@@ -418,7 +417,6 @@ export function buildMapLayers(
           filter: [
             'all',
             ['==', ['get', 'is_zone'], false],
-            ...buildReseauxDeChaleurFilters(config.reseauxDeChaleur),
             ...buildFiltreGestionnaire(config.filtreGestionnaire),
           ],
           ...outlineLayerStyle,
@@ -798,7 +796,6 @@ export function buildMapLayers(
           filter: [
             'all',
             ['==', ['get', 'has_trace'], true],
-            ...buildReseauxDeChaleurFilters(config.reseauxDeChaleur),
             ...buildFiltreGestionnaire(config.filtreGestionnaire),
             ...buildFiltreIdentifiantReseau(config.filtreIdentifiantReseau),
           ],
@@ -816,7 +813,6 @@ export function buildMapLayers(
           filter: [
             'all',
             ['==', ['get', 'has_trace'], false],
-            ...buildReseauxDeChaleurFilters(config.reseauxDeChaleur),
             ...buildFiltreGestionnaire(config.filtreGestionnaire),
             ...buildFiltreIdentifiantReseau(config.filtreIdentifiantReseau),
           ],
@@ -1134,33 +1130,28 @@ export function applyMapConfigurationToLayers(
   map.setFilter('reseauxDeFroid-avec-trace', [
     'all',
     ['==', ['get', 'has_trace'], true],
-    ...buildReseauxDeChaleurFilters(config.reseauxDeChaleur),
     ...buildFiltreGestionnaire(config.filtreGestionnaire),
     ...buildFiltreIdentifiantReseau(config.filtreIdentifiantReseau),
   ]);
   map.setFilter('reseauxDeFroid-sans-trace', [
     'all',
     ['==', ['get', 'has_trace'], false],
-    ...buildReseauxDeChaleurFilters(config.reseauxDeChaleur),
     ...buildFiltreGestionnaire(config.filtreGestionnaire),
     ...buildFiltreIdentifiantReseau(config.filtreIdentifiantReseau),
   ]);
   map.setFilter('reseauxEnConstruction-zone', [
     'all',
     ['==', ['get', 'is_zone'], true],
-    ...buildReseauxDeChaleurFilters(config.reseauxDeChaleur),
     ...buildFiltreGestionnaire(config.filtreGestionnaire),
   ]);
   map.setFilter('reseauxEnConstruction-trace', [
     'all',
     ['==', ['get', 'is_zone'], false],
-    ...buildReseauxDeChaleurFilters(config.reseauxDeChaleur),
     ...buildFiltreGestionnaire(config.filtreGestionnaire),
   ]);
 }
 
 type ReseauxDeChaleurFilter = {
-  label: string;
   valueKey: keyof Network;
   confKey: Exclude<keyof MapConfiguration['reseauxDeChaleur'], 'show'>;
   defaultInterval: Interval;
@@ -1169,29 +1160,25 @@ type ReseauxDeChaleurFilter = {
 
 const reseauxDeChaleurFilters = [
   {
-    label: 'Taux d’EnR&R',
     confKey: 'tauxENRR',
     valueKey: 'Taux EnR&R',
     defaultInterval: percentageMaxInterval,
   },
   {
-    label: 'Émission de CO2',
-    confKey: 'emissionCO2',
+    confKey: 'emissionsCO2',
     valueKey: 'contenu CO2 ACV',
-    defaultInterval: emissionCO2MaxInterval,
+    defaultInterval: emissionsCO2MaxInterval,
     filterPreprocess: (v: number) => v / 1000,
   },
   {
-    label: 'Prix moyen',
     confKey: 'prixMoyen',
     valueKey: 'PM',
     defaultInterval: prixMoyenMaxInterval,
   },
   {
-    label: 'Période de construction',
-    confKey: 'periodeConstruction',
+    confKey: 'anneeConstruction',
     valueKey: 'annee_creation',
-    defaultInterval: periodeConstructionMaxInterval,
+    defaultInterval: anneeConstructionMaxInterval,
   },
 ] satisfies ReseauxDeChaleurFilter[];
 

--- a/src/components/Network/Network.tsx
+++ b/src/components/Network/Network.tsx
@@ -495,6 +495,7 @@ const NetworkPanel = ({
                     reseauxDeChaleur: {
                       show: true,
                     },
+                    filtreIdentifiantReseau: [network['Identifiant reseau']],
                     reseauxDeFroid: true,
                   })}
                 />

--- a/src/components/Network/Network.tsx
+++ b/src/components/Network/Network.tsx
@@ -1,7 +1,6 @@
 import HoverableIcon from '@components/Hoverable/HoverableIcon';
 import Map from '@components/Map/Map';
 import { getConso } from 'src/services/Map/conso';
-import { Network } from 'src/types/Summary/Network';
 import ClassedNetwork from './ClassedNetwork';
 import ColdNetwork from './ColdNetwork';
 import {
@@ -19,6 +18,7 @@ import EnergiesChart from './EnergiesChart';
 import Text from '@components/ui/Text';
 import Link from 'next/link';
 import { createMapConfiguration } from 'src/services/Map/map-configuration';
+import { Network } from 'src/types/Summary/Network';
 
 const getFullURL = (link: string) => {
   return link.startsWith('http://') || link.startsWith('https://')
@@ -44,7 +44,7 @@ const hasSecondColumn = (isCold: boolean, displayBlocks?: string[]) => {
   );
 };
 
-const Network = ({
+const NetworkPanel = ({
   network,
   displayBlocks,
   externalLinks,
@@ -492,7 +492,9 @@ const Network = ({
                   initialCenter={[network.lon, network.lat]}
                   initialZoom={13}
                   initialMapConfiguration={createMapConfiguration({
-                    reseauxDeChaleur: true,
+                    reseauxDeChaleur: {
+                      show: true,
+                    },
                     reseauxDeFroid: true,
                   })}
                 />
@@ -561,4 +563,4 @@ const Network = ({
   );
 };
 
-export default Network;
+export default NetworkPanel;

--- a/src/components/Slider/Components.jsx
+++ b/src/components/Slider/Components.jsx
@@ -5,14 +5,6 @@ import { Fragment } from 'react';
 // *******************************************************
 // RAIL
 // *******************************************************
-const railOuterStyle = {
-  position: 'absolute',
-  width: '100%',
-  height: 21,
-  transform: 'translate(0%, -50%)',
-  borderRadius: 7,
-  cursor: 'pointer',
-};
 
 const railInnerStyle = {
   position: 'absolute',
@@ -25,12 +17,7 @@ const railInnerStyle = {
 };
 
 export function SliderRail({ getRailProps }) {
-  return (
-    <Fragment>
-      <div style={railOuterStyle} {...getRailProps()} />
-      <div style={railInnerStyle} />
-    </Fragment>
-  );
+  return <div style={railInnerStyle} {...getRailProps()} />;
 }
 
 SliderRail.propTypes = {

--- a/src/components/ui/CollapsibleBox.tsx
+++ b/src/components/ui/CollapsibleBox.tsx
@@ -22,6 +22,15 @@ export default function CollapsibleBox({
     }
   }, [boxRef]);
 
+  const [loaded, setLoaded] = useState(false);
+  useEffect(() => {
+    if (loaded && !expand) {
+      // recalculate the container height in case it had changed before collapsing it
+      setHeight(`-${boxRef.current?.getBoundingClientRect().height}px`);
+    }
+    setLoaded(true);
+  }, [expand]);
+
   // hack to try to hide the initial expanded state
   const [classes, setClasses] = useState('initial-collapsed-state');
   useEffect(() => {

--- a/src/components/ui/Tooltip.style.tsx
+++ b/src/components/ui/Tooltip.style.tsx
@@ -15,3 +15,24 @@ export const StyledTooltip = styled.div`
     }
   }
 `;
+
+export const StyledSimpleTooltip = styled.div`
+  &:hover + div {
+    display: block;
+  }
+`;
+
+export const StyledSimpleTooltipContent = styled.div`
+  display: none;
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 100%;
+  background-color: black;
+  z-index: 9999;
+  color: white;
+  font-size: 12px;
+  line-height: 14px;
+  border-radius: 4px;
+  padding: 8px;
+`;

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -1,6 +1,11 @@
 import Hoverable from '@components/Hoverable';
 import { ReactNode } from 'react';
-import { StyledTooltip } from './Tooltip.style';
+import {
+  StyledSimpleTooltip,
+  StyledSimpleTooltipContent,
+  StyledTooltip,
+} from './Tooltip.style';
+import { SpacingProperties, spacingsToClasses } from './helpers/spacings';
 
 interface TooltipProps {
   children: ReactNode;
@@ -16,3 +21,26 @@ function Tooltip(props: TooltipProps) {
   );
 }
 export default Tooltip;
+
+interface SimpleTooltipProps extends SpacingProperties {
+  children: ReactNode;
+  icon: ReactNode;
+  className?: string;
+}
+
+/**
+ * Tooltip that extends its width to the parent container.
+ * The tooltip appears on top.
+ */
+export function SimpleTooltip(props: SimpleTooltipProps) {
+  return (
+    <>
+      <StyledSimpleTooltip
+        className={`${spacingsToClasses(props)} ${props.className ?? ''}`}
+      >
+        {props.icon}
+      </StyledSimpleTooltip>
+      <StyledSimpleTooltipContent>{props.children}</StyledSimpleTooltipContent>
+    </>
+  );
+}

--- a/src/pages/api/map/network-limits.ts
+++ b/src/pages/api/map/network-limits.ts
@@ -13,7 +13,7 @@ export default handleRouteErrors(async (req: NextApiRequest) => {
       ),
       db.raw(`array[floor(min("PM")), ceil(max("PM"))] as "prixMoyen"`),
       db.raw(
-        `array[min("annee_creation"), max("annee_creation")] as "anneeConstruction"`
+        `array[min("annee_creation"), extract(year from now())] as "anneeConstruction"` // max = année courante pour indiquer qu'on a des données récentes
       )
     )
     .first();

--- a/src/pages/api/map/network-limits.ts
+++ b/src/pages/api/map/network-limits.ts
@@ -1,0 +1,20 @@
+import { handleRouteErrors, requireGetMethod } from '@helpers/server';
+import type { NextApiRequest } from 'next';
+import db from 'src/db';
+
+export default handleRouteErrors(async (req: NextApiRequest) => {
+  requireGetMethod(req);
+
+  return await db('reseaux_de_chaleur')
+    .select(
+      db.raw(`array[min("Taux EnR&R"), max("Taux EnR&R")] as "tauxENRR"`),
+      db.raw(
+        `array[min("contenu CO2 ACV") * 1000, max("contenu CO2 ACV") * 1000] as "emissionsCO2"`
+      ),
+      db.raw(`array[floor(min("PM")), ceil(max("PM"))] as "prixMoyen"`),
+      db.raw(
+        `array[min("annee_creation"), max("annee_creation")] as "anneeConstruction"`
+      )
+    )
+    .first();
+});

--- a/src/pages/carte-collectivite.tsx
+++ b/src/pages/carte-collectivite.tsx
@@ -7,7 +7,9 @@ const CollectivityMap = () => {
     <IframeWrapper>
       <Map
         initialMapConfiguration={createMapConfiguration({
-          reseauxDeChaleur: true,
+          reseauxDeChaleur: {
+            show: true,
+          },
           zonesDeDeveloppementPrioritaire: true,
         })}
         enabledLegendFeatures={[

--- a/src/pages/charleville-mezieres.tsx
+++ b/src/pages/charleville-mezieres.tsx
@@ -7,7 +7,9 @@ const CharlevilleMezieresMap = () => {
     <IframeWrapper>
       <Map
         initialMapConfiguration={createMapConfiguration({
-          reseauxDeChaleur: true,
+          reseauxDeChaleur: {
+            show: true,
+          },
           reseauxEnConstruction: true,
         })}
         enabledLegendFeatures={['reseauxDeChaleur', 'reseauxEnConstruction']}

--- a/src/pages/dalkia.tsx
+++ b/src/pages/dalkia.tsx
@@ -1,13 +1,18 @@
 import IframeWrapper from '@components/IframeWrapper';
 import Map from '@components/Map/Map';
-import { iframeSimpleMapConfiguration } from 'src/services/Map/map-configuration';
+import { createMapConfiguration } from 'src/services/Map/map-configuration';
 import { MapPopupType } from 'src/types/MapComponentsInfos';
 
 const DalkiaMap = () => {
   return (
     <IframeWrapper>
       <Map
-        initialMapConfiguration={iframeSimpleMapConfiguration}
+        initialMapConfiguration={createMapConfiguration({
+          reseauxDeChaleur: {
+            show: true,
+          },
+          filtreGestionnaire: ['dalkia'],
+        })}
         enabledLegendFeatures={[
           'reseauxDeChaleur',
           'reseauxDeFroid',
@@ -22,19 +27,6 @@ const DalkiaMap = () => {
           alt: 'logo Dalkia',
         }}
         popupType={MapPopupType.DALKIA}
-        filter={[
-          'any',
-          [
-            'in',
-            'dalkia',
-            ['downcase', ['coalesce', ['get', 'gestionnaire'], '']],
-          ],
-          [
-            'in',
-            'dalkia',
-            ['downcase', ['coalesce', ['get', 'Gestionnaire'], '']],
-          ],
-        ]}
         withFCUAttribution
       />
     </IframeWrapper>

--- a/src/pages/engie.tsx
+++ b/src/pages/engie.tsx
@@ -1,13 +1,18 @@
 import IframeWrapper from '@components/IframeWrapper';
 import Map from '@components/Map/Map';
-import { iframeSimpleMapConfiguration } from 'src/services/Map/map-configuration';
+import { createMapConfiguration } from 'src/services/Map/map-configuration';
 import { MapPopupType } from 'src/types/MapComponentsInfos';
 
 const EngieMap = () => {
   return (
     <IframeWrapper>
       <Map
-        initialMapConfiguration={iframeSimpleMapConfiguration}
+        initialMapConfiguration={createMapConfiguration({
+          reseauxDeChaleur: {
+            show: true,
+          },
+          filtreGestionnaire: ['engie'],
+        })}
         enabledLegendFeatures={[
           'reseauxDeChaleur',
           'reseauxDeFroid',
@@ -22,19 +27,6 @@ const EngieMap = () => {
           alt: 'logo ENGIE',
         }}
         popupType={MapPopupType.ENGIE}
-        filter={[
-          'any',
-          [
-            'in',
-            'engie',
-            ['downcase', ['coalesce', ['get', 'gestionnaire'], '']],
-          ],
-          [
-            'in',
-            'engie',
-            ['downcase', ['coalesce', ['get', 'Gestionnaire'], '']],
-          ],
-        ]}
         withFCUAttribution
       />
     </IframeWrapper>

--- a/src/pages/idex.tsx
+++ b/src/pages/idex.tsx
@@ -1,13 +1,18 @@
 import IframeWrapper from '@components/IframeWrapper';
 import Map from '@components/Map/Map';
-import { iframeSimpleMapConfiguration } from 'src/services/Map/map-configuration';
+import { createMapConfiguration } from 'src/services/Map/map-configuration';
 import { MapPopupType } from 'src/types/MapComponentsInfos';
 
 const IdexMap = () => {
   return (
     <IframeWrapper>
       <Map
-        initialMapConfiguration={iframeSimpleMapConfiguration}
+        initialMapConfiguration={createMapConfiguration({
+          reseauxDeChaleur: {
+            show: true,
+          },
+          filtreGestionnaire: ['idex', 'mixéner'],
+        })}
         enabledLegendFeatures={[
           'reseauxDeChaleur',
           'reseauxDeFroid',
@@ -22,30 +27,6 @@ const IdexMap = () => {
           alt: 'logo Idex',
         }}
         popupType={MapPopupType.IDEX}
-        //Filter : gestionnaire for futurNetwork and Gestionnaire for coldNetwork and network
-        filter={[
-          'any',
-          [
-            'in',
-            'idex',
-            ['downcase', ['coalesce', ['get', 'gestionnaire'], '']],
-          ],
-          [
-            'in',
-            'idex',
-            ['downcase', ['coalesce', ['get', 'Gestionnaire'], '']],
-          ],
-          [
-            'in',
-            'mixéner',
-            ['downcase', ['coalesce', ['get', 'gestionnaire'], '']],
-          ],
-          [
-            'in',
-            'mixéner',
-            ['downcase', ['coalesce', ['get', 'Gestionnaire'], '']],
-          ],
-        ]}
         withFCUAttribution
       />
     </IframeWrapper>

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -45,14 +45,14 @@ const MapPage = () => {
         .split(',')
         .map((f) => legendURLKeyToLegendFeature[f])
         .filter((v) => !!v)
-    : undefined;
+    : [];
 
   // uniquement pour ces 2 couches, on les affiche directement si affichées dans la légende
   const initialMapConfiguration = createMapConfiguration({
     reseauxDeChaleur: {
-      show: legendFeatures?.includes('reseauxDeChaleur'),
+      show: legendFeatures.includes('reseauxDeChaleur'),
     },
-    reseauxEnConstruction: legendFeatures?.includes('reseauxEnConstruction'),
+    reseauxEnConstruction: legendFeatures.includes('reseauxEnConstruction'),
   });
 
   return (

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -49,7 +49,9 @@ const MapPage = () => {
 
   // uniquement pour ces 2 couches, on les affiche directement si affichées dans la légende
   const initialMapConfiguration = createMapConfiguration({
-    reseauxDeChaleur: legendFeatures?.includes('reseauxDeChaleur'),
+    reseauxDeChaleur: {
+      show: legendFeatures?.includes('reseauxDeChaleur'),
+    },
     reseauxEnConstruction: legendFeatures?.includes('reseauxEnConstruction'),
   });
 

--- a/src/pages/page-reseaux/[network].tsx
+++ b/src/pages/page-reseaux/[network].tsx
@@ -1,4 +1,4 @@
-import Network from '@components/Network/Network';
+import NetworkPanel from '@components/Network/Network';
 import {
   getColdNetwork,
   getNetwork,
@@ -6,6 +6,7 @@ import {
 import { GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import { Network } from 'src/types/Summary/Network';
 
 const PageReseau = ({ network }: { network: Network }) => {
   const router = useRouter();
@@ -31,7 +32,11 @@ const PageReseau = ({ network }: { network: Network }) => {
   }
 
   return (
-    <Network network={network} displayBlocks={displayBlocks} externalLinks />
+    <NetworkPanel
+      network={network}
+      displayBlocks={displayBlocks}
+      externalLinks
+    />
   );
 };
 

--- a/src/pages/reseaux/[network].tsx
+++ b/src/pages/reseaux/[network].tsx
@@ -1,4 +1,4 @@
-import Network from '@components/Network/Network';
+import NetworkPanel from '@components/Network/Network';
 import Slice from '@components/Slice/Slice';
 import SimplePage from '@components/shared/page/SimplePage';
 import {
@@ -8,6 +8,7 @@ import {
 import { Breadcrumb, BreadcrumbItem } from '@dataesr/react-dsfr';
 import { GetStaticProps } from 'next';
 import Link from 'next/link';
+import { Network } from 'src/types/Summary/Network';
 
 const PageReseau = ({ network }: { network: Network }) => {
   if (!network) {
@@ -26,7 +27,7 @@ const PageReseau = ({ network }: { network: Network }) => {
         </Breadcrumb>
       </Slice>
       <Slice className="fr-mb-4w">
-        <Network network={network} />
+        <NetworkPanel network={network} />
       </Slice>
     </SimplePage>
   );

--- a/src/services/Map/map-configuration.ts
+++ b/src/services/Map/map-configuration.ts
@@ -54,9 +54,9 @@ export type MapConfiguration = {
     show: boolean;
     energieMajoritaire?: FiltreEnergieConfKey;
     tauxENRR: Interval;
-    emissionCO2: Interval;
+    emissionsCO2: Interval;
     prixMoyen: Interval;
-    periodeConstruction: Interval;
+    anneeConstruction: Interval;
   } & Record<EnergieRatioConfKey, Interval>;
   reseauxDeFroid: boolean;
   reseauxEnConstruction: boolean;
@@ -98,9 +98,9 @@ export type MapConfiguration = {
 export type MapConfigurationProperty = FlattenKeys<MapConfiguration>;
 
 export const percentageMaxInterval: Interval = [0, 100];
-export const emissionCO2MaxInterval: Interval = [0, 500];
+export const emissionsCO2MaxInterval: Interval = [0, 400];
 export const prixMoyenMaxInterval: Interval = [0, 300];
-export const periodeConstructionMaxInterval: Interval = [1900, 2024];
+export const anneeConstructionMaxInterval: Interval = [1900, 2024];
 
 const emptyMapConfiguration: MapConfiguration = {
   proMode: false,
@@ -118,9 +118,9 @@ const emptyMapConfiguration: MapConfiguration = {
     energie_ratio_gaz: percentageMaxInterval,
     energie_ratio_fioul: percentageMaxInterval,
     tauxENRR: percentageMaxInterval,
-    emissionCO2: [0, 500],
+    emissionsCO2: [0, 500],
     prixMoyen: prixMoyenMaxInterval,
-    periodeConstruction: [1900, 2024],
+    anneeConstruction: [1900, 2024],
   },
   reseauxDeFroid: false,
   reseauxEnConstruction: false,

--- a/src/services/Map/map-configuration.ts
+++ b/src/services/Map/map-configuration.ts
@@ -1,9 +1,32 @@
 import { deepMergeObjects } from '@utils/core';
 import { DeepPartial, FlattenKeys } from '@utils/typescript';
 
+type Interval = [number, number];
+
+export const energiesMajoritaires = [
+  'Biomasse',
+  'Géothermie',
+  'UVE',
+  'Chaleur industrielle',
+  'Solaire thermique',
+  'Pompe à chaleur',
+  'Gaz',
+  'Fioul',
+] as const;
+
+type EnergieMajoritaire = (typeof energiesMajoritaires)[number];
+
 export type MapConfiguration = {
   proMode: boolean;
-  reseauxDeChaleur: boolean;
+  reseauxDeChaleur: {
+    show: boolean;
+    energieMajoritaire?: EnergieMajoritaire;
+    energiesSecondaires: Record<EnergieMajoritaire, Interval>;
+    tauxENRR: Interval;
+    emissionCO2: Interval;
+    prixMoyen: Interval;
+    periodeConstruction: Interval;
+  };
   reseauxDeFroid: boolean;
   reseauxEnConstruction: boolean;
   zonesDeDeveloppementPrioritaire: boolean;
@@ -13,15 +36,15 @@ export type MapConfiguration = {
     logements: boolean;
     tertiaire: boolean;
     industrie: boolean;
-    interval: [number, number];
+    interval: Interval;
   };
   batimentsGazCollectif: {
     show: boolean;
-    interval: [number, number];
+    interval: Interval;
   };
   batimentsFioulCollectif: {
     show: boolean;
-    interval: [number, number];
+    interval: Interval;
   };
   batimentsRaccordes: boolean;
   enrrMobilisables: {
@@ -43,9 +66,31 @@ export type MapConfiguration = {
 };
 export type MapConfigurationProperty = FlattenKeys<MapConfiguration>;
 
+export const percentageMaxInterval: Interval = [0, 100];
+export const emissionCO2MaxInterval: Interval = [0, 500];
+export const prixMoyenMaxInterval: Interval = [0, 300];
+export const periodeConstructionMaxInterval: Interval = [1900, 2024];
+
 const emptyMapConfiguration: MapConfiguration = {
   proMode: false,
-  reseauxDeChaleur: false,
+  reseauxDeChaleur: {
+    show: false,
+    energieMajoritaire: undefined,
+    energiesSecondaires: {
+      Biomasse: percentageMaxInterval,
+      Géothermie: percentageMaxInterval,
+      UVE: percentageMaxInterval,
+      'Chaleur industrielle': percentageMaxInterval,
+      'Solaire thermique': percentageMaxInterval,
+      'Pompe à chaleur': percentageMaxInterval,
+      Gaz: percentageMaxInterval,
+      Fioul: percentageMaxInterval,
+    },
+    tauxENRR: percentageMaxInterval,
+    emissionCO2: [0, 500],
+    prixMoyen: prixMoyenMaxInterval,
+    periodeConstruction: [1900, 2024],
+  },
   reseauxDeFroid: false,
   reseauxEnConstruction: false,
   zonesDeDeveloppementPrioritaire: false,
@@ -86,7 +131,10 @@ const emptyMapConfiguration: MapConfiguration = {
 
 export const defaultMapConfiguration = createMapConfiguration({
   proMode: true,
-  reseauxDeChaleur: true,
+  reseauxDeChaleur: {
+    show: true,
+    tauxENRR: [0, 100],
+  },
   reseauxEnConstruction: true,
   consommationsGaz: {
     show: true,
@@ -104,7 +152,9 @@ export const defaultMapConfiguration = createMapConfiguration({
 });
 
 export const iframeSimpleMapConfiguration = createMapConfiguration({
-  reseauxDeChaleur: true,
+  reseauxDeChaleur: {
+    show: true,
+  },
 });
 
 export function createMapConfiguration(

--- a/src/services/Map/map-configuration.ts
+++ b/src/services/Map/map-configuration.ts
@@ -57,6 +57,12 @@ export type MapConfiguration = {
     emissionsCO2: Interval;
     prixMoyen: Interval;
     anneeConstruction: Interval;
+    limits: {
+      tauxENRR: Interval;
+      emissionsCO2: Interval;
+      prixMoyen: Interval;
+      anneeConstruction: Interval;
+    };
   } & Record<EnergieRatioConfKey, Interval>;
   reseauxDeFroid: boolean;
   reseauxEnConstruction: boolean;
@@ -95,14 +101,39 @@ export type MapConfiguration = {
   };
   caracteristiquesBatiments: boolean;
 };
+
+/**
+ * Map configuration qui doit être complétée dynamiquement avec les limites
+ * des réseaux de chaleur, afin de construire les limites pour les filtres.
+ */
+export type EmptyMapConfiguration = Omit<
+  MapConfiguration,
+  'reseauxDeChaleur'
+> & {
+  reseauxDeChaleur: Omit<MapConfiguration['reseauxDeChaleur'], 'limits'> & {
+    limits: null;
+  };
+};
+
+export type MaybeEmptyMapConfiguration =
+  | MapConfiguration
+  | EmptyMapConfiguration;
+
 export type MapConfigurationProperty = FlattenKeys<MapConfiguration>;
 
-export const percentageMaxInterval: Interval = [0, 100];
-export const emissionsCO2MaxInterval: Interval = [0, 400];
-export const prixMoyenMaxInterval: Interval = [0, 300];
-export const anneeConstructionMaxInterval: Interval = [1900, 2024];
+export function isMapConfigurationInitialized(
+  conf: MaybeEmptyMapConfiguration
+): conf is MapConfiguration {
+  return !!conf.reseauxDeChaleur.limits;
+}
 
-const emptyMapConfiguration: MapConfiguration = {
+export const percentageMaxInterval: Interval = [0, 100];
+export const defaultInterval: Interval = [
+  Number.MIN_SAFE_INTEGER,
+  Number.MAX_SAFE_INTEGER,
+];
+
+const emptyMapConfiguration: EmptyMapConfiguration = {
   proMode: false,
   filtreIdentifiantReseau: [],
   filtreGestionnaire: [],
@@ -118,9 +149,10 @@ const emptyMapConfiguration: MapConfiguration = {
     energie_ratio_gaz: percentageMaxInterval,
     energie_ratio_fioul: percentageMaxInterval,
     tauxENRR: percentageMaxInterval,
-    emissionsCO2: [0, 500],
-    prixMoyen: prixMoyenMaxInterval,
-    anneeConstruction: [1900, 2024],
+    emissionsCO2: defaultInterval,
+    prixMoyen: defaultInterval,
+    anneeConstruction: defaultInterval,
+    limits: null, // fetched dynamically from the API
   },
   reseauxDeFroid: false,
   reseauxEnConstruction: false,

--- a/src/services/Map/map-configuration.ts
+++ b/src/services/Map/map-configuration.ts
@@ -1,32 +1,63 @@
 import { deepMergeObjects } from '@utils/core';
+import { Interval } from '@utils/interval';
 import { DeepPartial, FlattenKeys } from '@utils/typescript';
 
-type Interval = [number, number];
+type FiltreEnergie = {
+  label: string;
+  confKey: string;
+};
 
-export const energiesMajoritaires = [
-  'Biomasse',
-  'Géothermie',
-  'UVE',
-  'Chaleur industrielle',
-  'Solaire thermique',
-  'Pompe à chaleur',
-  'Gaz',
-  'Fioul',
-] as const;
+export const filtresEnergies = [
+  {
+    label: 'Biomasse',
+    confKey: 'biomasse',
+  },
+  {
+    label: 'Géothermie',
+    confKey: 'geothermie',
+  },
+  {
+    label: 'UVE',
+    confKey: 'uve',
+  },
+  {
+    label: 'Chaleur industrielle',
+    confKey: 'chaleurIndustrielle',
+  },
+  {
+    label: 'Solaire thermique',
+    confKey: 'solaireThermique',
+  },
+  {
+    label: 'Pompe à chaleur',
+    confKey: 'pompeAChaleur',
+  },
+  {
+    label: 'Gaz',
+    confKey: 'gaz',
+  },
+  {
+    label: 'Fioul',
+    confKey: 'fioul',
+  },
+] as const satisfies ReadonlyArray<FiltreEnergie>;
 
-type EnergieMajoritaire = (typeof energiesMajoritaires)[number];
+type FiltreEnergieConfKey = (typeof filtresEnergies)[number]['confKey'];
+
+type EnergieRatioConfKey = `energie_ratio_${FiltreEnergieConfKey}`;
 
 export type MapConfiguration = {
   proMode: boolean;
+  filtreIdentifiantReseau: string[];
+  filtreGestionnaire: string[];
   reseauxDeChaleur: {
     show: boolean;
-    energieMajoritaire?: EnergieMajoritaire;
-    energiesSecondaires: Record<EnergieMajoritaire, Interval>;
+    energieMajoritaire?: FiltreEnergieConfKey;
     tauxENRR: Interval;
     emissionCO2: Interval;
     prixMoyen: Interval;
     periodeConstruction: Interval;
-  };
+  } & Record<EnergieRatioConfKey, Interval>;
   reseauxDeFroid: boolean;
   reseauxEnConstruction: boolean;
   zonesDeDeveloppementPrioritaire: boolean;
@@ -73,19 +104,19 @@ export const periodeConstructionMaxInterval: Interval = [1900, 2024];
 
 const emptyMapConfiguration: MapConfiguration = {
   proMode: false,
+  filtreIdentifiantReseau: [],
+  filtreGestionnaire: [],
   reseauxDeChaleur: {
     show: false,
     energieMajoritaire: undefined,
-    energiesSecondaires: {
-      Biomasse: percentageMaxInterval,
-      Géothermie: percentageMaxInterval,
-      UVE: percentageMaxInterval,
-      'Chaleur industrielle': percentageMaxInterval,
-      'Solaire thermique': percentageMaxInterval,
-      'Pompe à chaleur': percentageMaxInterval,
-      Gaz: percentageMaxInterval,
-      Fioul: percentageMaxInterval,
-    },
+    energie_ratio_biomasse: percentageMaxInterval,
+    energie_ratio_geothermie: percentageMaxInterval,
+    energie_ratio_uve: percentageMaxInterval,
+    energie_ratio_chaleurIndustrielle: percentageMaxInterval,
+    energie_ratio_solaireThermique: percentageMaxInterval,
+    energie_ratio_pompeAChaleur: percentageMaxInterval,
+    energie_ratio_gaz: percentageMaxInterval,
+    energie_ratio_fioul: percentageMaxInterval,
     tauxENRR: percentageMaxInterval,
     emissionCO2: [0, 500],
     prixMoyen: prixMoyenMaxInterval,
@@ -133,15 +164,10 @@ export const defaultMapConfiguration = createMapConfiguration({
   proMode: true,
   reseauxDeChaleur: {
     show: true,
-    tauxENRR: [0, 100],
   },
   reseauxEnConstruction: true,
   consommationsGaz: {
     show: true,
-    logements: true,
-    tertiaire: true,
-    industrie: true,
-    interval: [1000, Number.MAX_VALUE],
   },
   batimentsGazCollectif: {
     show: true,

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -1,3 +1,4 @@
+import { isDevModeEnabled } from '@components/Map/components/DevModeIcon';
 import { fbEvent } from '@rivercode/facebook-conversion-api-nextjs';
 import { init as initMatomo } from '@totak/matomo-next';
 import { atom, useAtom, useAtomValue } from 'jotai';
@@ -501,7 +502,7 @@ export type TrackingEvent = keyof typeof trackingEvents;
  * eventPayload is only use for Matomo at the moment.
  */
 export const trackEvent = (eventKey: TrackingEvent, ...eventPayload: any[]) => {
-  if ((window as any).devMode) {
+  if (isDevModeEnabled()) {
     // eslint-disable-next-line no-console
     console.log('trackEvent', eventKey, eventPayload, trackingEvents[eventKey]);
   }

--- a/src/services/tiles.config.ts
+++ b/src/services/tiles.config.ts
@@ -98,8 +98,7 @@ export const tilesInfo: Record<SourceId, TileInfo> = {
   network: {
     source: 'database',
     table: 'reseaux_de_chaleur',
-    // tiles: 'reseaux_de_chaleur_tiles',
-    tiles: 'reseaux_de_chaleur_tiles_pr_filtres', // DEBUG
+    tiles: 'reseaux_de_chaleur_tiles',
     airtable: Airtable.NETWORKS,
     id: 'id_fcu',
     extraWhere: (query) => query,

--- a/src/services/tiles.config.ts
+++ b/src/services/tiles.config.ts
@@ -113,6 +113,8 @@ export const tilesInfo: Record<SourceId, TileInfo> = {
       'livraisons_totale_MWh',
       'nb_pdl',
       'has_trace',
+      'PM',
+      'annee_creation',
     ],
     sourceLayer: 'outline',
   },

--- a/src/services/tiles.config.ts
+++ b/src/services/tiles.config.ts
@@ -98,7 +98,8 @@ export const tilesInfo: Record<SourceId, TileInfo> = {
   network: {
     source: 'database',
     table: 'reseaux_de_chaleur',
-    tiles: 'reseaux_de_chaleur_tiles',
+    // tiles: 'reseaux_de_chaleur_tiles',
+    tiles: 'reseaux_de_chaleur_tiles_pr_filtres', // DEBUG
     airtable: Airtable.NETWORKS,
     id: 'id_fcu',
     extraWhere: (query) => query,

--- a/src/utils/interval.spec.ts
+++ b/src/utils/interval.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from 'vitest';
+import { Interval, intervalsEqual } from './interval';
+
+test('intervalsEqual()', () => {
+  const tests: Array<{ a: Interval; b: Interval; expectedResult: boolean }> = [
+    {
+      a: [1, 2],
+      b: [1, 2],
+      expectedResult: true,
+    },
+    {
+      a: [1, 2],
+      b: [1, 3],
+      expectedResult: false,
+    },
+    {
+      a: [2, 2],
+      b: [1, 3],
+      expectedResult: false,
+    },
+    {
+      a: [2, 2],
+      b: [1, 3],
+      expectedResult: false,
+    },
+  ];
+
+  tests.forEach((test) => {
+    expect(intervalsEqual(test.a, test.b)).toStrictEqual(test.expectedResult);
+  });
+});

--- a/src/utils/interval.ts
+++ b/src/utils/interval.ts
@@ -1,0 +1,8 @@
+export type Interval = [number, number];
+
+/**
+ * Returns true if two intervals are equal, false otherwise.
+ */
+export function intervalsEqual(a: Interval, b: Interval): boolean {
+  return a[0] === b[0] && a[1] === b[1];
+}


### PR DESCRIPTION
- Ajoute des filtres sur les métadonnées des réseaux de chaleur (+ les ratios d'énergies)
![image](https://github.com/betagouv/france-chaleur-urbaine/assets/8938024/2fe8678b-d33c-4e73-a466-b677fb2d7831)

- J'ai dû modifier la génération des tuiles des réseaux de chaleur pour y intégrer les métadonnées 
- A l'initialisation de la carte, les limites de certaines métadonnées des réseaux de chaleur sont téléchargées pour construire les filtres dynamiques.

TODO
- [x] mettre le script avec les commandes pour gérérer les tuiles
- [x] valider le workflow car ça change un peu la façon dont les réseaux sont mis à jour