### PR TITLE
perf: optimisation performances requête calcul distance

### DIFF
--- a/src/core/infrastructure/repository/addresseInformation.ts
+++ b/src/core/infrastructure/repository/addresseInformation.ts
@@ -48,10 +48,7 @@ export const closestNetwork = async (
   const network = await db('reseaux_de_chaleur')
     .select(
       db.raw(
-        `ST_Distance(
-          ST_Transform('SRID=4326;POINT(${lon} ${lat})'::geometry, 2154),
-          ST_Transform(geom, 2154)
-        ) as distance, "Identifiant reseau", "Taux EnR&R", "contenu CO2 ACV", "Gestionnaire", nom_reseau`
+        `geom <-> ST_Transform('SRID=4326;POINT(${lon} ${lat})'::geometry, 2154) as distance, "Identifiant reseau", "Taux EnR&R", "contenu CO2 ACV", "Gestionnaire", nom_reseau`
       )
     )
     .where('has_trace', true)
@@ -71,10 +68,7 @@ const closestFuturNetwork = async (
   const network = await db('zones_et_reseaux_en_construction')
     .select(
       db.raw(
-        `ST_Distance(
-          ST_Transform('SRID=4326;POINT(${lon} ${lat})'::geometry, 2154),
-          ST_Transform(geom, 2154)
-        ) as distance, "gestionnaire"`
+        `geom <-> ST_Transform('SRID=4326;POINT(${lon} ${lat})'::geometry, 2154) as distance, "gestionnaire"`
       )
     )
     .where('is_zone', false)


### PR DESCRIPTION
Permet d'utiliser l'index pour calculer la distance.
Permet de passer de 100/120ms à 15/20ms pour la table reseaux_de_chaleur.