### PR TITLE
Forcage du type button pour le test d'adresse

### DIFF
--- a/src/components/HeadSliceForm/HeadSliceForm.tsx
+++ b/src/components/HeadSliceForm/HeadSliceForm.tsx
@@ -183,6 +183,7 @@ const HeadSlice = ({
 
             <Buttons>
               <Button
+                type="button"
                 size="large"
                 disabled={!address || !geoAddress || !heatingType || (loadingStatus === 'loading' && !eligibilityError)}
                 onClick={testAddress}
@@ -194,6 +195,7 @@ const HeadSlice = ({
                 <>
                   <Separator />
                   <Button
+                    type="button"
                     size="large"
                     priority="secondary"
                     onClick={() => {


### PR DESCRIPTION
Corrige un problème avec firefox 115esr qui valide le formulaire nativement sinon et se retrouve sur l'URL avec les paramètres du formulaire.