### PR TITLE
Supprime du code lié à l'ancien mode pro de la carte

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -96,7 +96,6 @@ type MapProps = {
   initialMapConfiguration?: MapConfiguration;
   enabledLegendFeatures?: MapLegendFeature[];
   withLegend?: boolean;
-  withHideLegendSwitch?: boolean;
   withBorder?: boolean;
   legendTitle?: string;
   legendLogoOpt?: TypeLegendLogo;
@@ -123,7 +122,6 @@ const Map = ({ initialMapConfiguration, ...props }: MapProps) => {
 const InternalMap = ({
   withoutLogo,
   withLegend,
-  withHideLegendSwitch,
   withBorder,
   legendTitle,
   enabledLegendFeatures,
@@ -555,10 +553,9 @@ const InternalMap = ({
     const bbox = (router.query.bbox as string).split(',').map((n) => Number.parseFloat(n)) as [number, number, number, number];
 
     const mapViewportFitPadding = 50; // px
-    const headerWithProModeHeight = 106; // px
     const headerHeight = 56; // px
     const mapViewportWidth = window.innerWidth - (withLegend && !legendCollapsed ? legendWidth : 0) - mapViewportFitPadding;
-    const mapViewportHeight = window.innerHeight - (withHideLegendSwitch ? headerWithProModeHeight : headerHeight) - mapViewportFitPadding;
+    const mapViewportHeight = window.innerHeight - headerHeight - mapViewportFitPadding;
 
     const { center, zoom } = geoViewport.viewport(
       bbox, // bounds
@@ -582,13 +579,7 @@ const InternalMap = ({
 
   return (
     <>
-      <MapStyle
-        legendCollapsed={!withLegend || legendCollapsed}
-        isDrawing={isDrawing}
-        withTopLegend={withHideLegendSwitch}
-        withHideLegendSwitch={withHideLegendSwitch}
-        withBorder={withBorder}
-      />
+      <MapStyle legendCollapsed={!withLegend || legendCollapsed} isDrawing={isDrawing} withBorder={withBorder} />
       <div className="map-wrap">
         {withLegend && (
           <>

--- a/src/pages/carte-collectivite.tsx
+++ b/src/pages/carte-collectivite.tsx
@@ -15,7 +15,6 @@ const CollectivityMap = () => {
         enabledLegendFeatures={['reseauxDeChaleur', 'zonesDeDeveloppementPrioritaire']}
         withLegend
         withBorder
-        withHideLegendSwitch
         legendTitle="Réseaux de chaleur"
         withFCUAttribution
       />

--- a/src/pages/charleville-mezieres.tsx
+++ b/src/pages/charleville-mezieres.tsx
@@ -15,7 +15,6 @@ const CharlevilleMezieresMap = () => {
         enabledLegendFeatures={['reseauxDeChaleur', 'reseauxEnConstruction']}
         withLegend
         withBorder
-        withHideLegendSwitch
         initialCenter={[4.717692, 49.767402]}
         initialZoom={12}
         legendTitle="Réseaux de chaleur"

--- a/src/pages/dalkia.tsx
+++ b/src/pages/dalkia.tsx
@@ -16,7 +16,6 @@ const DalkiaMap = () => {
         enabledLegendFeatures={['reseauxDeChaleur', 'reseauxDeFroid', 'reseauxEnConstruction', 'zonesDeDeveloppementPrioritaire']}
         withLegend
         withBorder
-        withHideLegendSwitch
         legendLogoOpt={{
           src: '/logo-DALKIA.png',
           alt: 'logo Dalkia',

--- a/src/pages/engie.tsx
+++ b/src/pages/engie.tsx
@@ -16,7 +16,6 @@ const EngieMap = () => {
         enabledLegendFeatures={['reseauxDeChaleur', 'reseauxDeFroid', 'reseauxEnConstruction', 'zonesDeDeveloppementPrioritaire']}
         withLegend
         withBorder
-        withHideLegendSwitch
         legendLogoOpt={{
           src: '/logo-ENGIE.jpg',
           alt: 'logo ENGIE',

--- a/src/pages/idex.tsx
+++ b/src/pages/idex.tsx
@@ -16,7 +16,6 @@ const IdexMap = () => {
         enabledLegendFeatures={['reseauxDeChaleur', 'reseauxDeFroid', 'reseauxEnConstruction', 'zonesDeDeveloppementPrioritaire']}
         withLegend
         withBorder
-        withHideLegendSwitch
         legendLogoOpt={{
           src: '/logo-IDEX.jpg',
           alt: 'logo Idex',

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -63,7 +63,6 @@ const MapPage = () => {
     <IframeWrapper>
       <Map
         withLegend={legend === 'true'}
-        withHideLegendSwitch={legend === 'true'}
         withBorder
         enabledLegendFeatures={legendFeatures}
         initialMapConfiguration={initialMapConfiguration}

--- a/src/pages/viaseva.tsx
+++ b/src/pages/viaseva.tsx
@@ -11,7 +11,6 @@ const ViasevaMap = () => {
         enabledLegendFeatures={['reseauxDeChaleur', 'reseauxDeFroid', 'reseauxEnConstruction', 'zonesDeDeveloppementPrioritaire']}
         withLegend
         withBorder
-        withHideLegendSwitch
         legendLogoOpt={{
           src: '/logo-viaseva.svg',
           alt: 'logo viaseva',

--- a/src/services/Map/map-configuration.ts
+++ b/src/services/Map/map-configuration.ts
@@ -47,7 +47,6 @@ export type FiltreEnergieConfKey = (typeof filtresEnergies)[number]['confKey'];
 type EnergieRatioConfKey = `energie_ratio_${FiltreEnergieConfKey}`;
 
 export type MapConfiguration = {
-  proMode: boolean;
   filtreIdentifiantReseau: string[];
   filtreGestionnaire: string[];
   reseauxDeChaleur: {
@@ -140,7 +139,6 @@ export const defaultInterval: Interval = [Number.MIN_SAFE_INTEGER, Number.MAX_SA
 export const communesFortPotentielPourCreationReseauxChaleurInterval: Interval = [0, 100_000];
 
 const emptyMapConfiguration: EmptyMapConfiguration = {
-  proMode: false,
   filtreIdentifiantReseau: [],
   filtreGestionnaire: [],
   reseauxDeChaleur: {
@@ -213,20 +211,10 @@ const emptyMapConfiguration: EmptyMapConfiguration = {
 };
 
 export const defaultMapConfiguration = createMapConfiguration({
-  proMode: true,
   reseauxDeChaleur: {
     show: true,
   },
   reseauxEnConstruction: true,
-  consommationsGaz: {
-    show: false,
-  },
-  batimentsGazCollectif: {
-    show: false,
-  },
-  batimentsFioulCollectif: {
-    show: false,
-  },
 });
 
 export const iframeSimpleMapConfiguration = createMapConfiguration({


### PR DESCRIPTION
Plus besoin de proMode dans la MapConfiguration et de withHideLegendSwitch dans Map car plus de bande blanche en haut.