### PR TITLE
fix: prevent forms double submission

### DIFF
--- a/src/components/EligibilityForm/EligibilityFormContact.tsx
+++ b/src/components/EligibilityForm/EligibilityFormContact.tsx
@@ -25,17 +25,16 @@ import {
 
 type EligibilityFormContactType = {
   addressData: AddressDataType;
-  isSent?: boolean;
   cardMode?: boolean;
   onSubmit?: (...arg: any) => Promise<any>;
 };
 
 const EligibilityFormContact = ({
   addressData,
-  isSent,
   cardMode,
   onSubmit,
 }: EligibilityFormContactType) => {
+  const [contactFormLoading, setContactFormLoading] = useState(false);
   const [contactFormError, setContactFormError] = useState(false);
 
   const { ready, variation } = useMatomoAbTestingExperiment(
@@ -113,7 +112,10 @@ const EligibilityFormContact = ({
         }
 
         if (onSubmit) {
-          await onSubmit(sendedValues);
+          setContactFormLoading(true);
+          await onSubmit(sendedValues).finally(() => {
+            setContactFormLoading(false);
+          });
         }
       } catch (err: any) {
         setContactFormError(true);
@@ -207,7 +209,7 @@ const EligibilityFormContact = ({
             <ContactForm
               city={addressData.geoAddress?.properties.city}
               onSubmit={handleSubmitForm}
-              isLoading={isSent}
+              isLoading={contactFormLoading}
               cardMode={cardMode}
             />
             {contactFormError && (

--- a/src/components/HeadSliceForm/HeadSliceForm.tsx
+++ b/src/components/HeadSliceForm/HeadSliceForm.tsx
@@ -71,7 +71,6 @@ const HeadSlice = ({
     addressData,
     contactReady,
     showWarning,
-    messageSent,
     messageReceived,
     loadingStatus,
     warningMessage,
@@ -203,7 +202,12 @@ const HeadSlice = ({
             <Buttons>
               <Button
                 size="lg"
-                disabled={!address || !geoAddress || !heatingType}
+                disabled={
+                  !address ||
+                  !geoAddress ||
+                  !heatingType ||
+                  (loadingStatus === 'loading' && !eligibilityError)
+                }
                 onClick={testAddress}
               >
                 Tester cette adresse
@@ -271,7 +275,6 @@ const HeadSlice = ({
           {address && (
             <EligibilityFormContact
               addressData={addressData}
-              isSent={messageSent}
               onSubmit={handleOnSubmitContact}
             />
           )}

--- a/src/components/Map/components/CardSearchDetailsForm.tsx
+++ b/src/components/Map/components/CardSearchDetailsForm.tsx
@@ -20,7 +20,6 @@ const CardSearchDetailsForm: React.FC<{
     EligibilityFormContactRef,
     addressData,
     contactReady,
-    messageSent,
     messageReceived,
     handleOnChangeAddress,
     handleOnFetchAddress,
@@ -65,7 +64,6 @@ const CardSearchDetailsForm: React.FC<{
         <ContactFormWrapper active={contactReady && !messageReceived}>
           <EligibilityFormContact
             addressData={addressData}
-            isSent={messageSent}
             onSubmit={handleSubmitForm}
             cardMode
           />

--- a/src/components/SliceForm/SliceForm.tsx
+++ b/src/components/SliceForm/SliceForm.tsx
@@ -26,7 +26,6 @@ const HeadSlice = ({
     addressData,
     contactReady,
     showWarning,
-    messageSent,
     messageReceived,
     loadingStatus,
     warningMessage,
@@ -73,7 +72,6 @@ const HeadSlice = ({
         >
           <EligibilityFormContact
             addressData={addressData}
-            isSent={messageSent}
             onSubmit={handleOnSubmitContact}
           />
         </Slice>

--- a/src/components/StickyForm/StickyForm.tsx
+++ b/src/components/StickyForm/StickyForm.tsx
@@ -20,7 +20,6 @@ const StickyForm = ({ title }: { title?: string }) => {
     addressData,
     contactReady,
     showWarning,
-    messageSent,
     messageReceived,
     loadingStatus,
     warningMessage,
@@ -68,7 +67,6 @@ const StickyForm = ({ title }: { title?: string }) => {
         >
           <EligibilityFormContact
             addressData={addressData}
-            isSent={messageSent}
             onSubmit={handleOnSubmitContact}
           />
         </Slice>


### PR DESCRIPTION
Corrige la double soumission des formulaires de contact. Le comportement avait récemment changé pour afficher des erreurs côté API.

Fini les `isLoading=(isSent}` :sweat_smile: 