### PR TITLE
fix: zoom initial carte fiches réseau

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -599,7 +599,7 @@ const Map = ({
         };
         setMarkersList([newMarker]);
       }
-      jumpTo({ coordinates: initialCenter });
+      jumpTo({ coordinates: initialCenter, zoom: initialZoom });
     }
   }, [initialCenter, jumpTo, withCenterPin]);
 


### PR DESCRIPTION
Corrige le zoom à 16 sur les fiches réseau, au lieu de 13, surtout visible en prod.
![image](https://github.com/betagouv/france-chaleur-urbaine/assets/8938024/ad8d6311-ae0b-4964-a5c1-c0ba73f549d0)

Pour reproduire en local, j'ai dû activer un outil de tracking (linkedin par exemple).
