### PR TITLE
Fix harmonisation éligibilité api formulaire

### DIFF
--- a/src/core/infrastructure/repository/addresseInformation.ts
+++ b/src/core/infrastructure/repository/addresseInformation.ts
@@ -286,13 +286,6 @@ export const getNetworkEligibilityDistances = (networkId: string) => {
     : { eligibleDistance: 200, veryEligibleDistance: 100 };
 };
 
-const isDistanceEligible = (distance: number, city?: string) => {
-  if (city && city.toLowerCase() === 'paris') {
-    return { isEligible: distance <= 100, veryEligibleDistance: 60 };
-  }
-  return { isEligible: distance <= 200, veryEligibleDistance: 100 };
-};
-
 export const getCityEligilityStatus = async (
   city: string
 ): Promise<CityNetwork> => {
@@ -338,8 +331,7 @@ export const getNetworkEligilityStatus = async (
 
 export const getEligilityStatus = async (
   lat: number,
-  lon: number,
-  city?: string
+  lon: number
 ): Promise<HeatNetwork> => {
   const [inZDP, irisNetwork, inFuturNetwork, futurNetwork, network] =
     await Promise.all([
@@ -350,11 +342,21 @@ export const getEligilityStatus = async (
       closestNetwork(lat, lon),
     ]);
 
-  const eligibility = isDistanceEligible(Number(network.distance), city);
-  const futurEligibility = isDistanceEligible(
-    Number(futurNetwork.distance),
-    city
+  const eligibilityDistances = getNetworkEligibilityDistances(
+    network['Identifiant reseau']
   );
+  const futurEligibilityDistances = getNetworkEligibilityDistances(''); // gets the default distances
+  const eligibility = {
+    isEligible:
+      Number(network.distance) <= eligibilityDistances.eligibleDistance,
+    veryEligibleDistance: eligibilityDistances.veryEligibleDistance,
+  };
+  const futurEligibility = {
+    isEligible:
+      futurNetwork.distance <= futurEligibilityDistances.eligibleDistance,
+    veryEligibleDistance: futurEligibilityDistances.veryEligibleDistance,
+  };
+
   if (
     eligibility.isEligible &&
     Number(network.distance) < eligibility.veryEligibleDistance

--- a/src/pages/api/map/bulkEligibilityStatus/index.ts
+++ b/src/pages/api/map/bulkEligibilityStatus/index.ts
@@ -235,10 +235,11 @@ const bulkEligibilitygibilityStatus = async (
       const address = informations.slice(0, informations.length - 5).join(',');
 
       const result = label
-        ? await getEligilityStatus(Number(lat), Number(lon), city)
+        ? await getEligilityStatus(Number(lat), Number(lon))
         : { isEligible: null };
       results.push({
         ...result,
+        city,
         address,
         score: Math.round(Number.parseFloat(score) * 1000) / 1000,
         label,

--- a/src/pages/api/map/eligibilityStatus.ts
+++ b/src/pages/api/map/eligibilityStatus.ts
@@ -14,7 +14,6 @@ const eligibilityStatus = handleRouteErrors(async (req: NextApiRequest) => {
   const { lat, lon } = await validateObjectSchema(req.query, {
     lat: z.coerce.number(),
     lon: z.coerce.number(),
-    city: z.string(),
   });
   return await getEligilityStatus(lat, lon);
 });

--- a/src/pages/api/map/eligibilityStatus.ts
+++ b/src/pages/api/map/eligibilityStatus.ts
@@ -11,12 +11,12 @@ import { z } from 'zod';
 const eligibilityStatus = handleRouteErrors(async (req: NextApiRequest) => {
   requireGetMethod(req);
 
-  const { lat, lon, city } = await validateObjectSchema(req.query, {
+  const { lat, lon } = await validateObjectSchema(req.query, {
     lat: z.coerce.number(),
     lon: z.coerce.number(),
     city: z.string(),
   });
-  return await getEligilityStatus(lat, lon, city);
+  return await getEligilityStatus(lat, lon);
 });
 
 export default withCors(eligibilityStatus);

--- a/src/services/heatNetwork.ts
+++ b/src/services/heatNetwork.ts
@@ -36,7 +36,7 @@ export class HeatNetworkService {
       } else {
         const [lon, lat] = geoAddress.geometry.coordinates;
         return await this.httpClient.get<HeatNetworksResponse>(
-          `/api/map/eligibilityStatus?lat=${lat}&lon=${lon}&city=${geoAddress.properties.city}`
+          `/api/map/eligibilityStatus?lat=${lat}&lon=${lon}`
         );
       }
     } catch (e) {


### PR DESCRIPTION
- Basé sur #779 car il y a quelques changements liés au test d'éligibilité.
- Supprime la ville des paramètres du test d'éligibilité. Les seuils réduits à 100m/60m sont seulement valables pour les réseaux 7501C et 7511C (Paris) (vu avec Florence)

- j'ai pas complètement enlevé la ville du bulk, pour avoir moins d'impacts