### PR TITLE
Autorise la désactivation de la géolocalisation

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -637,7 +637,8 @@ const InternalMap = ({
             onSourceData={onMapSourceData}
             ref={mapRef}
           >
-            {!geolocDisabled && <GeolocateControl fitBoundsOptions={{ maxZoom: 13 }} />}
+            {/* trackUserLocation allows the user to disable the geolocation marker */}
+            {!geolocDisabled && <GeolocateControl fitBoundsOptions={{ maxZoom: 13 }} trackUserLocation />}
             <AttributionControl
               compact={false}
               position="bottom-right"


### PR DESCRIPTION
Par défaut, quand on active la géolocalisation via le bouton en haut à droite de la carte, un rond s'affiche et on ne peut plus le supprimer.

Avec cette PR, il devient un toggle et on peut donc le retirer de l'affichage.