### PR TITLE
chore: ajout typing sur MapConfigurationProperty

### DIFF
--- a/src/components/Map/components/SimpleMapLegend.tsx
+++ b/src/components/Map/components/SimpleMapLegend.tsx
@@ -50,6 +50,7 @@ import {
 } from 'src/services/Map/businessRules/zonePotentielChaud';
 import DevModeIcon from './DevModeIcon';
 import RangeFilter from './RangeFilter';
+import { Interval } from '@utils/interval';
 
 const consommationsGazLegendColor = '#D9D9D9';
 const consommationsGazUsageLegendOpacity = 0.53;
@@ -121,14 +122,14 @@ function SimpleMapLegend({
     });
   }
 
-  function toggleLayer(property: MapConfigurationProperty) {
+  function toggleLayer(property: MapConfigurationProperty<boolean>) {
     toggleBoolean(mapConfiguration, property);
     onMapConfigurationChange({ ...mapConfiguration });
   }
 
   function updateScaleInterval(
-    property: MapConfigurationProperty,
-    interval: [number, number]
+    property: MapConfigurationProperty<Interval>,
+    interval: Interval
   ) {
     setProperty(mapConfiguration, property, interval);
     onMapConfigurationChange({ ...mapConfiguration });

--- a/src/pages/carte.tsx
+++ b/src/pages/carte.tsx
@@ -28,7 +28,7 @@ const MapWrapper = styled.div`
 `;
 
 export const layerURLKeysToMapConfigPath = {
-  reseauxDeChaleur: 'reseauxDeChaleur',
+  reseauxDeChaleur: 'reseauxDeChaleur.show',
   reseauxDeFroid: 'reseauxDeFroid',
   reseauxEnConstruction: 'reseauxEnConstruction',
   zonesDeDeveloppementPrioritaire: 'zonesDeDeveloppementPrioritaire',
@@ -40,7 +40,7 @@ export const layerURLKeysToMapConfigPath = {
   zonesOpportunite: 'zonesOpportunite.show',
   enrrMobilisables: 'enrrMobilisables.show',
   caracteristiquesBatiments: 'caracteristiquesBatiments',
-} as const satisfies { [key: string]: MapConfigurationProperty };
+} as const satisfies { [key: string]: MapConfigurationProperty<boolean> };
 
 export type LayerURLKey = keyof typeof layerURLKeysToMapConfigPath;
 

--- a/src/services/Map/map-configuration.ts
+++ b/src/services/Map/map-configuration.ts
@@ -119,7 +119,10 @@ export type MaybeEmptyMapConfiguration =
   | MapConfiguration
   | EmptyMapConfiguration;
 
-export type MapConfigurationProperty = FlattenKeys<MapConfiguration>;
+export type MapConfigurationProperty<ValueType = any> = FlattenKeys<
+  MapConfiguration,
+  ValueType
+>;
 
 export function isMapConfigurationInitialized(
   conf: MaybeEmptyMapConfiguration

--- a/src/utils/typescript.ts
+++ b/src/utils/typescript.ts
@@ -1,18 +1,18 @@
 /**
- * Get all keys and nested keys of an object separated by dots.
+ * Get all keys and nested keys of an object separated by dots, filtered by value type.
  */
-export type FlattenKeys<Type> = Type extends Array<any>
+export type FlattenKeys<Type, ValueType = any> = Type extends Array<any>
   ? never
   : Type extends Record<string, any>
-  ? InternalFlattenKeys<Type>
+  ? InternalFlattenKeys<Type, ValueType>
   : '';
 
-type InternalFlattenKeys<Obj> = Obj extends Record<string, any>
+type InternalFlattenKeys<Obj, ValueType> = Obj extends Record<string, any>
   ? {
       [Key in keyof Obj]:
-        | `${Key & string}`
+        | (Obj[Key] extends ValueType ? `${Key & string}` : never)
         | (Obj[Key] extends Record<string, any>
-            ? `${Key & string}.${FlattenKeys<Obj[Key]> & string}`
+            ? `${Key & string}.${FlattenKeys<Obj[Key], ValueType> & string}`
             : never);
     }[keyof Obj]
   : never;


### PR DESCRIPTION
Permet de restreindre les propriétés retournées par le FlattenKeys afin de limiter les risques d'erreur quand on met à jour la conf.

A permis de détecter une erreur au niveau du mapping URL => couche affichée.