### PR TITLE
feat: gestion basique des erreurs des formulaires de test

### DIFF
--- a/src/components/HeadSliceForm/HeadSliceForm.tsx
+++ b/src/components/HeadSliceForm/HeadSliceForm.tsx
@@ -11,11 +11,14 @@ import {
 import MarkdownWrapper from '@components/MarkdownWrapper';
 import Slice from '@components/Slice';
 import AddressAutocomplete from '@components/addressAutocomplete';
+import Box from '@components/ui/Box';
+import Link from '@components/ui/Link';
 import { Button } from '@dataesr/react-dsfr';
 import { useContactFormFCU } from '@hooks';
 import { useRouter } from 'next/router';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useServices } from 'src/services';
+import { AnalyticsFormId } from 'src/services/analytics';
 import { AvailableHeating } from 'src/types/AddressData';
 import { SuggestionItem } from 'src/types/Suggestions';
 import BulkEligibilitySlice from './BulkEligibilitySlice';
@@ -32,7 +35,6 @@ import {
   Separator,
   SliceContactFormStyle,
 } from './HeadSliceForm.style';
-import { AnalyticsFormId } from 'src/services/analytics';
 
 type HeadBannerType = {
   bg?: string;
@@ -85,6 +87,7 @@ const HeadSlice = ({
   const [geoAddress, setGeoAddress] = useState<SuggestionItem>();
   const [address, setAddress] = useState('');
   const [autoValidate, setAutoValidate] = useState(false);
+  const [eligibilityError, setEligibilityError] = useState(false);
 
   const [displayBulkEligibility, setDisplayBulkEligibility] = useState(false);
 
@@ -105,6 +108,7 @@ const HeadSlice = ({
   );
 
   const testAddress = useCallback(async () => {
+    setEligibilityError(false);
     if (!geoAddress) {
       return;
     }
@@ -116,15 +120,18 @@ const HeadSlice = ({
     const [lon, lat] = geoAddress.geometry.coordinates;
     const coords = { lon, lat };
 
-    const networkData = await heatNetworkService.findByCoords(geoAddress);
-
-    handleOnSuccessAddress({
-      address,
-      heatingType,
-      coords,
-      geoAddress,
-      eligibility: networkData,
-    });
+    try {
+      const networkData = await heatNetworkService.findByCoords(geoAddress);
+      handleOnSuccessAddress({
+        address,
+        heatingType,
+        coords,
+        geoAddress,
+        eligibility: networkData,
+      });
+    } catch (err: any) {
+      setEligibilityError(true);
+    }
   }, [
     address,
     geoAddress,
@@ -182,9 +189,16 @@ const HeadSlice = ({
               {warningMessage}
             </FormWarningMessage>
 
-            <LoaderWrapper show={!showWarning && loadingStatus === 'loading'}>
-              <Loader color="#fff" />
-            </LoaderWrapper>
+            {eligibilityError ? (
+              <Box textColor="#c00">
+                Une erreur est survenue. Veuillez réessayer ou bien{' '}
+                <Link href="/contact">contacter le support</Link>.
+              </Box>
+            ) : (
+              <LoaderWrapper show={!showWarning && loadingStatus === 'loading'}>
+                <Loader color="#fff" />
+              </LoaderWrapper>
+            )}
 
             <Buttons>
               <Button
@@ -218,6 +232,7 @@ const HeadSlice = ({
       ),
     [
       address,
+      eligibilityError,
       geoAddress,
       heatingType,
       testAddress,

--- a/src/components/Map/components/CardSearchDetailsForm.tsx
+++ b/src/components/Map/components/CardSearchDetailsForm.tsx
@@ -3,6 +3,8 @@ import {
   EligibilityFormContact,
   EligibilityFormMessageConfirmation,
 } from '@components/EligibilityForm';
+import Box from '@components/ui/Box';
+import Link from '@components/ui/Link';
 import { useContactFormFCU } from '@hooks';
 import React, { useCallback, useState } from 'react';
 import {
@@ -26,6 +28,7 @@ const CardSearchDetailsForm: React.FC<{
     handleOnSubmitContact,
   } = useContactFormFCU();
 
+  const [contactFormError, setContactFormError] = useState(false);
   const [formIsSend, setFormIsSend] = useState(false);
 
   const onSuccess = useCallback(
@@ -33,10 +36,15 @@ const CardSearchDetailsForm: React.FC<{
     (data: any) => handleOnSuccessAddress(data, true, true),
     [handleOnSuccessAddress]
   );
-  const handleSubmitForm = (data: Record<string, any>) => {
-    handleOnSubmitContact(data, true);
-    onSubmit?.(data);
-    setFormIsSend(true);
+  const handleSubmitForm = async (data: Record<string, any>) => {
+    try {
+      setContactFormError(false);
+      await handleOnSubmitContact(data, true);
+      onSubmit?.(data);
+      setFormIsSend(true);
+    } catch (err) {
+      setContactFormError(true);
+    }
   };
 
   return (
@@ -61,6 +69,12 @@ const CardSearchDetailsForm: React.FC<{
             onSubmit={handleSubmitForm}
             cardMode
           />
+          {contactFormError && (
+            <Box textColor="#c00" mt="1w">
+              Une erreur est survenue. Veuillez réessayer ou bien{' '}
+              <Link href="/contact">contacter le support</Link>.
+            </Box>
+          )}
         </ContactFormWrapper>
 
         <ContactFormWrapper active={messageReceived}>

--- a/src/components/Map/components/MapSearchForm.tsx
+++ b/src/components/Map/components/MapSearchForm.tsx
@@ -1,4 +1,7 @@
 import AddressAutocomplete from '@components/addressAutocomplete';
+import Box from '@components/ui/Box';
+import Link from '@components/ui/Link';
+import { useState } from 'react';
 import { useServices } from 'src/services';
 import { HandleAddressSelect } from 'src/types/HeatNetworksResponse';
 import { SuggestionItem } from 'src/types/Suggestions';
@@ -9,6 +12,7 @@ const MapSearchForm = ({
 }: {
   onAddressSelect?: HandleAddressSelect;
 }) => {
+  const [eligibilityError, setEligibilityError] = useState(false);
   const { heatNetworkService } = useServices();
 
   const handleAddressSelected = async (
@@ -18,15 +22,23 @@ const MapSearchForm = ({
     if (!geoAddress) {
       return;
     }
+    try {
+      setEligibilityError(false);
+      const network = await heatNetworkService.findByCoords(geoAddress);
+      const addressDetail = {
+        network,
+        geoAddress,
+      };
 
-    const network = await heatNetworkService.findByCoords(geoAddress);
-    const addressDetail = {
-      network,
-      geoAddress,
-    };
-
-    if (onAddressSelect) {
-      onAddressSelect(address, geoAddress.geometry.coordinates, addressDetail);
+      if (onAddressSelect) {
+        onAddressSelect(
+          address,
+          geoAddress.geometry.coordinates,
+          addressDetail
+        );
+      }
+    } catch (err) {
+      setEligibilityError(true);
     }
   };
 
@@ -38,6 +50,12 @@ const MapSearchForm = ({
         onAddressSelected={handleAddressSelected}
         className="map-search-form"
       />
+      {eligibilityError && (
+        <Box textColor="#c00" mt="1w">
+          Une erreur est survenue. Veuillez réessayer ou bien{' '}
+          <Link href="/contact">contacter le support</Link>.
+        </Box>
+      )}
     </>
   );
 };

--- a/src/helpers/airtable.ts
+++ b/src/helpers/airtable.ts
@@ -86,13 +86,17 @@ export const submitToAirtable = async (
   values: any,
   type: Airtable
 ): Promise<Response> => {
-  return fetch('/api/airtable/records', {
+  const res = await fetch('/api/airtable/records', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({ ...values, type }),
   });
+  if (!res.ok) {
+    throw new Error(`wrong status ${res.status}`);
+  }
+  return res;
 };
 
 export const updateAirtable = async (

--- a/src/hooks/useContactFormFCU.ts
+++ b/src/hooks/useContactFormFCU.ts
@@ -98,14 +98,6 @@ const useContactFormFCU = () => {
       if (data && data.structure !== 'Tertiaire') {
         data.company = '';
       }
-      setMessageSent(true);
-      const { eligibility, address = '' } = (data as AddressDataType) || {};
-      trackEvent(
-        `Eligibilité|Formulaire de contact ${
-          eligibility?.isEligible ? 'é' : 'iné'
-        }ligible${fromMap ? ' - Carte' : ''} - Envoi`,
-        address
-      );
       const response = await submitToAirtable(
         formatDataToAirtable({
           ...data,
@@ -116,6 +108,14 @@ const useContactFormFCU = () => {
         Airtable.UTILISATEURS
       );
       const { id } = await response.json();
+      setMessageSent(true);
+      const { eligibility, address = '' } = (data as AddressDataType) || {};
+      trackEvent(
+        `Eligibilité|Formulaire de contact ${
+          eligibility?.isEligible ? 'é' : 'iné'
+        }ligible${fromMap ? ' - Carte' : ''} - Envoi`,
+        address
+      );
       const scrollTimer = timeoutScroller(500);
       setAddressData({
         ...addressData,


### PR DESCRIPTION
- Permet d'afficher un message d'erreur en cas d'erreur sur les formulaires de test d'adresse + demande de contact. Le but étant de ne pas afficher le message comme quoi la demande a été traitée si elle n'est pas enregistrée.
- Il y a pas mal de complexité dans les composants historiques liés au formulaire avec le hook avec beaucoup de callbacks en paramètre de composants, 
- \+ gros bugfix sur les pages avec le sticky form (pages villes + ressources)


- Sur la carte
![2024-06-21_14-55](https://github.com/betagouv/france-chaleur-urbaine/assets/8938024/359c01bd-bb79-47f0-b40d-003fd9711bae)
![2024-06-21_14-59](https://github.com/betagouv/france-chaleur-urbaine/assets/8938024/bd8d6b50-aa45-4644-a792-9c31cf69d4d5)

- Sur les fiches réseau
![2024-06-21_14-29](https://github.com/betagouv/france-chaleur-urbaine/assets/8938024/4f7f8197-429a-45ff-b783-7834457d45e9)
![2024-06-21_14-26](https://github.com/betagouv/france-chaleur-urbaine/assets/8938024/4915979c-e36a-45c7-983e-9bf4714947a7)

- Sur les pages vitrines
![image](https://github.com/betagouv/france-chaleur-urbaine/assets/8938024/722c94e9-6b29-4b7f-ade3-4cae3b593b8d)
![2024-06-21_14-18](https://github.com/betagouv/france-chaleur-urbaine/assets/8938024/616f707b-0c57-4e96-a068-d32e0a8d393d)

- Sur les pages ville...
![image](https://github.com/betagouv/france-chaleur-urbaine/assets/8938024/6308d2c1-9c9c-4116-a2f2-5b2acdb4d37e)
![image](https://github.com/betagouv/france-chaleur-urbaine/assets/8938024/4e2e8736-a08e-44f9-8235-d815de090ea2)
