### PR TITLE
Fix select comparateur

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@codegouvfr/react-dsfr": "^1.11.7",
-    "@betagouv/france-chaleur-urbaine-publicodes": "^0.14.0",
+    "@betagouv/france-chaleur-urbaine-publicodes": "^0.15.0",
     "@commander-js/extra-typings": "^11.1.0",
     "@emotion/react": "^11.11.4",
     "@emotion/server": "^11.11.0",

--- a/src/components/SimulatorPublicodes/TechnicienParametresTechniques.tsx
+++ b/src/components/SimulatorPublicodes/TechnicienParametresTechniques.tsx
@@ -23,8 +23,8 @@ const TechnicienBatimentForm: React.FC<TechnicienBatimentFormProps> = ({ childre
         <Input name="température de référence chaud" label="température de référence chaud" iconId="fr-icon-temp-cold-fill" />
         <Input name="augmenter la température de chauffe" label="augmenter la température de chauffe" iconId="fr-icon-temp-cold-fill" />
 
-        <Select name="zone climatique" label="Zone climatique" withDefaultOption={false} />
-        <Select name="sous zone climatique" label="Sous-zone climatique" withDefaultOption={false} />
+        <Select name="zone climatique" label="Zone climatique" />
+        <Select name="sous zone climatique" label="Sous-zone climatique" />
       </Accordion>
 
       <Accordion label="Choix du bâtiment">

--- a/src/components/SimulatorPublicodes/index.tsx
+++ b/src/components/SimulatorPublicodes/index.tsx
@@ -51,7 +51,7 @@ const addresseToPublicodesRules = {
   'caractéristique réseau de froid . production totale': (infos) => infos.nearestReseauDeFroid?.['production_totale_MWh'],
 
   'code département': (infos) => `'${infos.infosVille.departement_id}'`,
-  'température de référence chaud': (infos) => +infos.infosVille.temperature_ref_altitude_moyenne,
+  'température de référence chaud commune': (infos) => +infos.infosVille.temperature_ref_altitude_moyenne,
 } as const satisfies Partial<Record<DottedName, (infos: LocationInfoResponse) => any>>;
 
 const PublicodesSimulator: React.FC<PublicodesSimulatorProps> = ({

--- a/src/components/SimulatorPublicodes/index.tsx
+++ b/src/components/SimulatorPublicodes/index.tsx
@@ -52,8 +52,6 @@ const addresseToPublicodesRules = {
 
   'code département': (infos) => `'${infos.infosVille.departement_id}'`,
   'température de référence chaud': (infos) => +infos.infosVille.temperature_ref_altitude_moyenne,
-  'zone climatique': (infos) => `'${infos.infosVille.zone_climatique}'`,
-  'sous zone climatique': (infos) => `'${infos.infosVille.sous_zone_climatique}'`,
 } as const satisfies Partial<Record<DottedName, (infos: LocationInfoResponse) => any>>;
 
 const PublicodesSimulator: React.FC<PublicodesSimulatorProps> = ({

--- a/src/components/form/publicodes/Select.tsx
+++ b/src/components/form/publicodes/Select.tsx
@@ -3,9 +3,10 @@ import { Select as DSFRSelect } from '@codegouvfr/react-dsfr/SelectNext';
 import React from 'react';
 
 import useInViewport from '@hooks/useInViewport';
+import { isDefined } from '@utils/core';
 
 import { usePublicodesFormContext } from './FormProvider';
-import { fixupBooleanEngineValue, getOptions } from './helpers';
+import { fixupBooleanEngineValue, fixupSituationStringValue, getOptions } from './helpers';
 
 export type DSFRSelectProps = React.ComponentProps<typeof DSFRSelect> & {
   withDefaultOption?: boolean;
@@ -30,7 +31,9 @@ const Select = ({
   const options = isInView ? getOptions(engine, name) : [];
   const defaultValue = isInView ? fixupBooleanEngineValue(engine.getFieldDefaultValue(name) as string | null | undefined) : '';
   const value = isInView
-    ? `${(withDefaultOption ? engine.getSituation()[name] : fixupBooleanEngineValue(engine.getField(name))) ?? ''}`
+    ? `${
+        (withDefaultOption ? fixupSituationStringValue(engine.getSituation()[name]) : fixupBooleanEngineValue(engine.getField(name))) ?? ''
+      }`
     : '';
 
   return (
@@ -53,7 +56,7 @@ const Select = ({
         ...(withDefaultOption
           ? [
               {
-                label: `Par défaut (${defaultValue})`,
+                label: `Par défaut${isDefined(defaultValue) ? ` (${defaultValue})` : ''}`,
                 value: '',
               },
             ]

--- a/src/components/form/publicodes/helpers.ts
+++ b/src/components/form/publicodes/helpers.ts
@@ -13,7 +13,16 @@ export const getOptions = (engine: ReturnType<typeof usePublicodesFormContext>['
   return [];
 };
 
-// Convertit les booléen de nodeValue en oui ou non pour correspondre au formulaire.
+/**
+ * Convertit les booléen de nodeValue en oui ou non pour correspondre au formulaire.
+ */
 export const fixupBooleanEngineValue = (value: any): any => {
   return typeof value === 'boolean' ? (value ? 'oui' : 'non') : value;
+};
+
+/**
+ * Enlève les apostrophes des string constantes de la situation pour correspondre au formulaire.
+ */
+export const fixupSituationStringValue = (value: any): any => {
+  return typeof value === 'string' && value.at(0) === "'" && value.at(-1) === "'" ? value.substring(1, value.length - 1) : value;
 };

--- a/src/pages/api/location-infos.ts
+++ b/src/pages/api/location-infos.ts
@@ -54,8 +54,6 @@ export interface InfosVille {
   altitude_moyenne: number;
   temperature_ref_altitude_moyenne: string;
   source: string;
-  zone_climatique: string;
-  sous_zone_climatique: string;
 }
 
 export default handleRouteErrors(async (req: NextApiRequest) => {
@@ -103,16 +101,10 @@ export default handleRouteErrors(async (req: NextApiRequest) => {
       .orderByRaw(distanceSubQuery)
       .first(),
     db('communes')
-      .select(
-        'communes.departement_id as departement_id',
-        'communes.temperature_ref_altitude_moyenne as temperature_ref_altitude_moyenne',
-        'departements.zone_climatique as zone_climatique',
-        'departements.sous_zone_climatique as sous_zone_climatique'
-      )
-      .leftJoin('departements', 'communes.departement_id', '=', 'departements.id')
-      .where('communes.id', cityCode)
-      .orWhere('communes.commune', city.toUpperCase())
-      .orWhere('communes.commune', 'like', `${city.toUpperCase()}-%-ARRONDISSEMENT`)
+      .select('departement_id', 'temperature_ref_altitude_moyenne')
+      .where('id', cityCode)
+      .orWhere('commune', city.toUpperCase())
+      .orWhere('commune', 'like', `${city.toUpperCase()}-%-ARRONDISSEMENT`)
       .first(),
   ]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -371,10 +371,10 @@
     "@babel/helper-validator-identifier" "^7.24.7"
     to-fast-properties "^2.0.0"
 
-"@betagouv/france-chaleur-urbaine-publicodes@^0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@betagouv/france-chaleur-urbaine-publicodes/-/france-chaleur-urbaine-publicodes-0.14.0.tgz#ab1526e56a6ae8e1efe383afb7aba3735cb6775f"
-  integrity sha512-hrWOy/MR1DJcYdx4RCdXSBOTzLLoyF7pzdztnSMipZd7y4BRutJWu02uwQsWTcWCFAU10HF4wJfC0Xe7/VSFbA==
+"@betagouv/france-chaleur-urbaine-publicodes@^0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@betagouv/france-chaleur-urbaine-publicodes/-/france-chaleur-urbaine-publicodes-0.15.0.tgz#f028af0057958ec26b3aa13d5813e70013d2aa8e"
+  integrity sha512-sxWqYojVgl/97w4R1BZzIFmUNkWFFxC+Ks0aSkEytC3lmq0rxaeLu9IzJx8cdjEwf9CFrXEkeZZbcCvRATlerA==
 
 "@codegouvfr/react-dsfr@^1.11.7":
   version "1.11.7"


### PR DESCRIPTION
Voir les commits:
- corrige les select foireux
- maintenant le formulaire contient que des placeholders quand on choisit la ville.  C'est donc plus simple de revenir à la valeur par défaut