### PR TITLE
Test d'adresse uniquement sur la fiche réseau, pas de villes

### DIFF
--- a/src/components/Network/EligibilityTestBox.tsx
+++ b/src/components/Network/EligibilityTestBox.tsx
@@ -133,7 +133,7 @@ const EligibilityTestBox = ({ networkId }: EligibilityTestBoxProps) => {
           Testez l'éligibilité d'une adresse pour ce réseau.
         </Text>
 
-        <AddressAutocomplete placeholder="Tapez ici votre adresse" onAddressSelected={onAddressSelected} />
+        <AddressAutocomplete placeholder="Tapez ici votre adresse" onAddressSelected={onAddressSelected} excludeCities />
 
         <Box display="flex" alignItems="center" justifyContent="end">
           {formState === 'eligibilitySubmissionError' && (

--- a/src/components/addressAutocomplete/AddressAutocomplete.tsx
+++ b/src/components/addressAutocomplete/AddressAutocomplete.tsx
@@ -24,6 +24,7 @@ type AddressProps = {
   popoverClassName?: string;
   onAddressSelected: (address: string, geoAddress?: SuggestionItem) => any;
   onChange?: (e: string) => void;
+  excludeCities?: boolean;
 };
 
 const findAddressInSuggestions = (address: string, suggestions: SuggestionItem[]): SuggestionItem | undefined => {
@@ -41,6 +42,7 @@ const AddressAutocomplete = ({
   centred,
   onAddressSelected,
   onChange,
+  excludeCities = false,
 }: AddressProps) => {
   const router = useRouter();
   const [address, setAddress] = useState('');
@@ -50,6 +52,7 @@ const AddressAutocomplete = ({
     debounceTime,
     limit: 5,
     minCharactersLength,
+    excludeCities,
   });
 
   const handleSelect = useCallback(

--- a/src/components/addressAutocomplete/useSuggestions.tsx
+++ b/src/components/addressAutocomplete/useSuggestions.tsx
@@ -12,14 +12,15 @@ enum Status {
   Error = 'error',
 }
 type ValueOf<Obj> = Obj[keyof Obj];
-type configProps = {
+type UseSuggestionsProps = {
   limit?: number;
   autocomplete?: boolean;
   debounceTime?: number;
   minCharactersLength?: number;
+  excludeCities?: boolean;
 };
 
-const useSuggestions = ({ limit = 5, debounceTime = 300, minCharactersLength = 3 }: configProps) => {
+const useSuggestions = ({ limit = 5, debounceTime = 300, minCharactersLength = 3, excludeCities }: UseSuggestionsProps) => {
   const [suggestions, setSuggestions] = useState<SuggestionItem[]>([]);
   const [status, setStatus] = useState<ValueOf<Status>>(Status.Idle);
   const isMounted = useIsMounted();
@@ -36,7 +37,10 @@ const useSuggestions = ({ limit = 5, debounceTime = 300, minCharactersLength = 3
         limit: limit.toString(),
       });
 
-      setSuggestions(fetchedSuggestions.features);
+      const features = excludeCities
+        ? fetchedSuggestions.features.filter((feature) => feature.properties.type !== 'municipality')
+        : fetchedSuggestions.features;
+      setSuggestions(features);
       setStatus(Status.Success);
     } catch (e) {
       setStatus(Status.Error);

--- a/src/types/Suggestions.d.ts
+++ b/src/types/Suggestions.d.ts
@@ -21,7 +21,7 @@ export interface SuggestionItem {
     score: number;
     housenumber: string;
     id: string;
-    type: string;
+    type: 'housenumber' | 'street' | 'locality' | 'municipality';
     name: string;
     postcode: string;
     citycode: string;


### PR DESCRIPTION
Par défaut le comportement de test d'adresse fonctionne comme ceci :
- On a une adresse globalement précise =>  l'utilisateur a la possibilité de laisser une demande
- On a une ville uniquement => on teste si la ville a un réseau de chaleur ou pas et on invite l'utilisateur à renseigner une adresse plus précise

Sur la fiche réseau, c'est une version différente (simplifiée) du test d'adresse (un peu différent aussi car on teste l'éligibilité avec un réseau en particulier), et on ne gérait pas le cas de test de ville.

~Maintenant, le champ de recherche d'adresse ne retourne que des adresses précises. Je n'ai pas trouvé le moyen de juste exclure les villes...~

~Potentiellement il faudrait peut-être récupérer ces résultats classiquement, mais filtrer côté UI pour supprimer les suggestions de villes. :shrug: 
Je vais voir avec Florence pour valider ce point là.~

=> filtrage côté UI pour éliminer les résultats de type ville