### PR TITLE
fix: apply range limits to the filters

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -222,6 +222,15 @@ const Map = ({
     fetchJSON<ReseauxDeChaleurLimits>('/api/map/network-limits').then(
       (limits) => {
         mapConfiguration.reseauxDeChaleur.limits = limits;
+
+        // apply the limits to the filters
+        mapConfiguration.reseauxDeChaleur.anneeConstruction =
+          limits.anneeConstruction;
+        mapConfiguration.reseauxDeChaleur.emissionsCO2 = limits.emissionsCO2;
+        mapConfiguration.reseauxDeChaleur.livraisonsAnnuelles =
+          limits.livraisonsAnnuelles;
+        mapConfiguration.reseauxDeChaleur.prixMoyen = limits.prixMoyen;
+
         setMapConfiguration({
           ...mapConfiguration,
         });

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -49,7 +49,7 @@ export function setProperty<Obj extends Record<string, any>>(
  * Deeply merge 2 objects in a new one.
  */
 export function deepMergeObjects<T, U>(obj1: T, obj2: U): T & U {
-  const result: any = { ...obj1 };
+  const result: any = cloneDeep(obj1);
 
   for (const key in obj2) {
     if (
@@ -72,4 +72,31 @@ export function deepMergeObjects<T, U>(obj1: T, obj2: U): T & U {
   }
 
   return result;
+}
+
+/**
+ * Deeply clone an object.
+ */
+export function cloneDeep(source: any): any {
+  const objectType = typeof source;
+  if (
+    objectType === 'string' ||
+    objectType === 'number' ||
+    objectType === 'boolean' ||
+    source === null ||
+    source === undefined
+  ) {
+    return source;
+  } else if (source instanceof Array) {
+    return source.map(cloneDeep);
+  } else if (source instanceof Date) {
+    return new Date(source.getTime());
+  } else if (objectType === 'object') {
+    return Object.keys(source).reduce((clone: any, key) => {
+      clone[key] = cloneDeep(source[key]);
+      return clone;
+    }, {});
+  } else {
+    throw new Error(`unknown object type: ${objectType}`);
+  }
 }


### PR DESCRIPTION
Besoin de #787 pour réorganiser les imports de Map.tsx

- Petite correction de deepMergeObjects  pour utiliser cloneDeep pour être sûr que l'objet en paramètre n'est pas muté.
- Une fois les limites des filtres récupérées, on les applique à la configuration. Jusqu'à présent, c'est le composant RangeFilter qui s'en occupait (et c'était donc pas génial...)
