### PR TITLE
feat: update mail sender

### DIFF
--- a/.env
+++ b/.env
@@ -6,7 +6,8 @@ AIRTABLE_BASE=airtable-secret-id-base
 API_DEBUG_MODE=0
 NEXTAUTH_SECRET=secret
 NEXTAUTH_URL=http://localhost:3000
-SENDING_EMAIL=france-chaleur-urbaine@developpement-durable.gouv.fr
+SENDING_EMAIL=France Chaleur Urbaine <france-chaleur-urbaine@applications.developpement-durable.gouv.fr>
+REPLYTO_EMAIL=France Chaleur Urbaine <france-chaleur-urbaine@developpement-durable.gouv.fr>
 
 # analytics
 NEXT_PUBLIC_MATOMO_URL=

--- a/src/pages/api/password/reset.ts
+++ b/src/pages/api/password/reset.ts
@@ -1,3 +1,4 @@
+import { logger } from '@helpers/logger';
 import {
   handleRouteErrors,
   requirePostMethod,
@@ -23,6 +24,7 @@ const reset = handleRouteErrors(async (req: NextApiRequest) => {
     .andWhere('active', true)
     .first();
   if (!user) {
+    logger.warn('reset-password: missing user', { email });
     await AirtableDB(Airtable.CONNEXION).create([
       {
         fields: {

--- a/src/services/email/index.ts
+++ b/src/services/email/index.ts
@@ -18,8 +18,6 @@ type Attachment = {
 const mailTransport = nodemailer.createTransport({
   host: process.env.MAIL_HOST,
   port: process.env.MAIL_PORT,
-  ignoreTLS: process.env.MAIL_REQUIRE_TLS === 'false',
-  requireTLS: process.env.MAIL_REQUIRE_TLS === 'true',
   secure: process.env.MAIL_SECURE === 'true',
   auth: {
     user: process.env.MAIL_USER,
@@ -40,13 +38,12 @@ const send = (
     to: toEmail.join(','),
     cc: ccEmail && ccEmail.join(','),
     bcc: bccEmail.join(','),
-    from: `FCU <${process.env.SENDING_EMAIL}>`,
-    replyTo: replyTo || process.env.SENDING_EMAIL,
+    from: process.env.SENDING_EMAIL,
+    replyTo: replyTo || process.env.REPLYTO_EMAIL,
     subject,
     html,
     attachments,
     text: html.replace(/<(?:.|\n)*?>/gm, ''),
-    headers: { 'X-Mailjet-TrackOpen': '0', 'X-Mailjet-TrackClick': '0' },
   };
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
- Petite modif pout utiliser la nouvelle adresse d'envoi, dont le domaine est authentifié côté Brevo
- Simplification des paramères de connexion / d'envoi d'email
- On conserve l'adresse actuelle en replyTo
- J'ai ajouté un log warning au niveau de l'oubli de mdp (en plus de la ligne dans airtable)


S'assurer d'avoir ça dans le fichier .env.local :
```sh
# mail
MAIL_HOST=mailpit
MAIL_PASS=mailpassword
MAIL_USER=mailuser
MAIL_PORT=1025
MAIL_SECURE=false
```

Il faudra mettre à jour les variables en prod au moment du déploiement