### PR TITLE
feat: ajout param bbox sur la carte

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@commander-js/extra-typings": "^11.1.0",
     "@dataesr/react-dsfr": "^3.9.1",
     "@faker-js/faker": "^8.0.2",
+    "@mapbox/geo-viewport": "^0.5.0",
     "@mapbox/mapbox-gl-draw": "^1.4.3",
     "@next/bundle-analyzer": "13.5.6",
     "@reach/combobox": "^0.18.0",

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -1,3 +1,4 @@
+import geoViewport from '@mapbox/geo-viewport';
 import MapReactGL, {
   AttributionControl,
   GeolocateControl,
@@ -771,6 +772,41 @@ const Map = ({
   if (router.query.zoom) {
     initialViewState.zoom =
       parseFloat(router.query.zoom as string) ?? mapSettings.defaultZoom;
+  }
+
+  // initial fit on bbox
+  if (router.query.bbox) {
+    const bbox = (router.query.bbox as string)
+      .split(',')
+      .map((n) => Number.parseFloat(n)) as [number, number, number, number];
+
+    const mapViewportFitPadding = 50; // px
+    const sideBarWidth = 345; // px
+    const headerWithProModeHeight = 106; // px
+    const headerHeight = 56; // px
+    const mapViewportWidth =
+      window.innerWidth -
+      (withLegend && !legendCollapsed ? sideBarWidth : 0) -
+      mapViewportFitPadding;
+    const mapViewportHeight =
+      window.innerHeight -
+      (setProMode || withHideLegendSwitch
+        ? headerWithProModeHeight
+        : headerHeight) -
+      mapViewportFitPadding;
+
+    const { center, zoom } = geoViewport.viewport(
+      bbox, // bounds
+      [mapViewportWidth, mapViewportHeight], // dimensions
+      11, // min zoom
+      16, // max zoom
+      512, // tile size for MVT
+      true // allow decimals in zoom
+    );
+
+    initialViewState.longitude = center[0] || mapSettings.defaultLongitude;
+    initialViewState.latitude = center[1] || mapSettings.defaultLatitude;
+    initialViewState.zoom = zoom;
   }
 
   return (

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -1,1 +1,2 @@
+declare module '@mapbox/geo-viewport';
 declare module 'vt-pbf';

--- a/yarn.lock
+++ b/yarn.lock
@@ -650,6 +650,13 @@
   resolved "https://registry.yarnpkg.com/@mapbox/extent/-/extent-0.4.0.tgz#3e591f32e1f0c3981c864239f7b0ac06e610f8a9"
   integrity sha512-MSoKw3qPceGuupn04sdaJrFeLKvcSETVLZCGS8JA9x6zXQL3FWiKaIXYIZEDXd5jpXpWlRxinCZIN49yRy0C9A==
 
+"@mapbox/geo-viewport@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/geo-viewport/-/geo-viewport-0.5.0.tgz#5e3b4ef19ed113169d168eec9c60840e430c52a6"
+  integrity sha512-h0b10JU+lSxw8/TLXGdzcVTPxMN9Ikv0os8sCo0OAHXUiSDkQs5fx4WWLJeQTnC++qaGFl6/Ssr+H5N6NIvE5g==
+  dependencies:
+    "@mapbox/sphericalmercator" "^1.2.0"
+
 "@mapbox/geojson-area@^0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz#18d7814aa36bf23fbbcc379f8e26a22927debf10"
@@ -717,6 +724,11 @@
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz#8a83f9335c7860effa2eeeca254332aa0aeed8f2"
   integrity sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==
+
+"@mapbox/sphericalmercator@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/sphericalmercator/-/sphericalmercator-1.2.0.tgz#55d4896be906bfff859e22a1d72267329a0fff90"
+  integrity sha512-ZTOuuwGuMOJN+HEmG/68bSEw15HHaMWmQ5gdTsWdWsjDe56K1kGvLOK6bOSC8gWgIvEO0w6un/2Gvv1q5hJSkQ==
 
 "@mapbox/tiny-sdf@^2.0.6":
   version "2.0.6"


### PR DESCRIPTION
- Feature demandée pour centrer la carte sur des villes avec une bbox calculée au préalable et passée en paramètre.
- Petite lib ajoutée pour s'occuper des calculs magiques pour en déduire le niveau de zoom et le centre de la carte selon les dimensions de la fenêtre et les coordonnées de la bbox.

Exemple avec un lien comme ceci (à adapter à l'environnement de preview) : https://france-chaleur-urbaine.beta.gouv.fr/carte?proMode=true&additionalLayers=enrrMobilisables,zonesOpportunite&bbox=7.13654739520414,43.693165306409476,7.1845181701831775,43.74226983240324