### PR TITLE
fix: évite le reset pagination manager à chaque modif d'une ligne

### DIFF
--- a/src/components/Manager/Comment.tsx
+++ b/src/components/Manager/Comment.tsx
@@ -37,12 +37,6 @@ const Comment = ({
     [debouncedUpdateDemand]
   );
 
-  useEffect(() => {
-    if (demand && value === '') {
-      setValue(demand[`Commentaire`]);
-    }
-  }, [demand, value]);
-
   return (
     <TextAreaInput
       label=""

--- a/src/components/Manager/Manager.tsx
+++ b/src/components/Manager/Manager.tsx
@@ -116,6 +116,10 @@ const Manager = () => {
         const existingDemand = demands.find((d) => d.id === demandId);
         if (existingDemand) {
           // on mute directement l'objet et on ne recrée pas un nouveau tableau demands pour ne pas réinitialiser la pagination de la datagrid
+          // les anciennes propriétés doivent être supprimées car l'API Airtable ne renvoie pas les propriétés vides
+          Object.keys(existingDemand).forEach((key) => {
+            delete existingDemand[key as keyof Demand];
+          });
           Object.assign(existingDemand, updatedDemand);
           setDemands(demands);
         }

--- a/src/components/Manager/Manager.tsx
+++ b/src/components/Manager/Manager.tsx
@@ -110,13 +110,15 @@ const Manager = () => {
   );
 
   const updateDemand = useCallback(
-    async (demandId: string, demand: Partial<Demand>) => {
-      const updatedDemand = await demandsService.update(demandId, demand);
+    async (demandId: string, demandUpdate: Partial<Demand>) => {
+      const updatedDemand = await demandsService.update(demandId, demandUpdate);
       if (updatedDemand) {
-        const index = demands.findIndex((d) => d.id === demandId);
-        const newDemands = [...demands];
-        newDemands.splice(index, 1, updatedDemand);
-        setDemands(newDemands);
+        const existingDemand = demands.find((d) => d.id === demandId);
+        if (existingDemand) {
+          // on mute directement l'objet et on ne recrée pas un nouveau tableau demands pour ne pas réinitialiser la pagination de la datagrid
+          Object.assign(existingDemand, updatedDemand);
+          setDemands(demands);
+        }
       }
     },
     [demands, demandsService]


### PR DESCRIPTION
Suite à #842, il ne faut pas recréer de nouveau tableau sinon la datagrid réinitialise se pagination. Donc on mute directement l'objet, sans le splice car datagrid freeze l'objet en dev...