### PR TITLE
feat: replace maildev by mailpit (better ux)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,26 +12,24 @@ services:
       - ./docker/postgresql.conf:/etc/postgresql/postgresql.conf:ro
       - db:/var/lib/postgresql/data
 
-  maildev:
-    image: maildev/maildev
-    environment:
-      MAILDEV_INCOMING_USER: mailuser
-      MAILDEV_INCOMING_PASS: mailpassword
+  mailpit:
+    image: axllent/mailpit:v1.18.5
+    restart: unless-stopped
     ports:
-      - '1080:1080'
-      - '1025:1025'
+      - 1025:1025
+      - 8025:8025
+    environment:
+      - MP_DATA_FILE=/data/mailpit.db
+    volumes:
+      - mailpit:/data
 
   web:
     build: ./docker/web
     command: sh -c "yarn dev"
     environment:
       DATABASE_URL: postgres://postgres:postgres_fcu@db:5432/postgres
-      MAIL_PASS: mailpassword
-      MAIL_USER: mailuser
-      MAIL_HOST: maildev
+      MAIL_HOST: mailpit
       MAIL_PORT: 1025
-      MAIL_SECURE: 'false'
-      MAIL_REQUIRE_TLS: 'false'
     ports:
       - '3000:3000'
     volumes:
@@ -41,3 +39,4 @@ services:
 
 volumes:
   db:
+  mailpit:


### PR DESCRIPTION
Change le serveur de mail de test utilisé en local par [mailpit](https://mailpit.axllent.org/).

Avantages :
- volume docker pour conserver l'historique des mails
- affiche les pièces jointes directement !
- projet maintenu !

![image](https://github.com/betagouv/france-chaleur-urbaine/assets/8938024/97640741-e873-4187-9edf-6e6ad6a35532)


En local, après avoir récupéré cette branche et / ou une fois mergée. Il faudra faire la commande suivante :
```
docker compose up -d --remove-orphans
```
