### PR TITLE
add vscode configuration

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "esbenp.prettier-vscode", // Prettier pour le formatage automatique du code
+    "dbaeumer.vscode-eslint" // ESLint pour la linting du code JavaScript et TypeScript
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+  "editor.tabSize": 2,
+  "editor.formatOnSave": true,
+  // Utilise Prettier pour le formatage
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  // Configure ESLint comme linter par défaut
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
+  // Active la correction automatique des erreurs à la sauvegarde pour ESLint
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit",
+    "source.organizeImports": "explicit"
+  },
+  "files.exclude": {
+    "**/.git": true,
+    "**/.DS_Store": true
+  }
+}


### PR DESCRIPTION
Recommandes les extensions Prettier et ESLint avec des réglages de base.
A compléter si besoin.