### PR TITLE
fix: diminue la taille des icones info

### DIFF
--- a/src/components/Hoverable/HoverableIcon.tsx
+++ b/src/components/Hoverable/HoverableIcon.tsx
@@ -8,7 +8,7 @@ import Hoverable from '.';
 
 const HoverableIcon = ({
   children,
-  iconSize,
+  iconSize = 'sm',
   iconName,
   position,
   top,

--- a/src/components/Network/Network.tsx
+++ b/src/components/Network/Network.tsx
@@ -238,7 +238,7 @@ const NetworkPanel = ({
                   <span>
                     <h3>
                       Informations tarifaires
-                      <HoverableIcon iconSize="lg" iconName="ri-information-fill" position="top-centered">
+                      <HoverableIcon iconSize="md" iconName="ri-information-fill" position="top-centered">
                         La comparaison avec le prix des autres énergies n’est pertinente qu’en coût global annuel, en intégrant les coûts
                         d’exploitation, de maintenance et d’investissement, amortis sur la durée de vie des installations.
                       </HoverableIcon>

--- a/src/components/Statistics/Statistics.tsx
+++ b/src/components/Statistics/Statistics.tsx
@@ -293,7 +293,7 @@ const Statistics = () => {
                 <NumberBlock className="fr-col-md-6 fr-col-12">
                   <NumberHighlight>{statistics.connection}</NumberHighlight>
                   Raccordements à l'étude ou en cours
-                  <HoverableIcon iconName="ri-information-fill" position="bottom" iconSize="md">
+                  <HoverableIcon iconName="ri-information-fill" position="bottom">
                     Par raccordements à l’étude, on désigne ceux pour lesquels une étude de faisabilité technico-économique est en cours au
                     niveau du gestionnaire du réseau, ou a été transmise à la copropriété ou au bâtiment tertiaire. En copropriété, la
                     proposition du gestionnaire de réseau devra ensuite être votée en AG avant que les travaux ne puissent démarrer.
@@ -366,7 +366,7 @@ const Statistics = () => {
                   <NumberHighlight>
                     <span>{statistics.connectionPercent}%</span>
                     <NumberHoverableIcon>
-                      <HoverableIcon iconName="ri-information-fill" position="bottom" iconSize="md">
+                      <HoverableIcon iconName="ri-information-fill" position="bottom">
                         A savoir : une partie des demandes déposées (environ 50%) ne peut aboutir en raison d'une distance trop importante
                         au réseau ou d'un mode de chauffage préexistant individuel.
                       </HoverableIcon>
@@ -405,7 +405,7 @@ const Statistics = () => {
                   <NumberHighlight>
                     <span>{Math.round(percentAddressPossible)}%</span>
                     <NumberHoverableIcon>
-                      <HoverableIcon iconName="ri-information-fill" position="bottom" iconSize="md">
+                      <HoverableIcon iconName="ri-information-fill" position="bottom">
                         "Potentiellement raccordables" : tests effectués pour des bâtiments situés à moins de 100 m d'un réseau (60 m sur
                         Paris)
                       </HoverableIcon>


### PR DESCRIPTION
Suite à la migration de la lib DSFR, la PR corrige les icones pages Réseau et Statistiques pour qu'elles aient la même taille qu'en prod actuellement. (déjà ok dans le manager)