### PR TITLE
feat: affichage message d'erreur détaillé formulaire reset pw

### DIFF
--- a/src/components/connexion/NewPasswordForm.tsx
+++ b/src/components/connexion/NewPasswordForm.tsx
@@ -37,7 +37,12 @@ const NewPasswordForm = ({ token }: { token: string }) => {
       passwordService
         .changePassword(token, password)
         .then(() => router.push('/connexion'))
-        .catch((e) => setFail(e.response.data.message));
+        .catch((e) =>
+          setFail(
+            e.response.data.error?.issues?.[0]?.message ??
+              e.response.data.message
+          )
+        );
     }
   };
   return (

--- a/src/pages/api/password/change.ts
+++ b/src/pages/api/password/change.ts
@@ -17,11 +17,14 @@ const changePasswordRequest = handleRouteErrors(async (req: NextApiRequest) => {
   const { password, token } = await validateObjectSchema(req.body, {
     password: zPassword,
     token: z.string().transform((token, ctx) => {
-      const decodedToken = jwt.verify(
-        req.body.token,
-        process.env.NEXTAUTH_SECRET as string
-      ) as { email: string; resetToken: string };
-      if (!decodedToken) {
+      try {
+        const decodedToken = jwt.verify(
+          token,
+          process.env.NEXTAUTH_SECRET as string
+        ) as { email: string; resetToken: string };
+
+        return decodedToken;
+      } catch (err) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message:
@@ -30,7 +33,6 @@ const changePasswordRequest = handleRouteErrors(async (req: NextApiRequest) => {
 
         return z.NEVER;
       }
-      return decodedToken;
     }),
   });
 

--- a/src/pages/api/password/reset.ts
+++ b/src/pages/api/password/reset.ts
@@ -38,7 +38,7 @@ const reset = handleRouteErrors(async (req: NextApiRequest) => {
   const payload = {
     email,
     resetToken,
-    exp: Math.round(Date.now() / 1000) + 60 * 60, // 1 hour expiration
+    exp: Math.round(Date.now() / 1000) + 60 * 60 * 3, // 3 hour expiration
   };
 
   const token = jwt.sign(payload, process.env.NEXTAUTH_SECRET as string);

--- a/src/services/email/views/password.ejs
+++ b/src/services/email/views/password.ejs
@@ -10,7 +10,7 @@
           <div style="overflow-wrap: break-word;">
             <p>Bonjour ! 👋</p>
             <p>
-              Pour réinitialiser votre mot de passe, veuillez cliquer sur le bouton suivant (valable pendant 1 heure) :
+              Pour réinitialiser votre mot de passe, veuillez cliquer sur le bouton suivant (valable pendant 3 heures) :
             </p>
             <p>
               <a href="<%= link %>"


### PR DESCRIPTION
- Finalement `jwt.verify` lève une exception plutôt que de renvoyer une valeur vide.
- \+ affichage du message d'erreur zod côté formulaire. (idéalement, il faudrait avoir un comportement similaire pour tous les formulaires