### PR TITLE
Solve bug pro mode

### DIFF
--- a/src/services/Map/map-configuration.ts
+++ b/src/services/Map/map-configuration.ts
@@ -205,13 +205,13 @@ export const defaultMapConfiguration = createMapConfiguration({
   },
   reseauxEnConstruction: true,
   consommationsGaz: {
-    show: true,
+    show: false,
   },
   batimentsGazCollectif: {
-    show: true,
+    show: false,
   },
   batimentsFioulCollectif: {
-    show: true,
+    show: false,
   },
 });
 


### PR DESCRIPTION
Je suis sur la carte en mode pro. Je désactive le mode pro : pas de pb cela fonctionne. Je ferme l’onglet. Je rouvre l’onglet (ou bien simplement, je vais sur une autre page du site puis reviens sur la carte) : mon choix est bien enregistré (mode pro désactivé), la légende est OK (mode pro désactivé) en revanche les données du mode pro apparaissent sur la carte (consos gaz, bât à chauffage collectif gaz et fioul). Je dois réactiver et redésactiver pour qu’elles ne s’affichent plus…