### PR TITLE
Essaie de réparer le domainTransform du RangeFilter

### DIFF
--- a/src/components/Map/components/RangeFilter.tsx
+++ b/src/components/Map/components/RangeFilter.tsx
@@ -1,10 +1,12 @@
 import { Range } from '@codegouvfr/react-dsfr/Range';
-import React, { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import React, { ReactNode, useEffect, useRef } from 'react';
 
 import Box from '@components/ui/Box';
 import Icon from '@components/ui/Icon';
 import { SimpleTooltip } from '@components/ui/Tooltip';
 import { Interval } from '@utils/interval';
+
+import { roundNumberProgressively } from './ReseauxDeChaleurFilters';
 
 interface RangeFilterProps {
   label: string;
@@ -17,95 +19,94 @@ interface RangeFilterProps {
     percentToValue: (value: number) => number;
     valueToPercent: (value: number) => number;
   };
-  nonLinear?: boolean;
+  formatNumber?: (value: number) => string;
 }
-
-type MinOrMax = 'min' | 'max';
 
 const RangeFilter = ({
   label,
   value: values,
-  domain: bounds,
+  domain,
   onChange,
   unit = '',
   tooltip,
-  domainTransform: valueTransform,
-  nonLinear,
+  domainTransform,
+  formatNumber = (v) => `${roundNumberProgressively(v)}`,
   ...props
 }: RangeFilterProps) => {
-  const valueToPercent = 100 / bounds[1];
-  const getNonLinearTransformValue = (value: number) => (valueTransform ? valueTransform.percentToValue(value * valueToPercent) : value);
-  const initNonLinearValue = (value: number) => (valueTransform ? valueTransform.valueToPercent(value) / valueToPercent : value);
+  const valueMin = domainTransform ? domainTransform.valueToPercent(values[0]) : values[0];
+  const valueMax = domainTransform ? domainTransform.valueToPercent(values[1]) : values[1];
 
-  const [valueMinRaw, setValueMinRaw] = useState<number>(nonLinear ? initNonLinearValue(values[0]) : values[0]);
-  const [valueMaxRaw, setValueMaxRaw] = useState<number>(nonLinear ? initNonLinearValue(values[1]) : values[1]);
-  const [valueMinTransform, setValueMinTransform] = useState<number>(values[0]);
-  const [valueMaxTransform, setValueMaxTransform] = useState<number>(values[1]);
-  const [min, max] = bounds;
+  const [min, max] = domainTransform ? [0, 100] : domain;
   const ref = useRef<HTMLDivElement>(null);
 
+  // hack : mise à jour manuelle de l'étiquette DSFR pour afficher l'invervalle transformé quand spécifié
+  // FIXME le DSFR peut à tout moment mettre à jour ça quand on fait une autre action et ce n'est plus à jour...
   useEffect(() => {
-    if (nonLinear) {
-      const textToUpdate = ref?.current?.querySelector('.fr-range__output');
-      if (textToUpdate) {
-        textToUpdate.textContent = valueMinTransform.toString() + unit + ' - ' + valueMaxTransform.toString() + unit;
-      }
+    if (domainTransform) {
+      updateRangeOutput(domain[0], domain[1]);
     }
   }, [ref]);
 
-  const onChangeValue = useCallback(
-    (rangeValue: number, minOrMax: MinOrMax) => {
-      const newValue: number = nonLinear ? getNonLinearTransformValue(rangeValue) : rangeValue;
-
-      if (nonLinear) {
-        const textToUpdate = ref?.current?.querySelector('.fr-range__output');
-        if (textToUpdate) {
-          const text: string =
-            minOrMax === 'min'
-              ? newValue.toString() + unit + ' - ' + valueMaxTransform.toString() + unit
-              : valueMinTransform.toString() + unit + ' - ' + newValue.toString() + unit;
-          textToUpdate.textContent = text;
-        }
-      }
-      if (minOrMax === 'min') {
-        setValueMinRaw(rangeValue);
-        setValueMinTransform(newValue);
-        onChange([newValue, valueMaxTransform]);
-      } else {
-        setValueMaxRaw(rangeValue);
-        setValueMaxTransform(newValue);
-        onChange([valueMinTransform, newValue]);
-      }
-    },
-    [ref, nonLinear, valueMaxTransform, valueMinTransform]
-  );
+  function updateRangeOutput(min: number, max: number) {
+    const textToUpdate = ref?.current?.querySelector('.fr-range__output');
+    if (textToUpdate) {
+      textToUpdate.textContent = `${formatNumber(min)}${unit} - ${formatNumber(max)}${unit}`;
+    }
+  }
 
   return (
-    <Range
-      label={
-        <Box display="flex" alignItems="center" justifyContent="space-between">
-          {label}
-          {tooltip && <SimpleTooltip icon={<Icon size="sm" name="ri-information-fill" cursor="help" />}>{tooltip}</SimpleTooltip>}
+    <>
+      <Range
+        label={
+          <Box display="flex" alignItems="center" justifyContent="space-between">
+            {label}
+            {tooltip && <SimpleTooltip icon={<Icon size="sm" name="ri-information-fill" cursor="help" />}>{tooltip}</SimpleTooltip>}
+          </Box>
+        }
+        ref={ref}
+        small
+        double
+        max={max}
+        min={min}
+        hideMinMax={!!domainTransform}
+        nativeInputProps={[
+          {
+            value: valueMin,
+            onChange: (e) => {
+              const value = +e.target.value;
+              const newValueMin = domainTransform ? domainTransform.percentToValue(value) : value;
+              onChange([newValueMin, values[1]]);
+              updateRangeOutput(newValueMin, values[1]);
+            },
+          },
+          {
+            value: valueMax,
+            onChange: (e) => {
+              const value = +e.target.value;
+              const newValueMax = domainTransform ? domainTransform.percentToValue(value) : value;
+              onChange([values[0], newValueMax]);
+              updateRangeOutput(values[0], newValueMax);
+            },
+          },
+        ]}
+        suffix={unit}
+        {...props}
+      />
+
+      {/* Si domainTransform spécifié, on doit gérer l'affichage des bornes nous-mêmes pour éviter d'avoir des pourcentages */}
+      {!!domainTransform && (
+        <Box display="flex" justifyContent="space-between">
+          <div className="fr-range__min">
+            {formatNumber(domain[0])}
+            {unit}
+          </div>
+          <div className="fr-range__max">
+            {formatNumber(domain[1])}
+            {unit}
+          </div>
         </Box>
-      }
-      ref={ref}
-      small
-      double
-      max={max}
-      min={min}
-      nativeInputProps={[
-        {
-          value: valueMinRaw,
-          onChange: (e) => onChangeValue(+e.target.value, 'min'),
-        },
-        {
-          value: valueMaxRaw,
-          onChange: (e) => onChangeValue(+e.target.value, 'max'),
-        },
-      ]}
-      suffix={unit}
-      {...props}
-    />
+      )}
+    </>
   );
 };
 

--- a/src/components/Map/components/ReseauxDeChaleurFilters.tsx
+++ b/src/components/Map/components/ReseauxDeChaleurFilters.tsx
@@ -86,7 +86,6 @@ function ReseauxDeChaleurFilters() {
           valueToPercent: (v) => roundNumberProgressively(getPercentageFromLivraisonsAnnuelles(v)),
         }}
         unit="GWh"
-        nonLinear
       />
       <Divider />
       <RangeFilter


### PR DESCRIPTION
- Simplification de la logique avec l'état interne qui n'est pas forcément nécessaire, suite à la migration DSFR.
- Cas particulier pour gérer le RangeFilter quand on lui passe un domainTransform (notamment quand le filtre n'est pas linéaire comme les livraisons annuelles de chaleur).
- [ ] Il reste toujours la mise à jour externe qui ne fonctionne pas.
- [ ] La mise à jour de l'élément output ne fonctionne pas complètement si on fait une autre action à côté, par exemple déplier un accordéon, qui fait que la lib dsfr (native) va maj tous ses composants et donc écraser notre valeur.

A discuter si j'ai loupé un truc et voir ce qu'on fait avec ce composant Range...