### PR TITLE
chore: ajoute sentry au cron pour voir les potentielles erreurs

### DIFF
--- a/sentry.node.config.ts
+++ b/sentry.node.config.ts
@@ -1,0 +1,14 @@
+// This file configures the initialization of Sentry for node
+// The config you add here will be used whenever you import this file
+
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+
+  // Adjust this value in production, or use tracesSampler for greater control
+  tracesSampleRate: 0.1,
+
+  // Setting this option to true will print useful information to the console while you're setting up Sentry.
+  debug: false,
+});

--- a/src/cron_jobs/launch.ts
+++ b/src/cron_jobs/launch.ts
@@ -1,9 +1,11 @@
+import * as Sentry from '@sentry/node';
 import {
   dailyNewManagerMail,
   dailyRelanceMail,
   weeklyOldManagerMail,
 } from 'src/services/manager';
 import { updateUsers } from 'src/services/users';
+import '../../sentry.node.config';
 
 export const jobs: Record<string, any> = {
   dailyNewManagerMail,
@@ -17,6 +19,7 @@ export const launchJob = async (job: string) => {
   try {
     await jobs[job]();
   } catch (e) {
+    Sentry.captureException(e);
     console.log(`CRON JOB ERROR: ${job}`, e);
   }
 };


### PR DESCRIPTION
Afin d'être notifié si un des cron part en erreur.

Pour tester

- configurer `NEXT_PUBLIC_SENTRY_DSN`
- récupérer la branche de test `sentry_on_cron_test`
-  Lancer `foreman start`
- Vérifier dans Sentry que l'erreur est bien la

Apres merge il faudra supprimer la branche `sentry_on_cron_test`
