### PR TITLE
fix: suppression du bloc informations si pas demandé

### DIFF
--- a/src/components/Network/Network.tsx
+++ b/src/components/Network/Network.tsx
@@ -39,6 +39,7 @@ const hasFirstColumn = (isCold: boolean, displayBlocks?: string[]) => {
 const hasSecondColumn = (isCold: boolean, displayBlocks?: string[]) => {
   return (
     !displayBlocks ||
+    displayBlocks.includes('informations') ||
     displayBlocks.includes('map') ||
     (!isCold && displayBlocks.includes('energies'))
   );
@@ -441,43 +442,45 @@ const NetworkPanel = ({
                 : 'fr-col-12'
             }
           >
-            {network.informationsComplementaires && (
-              <InformationsComplementairesBox>
-                <h3>Informations complémentaires</h3>
-                {network.informationsComplementaires
-                  .split('\n')
-                  .map((line, index) =>
-                    line === '' ? (
-                      <br key={index} />
-                    ) : (
-                      <Text key={index}>{line}</Text>
-                    )
-                  )}
-                {network.fichiers.length > 0 && (
-                  <div className="fr-mt-2w">
-                    {network.fichiers.map((fichier, index) => (
-                      <Link
-                        key={index}
-                        href={`/api/networks/${network['Identifiant reseau']}/files/${fichier.id}`}
-                        className="fr-mr-1w"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        {fichier.filename}
-                      </Link>
-                    ))}
-                  </div>
-                )}
-                <Text
-                  size="sm"
-                  legacyColor="lightgrey"
-                  fontStyle="italic"
-                  mt="4w"
-                >
-                  Informations fournies par la collectivité ou l’exploitant
-                </Text>
-              </InformationsComplementairesBox>
-            )}
+            {!displayBlocks ||
+              (displayBlocks.includes('informations') &&
+                network.informationsComplementaires && (
+                  <InformationsComplementairesBox>
+                    <h3>Informations complémentaires</h3>
+                    {network.informationsComplementaires
+                      .split('\n')
+                      .map((line, index) =>
+                        line === '' ? (
+                          <br key={index} />
+                        ) : (
+                          <Text key={index}>{line}</Text>
+                        )
+                      )}
+                    {network.fichiers.length > 0 && (
+                      <div className="fr-mt-2w">
+                        {network.fichiers.map((fichier, index) => (
+                          <Link
+                            key={index}
+                            href={`/api/networks/${network['Identifiant reseau']}/files/${fichier.id}`}
+                            className="fr-mr-1w"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            {fichier.filename}
+                          </Link>
+                        ))}
+                      </div>
+                    )}
+                    <Text
+                      size="sm"
+                      legacyColor="lightgrey"
+                      fontStyle="italic"
+                      mt="4w"
+                    >
+                      Informations fournies par la collectivité ou l’exploitant
+                    </Text>
+                  </InformationsComplementairesBox>
+                ))}
             {!isCold &&
               (!displayBlocks || displayBlocks.includes('energies')) && (
                 <Box>


### PR DESCRIPTION
Permet d'éviter d'afficher les informations complémentaires en ajoutant un paramètre comme pour les autres sections.

C'est [utilisé uniquement par Engie](https://www.rezomee.fr/velizy-reseau-chaleur/plan-reseau), et on ne veut pas faire de pub donc ce n'est pas documenté... 