### PR TITLE
Densité thermique linéaire sur besoins en chaleur des batiments

### DIFF
--- a/src/components/Map/components/tools/LinearHeatDensityTool.tsx
+++ b/src/components/Map/components/tools/LinearHeatDensityTool.tsx
@@ -1,6 +1,5 @@
 import Button from '@codegouvfr/react-dsfr/Button';
 import { DrawCreateEvent } from '@mapbox/mapbox-gl-draw';
-import { Tooltip } from '@mui/material';
 import { useKeyboardEvent } from '@react-hookz/web';
 import center from '@turf/center';
 import { lineString, points } from '@turf/helpers';
@@ -14,8 +13,8 @@ import { MapSourceLayersSpecification } from '@components/Map/map-layers';
 import useFCUMap from '@components/Map/MapProvider';
 import Box from '@components/ui/Box';
 import Divider from '@components/ui/Divider';
-import Icon from '@components/ui/Icon';
 import Text from '@components/ui/Text';
+import Tooltip from '@components/ui/Tooltip';
 import { PointDeConsommation } from '@pages/api/linear-heat-density';
 import { downloadObject } from '@utils/browser';
 import { formatAsISODate } from '@utils/date';
@@ -282,9 +281,10 @@ const LinearHeatDensityTool: React.FC = () => {
               <Tooltip
                 title="Densité thermique calculée sur la base des consommations de gaz à l'adresse situées à une distance de 10 ou 50 m du tracé
                   défini"
-              >
-                <Icon size="sm" name="ri-information-fill" ml="1w" />
-              </Tooltip>
+                iconProps={{
+                  className: 'fr-ml-1w',
+                }}
+              />
             </Text>
             <Box display="flex" justifyContent="space-between" pl="2w">
               <Box>À 10 mètres</Box>
@@ -308,11 +308,12 @@ const LinearHeatDensityTool: React.FC = () => {
             <Text>
               Densité thermique linéaire
               <Tooltip
-                title="Densité thermique calculée sur la base des consommations de gaz à l'adresse situées à une distance de 10 ou 50 m du tracé
+                title="Densité thermique calculée sur la base des besoins en chaleur des bâtiments situés à une distance de 10 ou 50 m du tracé
                   défini"
-              >
-                <Icon size="sm" name="ri-information-fill" ml="1w" />
-              </Tooltip>
+                iconProps={{
+                  className: 'fr-ml-1w',
+                }}
+              />
             </Text>
             <Box display="flex" justifyContent="space-between" pl="2w">
               <Box>À 10 mètres</Box>

--- a/src/components/Map/components/tools/LinearHeatDensityTool.tsx
+++ b/src/components/Map/components/tools/LinearHeatDensityTool.tsx
@@ -295,7 +295,7 @@ const LinearHeatDensityTool: React.FC = () => {
               <strong>{densite.consommationGaz.densitéThermiqueLinéaire['50m']}</strong>
             </Box>
 
-            <Text fontWeight="bold">Sur la base des besoins en chaleur (modélisés)&nbsp;:</Text>
+            <Text fontWeight="bold">Sur la base des besoins en chaleur (modélisés par le Cerema)&nbsp;:</Text>
             <Text>Besoins en chaleur</Text>
             <Box display="flex" justifyContent="space-between" pl="2w">
               <Box>À 10 mètres</Box>

--- a/src/components/Map/components/tools/LinearHeatDensityTool.tsx
+++ b/src/components/Map/components/tools/LinearHeatDensityTool.tsx
@@ -305,7 +305,15 @@ const LinearHeatDensityTool: React.FC = () => {
               <Box>À 50 mètres</Box>
               <strong>{densite.besoinsEnChaleur.cumul['50m']}</strong>
             </Box>
-            <Text>Densité thermique linéaire</Text>
+            <Text>
+              Densité thermique linéaire
+              <Tooltip
+                title="Densité thermique calculée sur la base des consommations de gaz à l'adresse situées à une distance de 10 ou 50 m du tracé
+                  défini"
+              >
+                <Icon size="sm" name="ri-information-fill" ml="1w" />
+              </Tooltip>
+            </Text>
             <Box display="flex" justifyContent="space-between" pl="2w">
               <Box>À 10 mètres</Box>
               <strong>{densite.besoinsEnChaleur.densitéThermiqueLinéaire['10m']}</strong>

--- a/src/components/Map/components/tools/LinearHeatDensityTool.tsx
+++ b/src/components/Map/components/tools/LinearHeatDensityTool.tsx
@@ -16,7 +16,7 @@ import Box from '@components/ui/Box';
 import Divider from '@components/ui/Divider';
 import Icon from '@components/ui/Icon';
 import Text from '@components/ui/Text';
-import { ConsommationGaz } from '@pages/api/linear-heat-density';
+import { PointDeConsommation } from '@pages/api/linear-heat-density';
 import { downloadObject } from '@utils/browser';
 import { formatAsISODate } from '@utils/date';
 import { formatDistance } from '@utils/geo';
@@ -29,9 +29,7 @@ export const linearHeatDensityLinesSourceId = 'linear-heat-density-lines';
 export const linearHeatDensityLabelsSourceId = 'linear-heat-density-labels';
 const defaultColor = '#000091';
 
-// FIXME déplacer ailleurs que dans le front peut-être
-// on peut garder le détail des conso pour pouvoir en supprimer certaines via la carte
-export type LinearHeatDensity = {
+type LinearHeatDensity = {
   longueurTotale: number;
   consommationGaz: {
     cumul: {
@@ -43,7 +41,6 @@ export type LinearHeatDensity = {
       '50m': string;
     };
   };
-  // TODO à venir avec la nouvelle couche
   besoinsEnChaleur: {
     cumul: {
       '10m': string;
@@ -267,7 +264,6 @@ const LinearHeatDensityTool: React.FC = () => {
         {densite && (
           <Box fontSize="14px" display="flex" flexDirection="column" gap="12px">
             <Box display="flex" justifyContent="space-between">
-              {/* FIXME faire valider le changement de nom distance => longueur */}
               <Box>Longueur totale</Box>
               <strong>{formatDistance(densite.longueurTotale)}</strong>
             </Box>
@@ -355,7 +351,7 @@ const LinearHeatDensityTool: React.FC = () => {
 
 export default LinearHeatDensityTool;
 
-const getConso = (consos: ConsommationGaz[]) => {
+const getConso = (consos: PointDeConsommation[]) => {
   const sum = consos.reduce((acc, current) => acc + current.conso_nb, 0);
   if (sum > 1000) {
     return `${(sum / 1000).toFixed(2)} GWh`;
@@ -364,7 +360,7 @@ const getConso = (consos: ConsommationGaz[]) => {
   return `${sum.toFixed(2)} MWh`;
 };
 
-const getDensite = (size: number, densite: ConsommationGaz[]) => {
+const getDensite = (size: number, densite: PointDeConsommation[]) => {
   if (densite.length === 0) {
     return '0 MWh/m';
   }

--- a/src/components/Map/components/tools/LinearHeatDensityTool.tsx
+++ b/src/components/Map/components/tools/LinearHeatDensityTool.tsx
@@ -271,7 +271,7 @@ const LinearHeatDensityTool: React.FC = () => {
               <Box>Longueur totale</Box>
               <strong>{formatDistance(densite.longueurTotale)}</strong>
             </Box>
-            <Text fontWeight="bold">Sur la base des consommations de gaz :</Text>
+            <Text fontWeight="bold">Sur la base des consommations de gaz&nbsp;:</Text>
             <Text>Consommation de gaz</Text>
             <Box display="flex" justifyContent="space-between" pl="2w">
               <Box>À 10 mètres</Box>
@@ -299,7 +299,7 @@ const LinearHeatDensityTool: React.FC = () => {
               <strong>{densite.consommationGaz.densitéThermiqueLinéaire['50m']}</strong>
             </Box>
 
-            <Text fontWeight="bold">Sur la base des besoins en chaleur (modélisés) :</Text>
+            <Text fontWeight="bold">Sur la base des besoins en chaleur (modélisés)&nbsp;:</Text>
             <Text>Besoins en chaleur</Text>
             <Box display="flex" justifyContent="space-between" pl="2w">
               <Box>À 10 mètres</Box>

--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -28,6 +28,7 @@ export type IconProps = StyledIconProps & {
   size?: 'xs' | 'sm' | 'md' | 'lg';
   // remix icons size
   riSize?: 'xs' | 'sm' | 'lg' | 'xl' | 'xxs' | '1x' | '2x' | '3x' | '4x' | '5x' | '6x' | '7x' | '8x' | '9x' | '10x';
+  className?: string;
 };
 
 /**

--- a/src/db/migrations/20241023000001_add_index_geom_donnees_de_conso.ts
+++ b/src/db/migrations/20241023000001_add_index_geom_donnees_de_conso.ts
@@ -1,0 +1,7 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`CREATE INDEX IF NOT EXISTS donnees_de_consos_geom_idx ON public.donnees_de_consos USING gist(geom)`);
+}
+
+export async function down(knex: Knex): Promise<void> {} // eslint-disable-line

--- a/src/pages/api/linear-heat-density.ts
+++ b/src/pages/api/linear-heat-density.ts
@@ -1,0 +1,69 @@
+import { multiLineString } from '@turf/helpers';
+import turfLength from '@turf/length';
+import { NextApiRequest } from 'next';
+import { z } from 'zod';
+
+import { handleRouteErrors, requireGetMethod, validateObjectSchema } from '@helpers/server';
+import db from 'src/db';
+
+export type ConsommationGaz = {
+  conso_nb: number;
+};
+
+export type RawLinearHeatDensity = {
+  longueurTotale: number;
+  consommationGaz: {
+    '10m': ConsommationGaz[];
+    '50m': ConsommationGaz[];
+  };
+  besoinsEnChaleur: {
+    '10m': ConsommationGaz[];
+    '50m': ConsommationGaz[];
+  };
+};
+
+const getConsoCloseLineQuery = (linesCoords: number[][][], distance: number) => `
+  ST_DWithin(
+    geom,
+    ST_Transform(
+      ST_GeomFromText(
+        'MULTILINESTRING(
+            ${linesCoords.map((lineCoords) => `(${lineCoords.map((coords) => `${coords[0]} ${coords[1]}`).join(', ')})`).join(',')}
+        )',
+        4326
+      ),
+      2154
+    ),
+    ${distance}
+  )
+`;
+
+export default handleRouteErrors(async (req: NextApiRequest) => {
+  requireGetMethod(req);
+  const { coordinates } = await validateObjectSchema(req.query, {
+    coordinates: z.preprocess((v) => JSON.parse(decodeURIComponent(v as string)), z.array(z.array(z.array(z.number())))),
+  });
+
+  const [consommationGazA10m, consommationGazA50m, besoinsEnChaleurA10m, besoinsEnChaleurA50m] = await Promise.all([
+    db('donnees_de_consos')
+      .select('conso_nb')
+      .where(db.raw(getConsoCloseLineQuery(coordinates, 10))),
+    db('donnees_de_consos')
+      .select('conso_nb')
+      .where(db.raw(getConsoCloseLineQuery(coordinates, 50))),
+    db('besoins_en_chaleur_batiments')
+      .select(db.raw('chauf_mwh::integer as conso_nb'))
+      .where(db.raw(getConsoCloseLineQuery(coordinates, 10))),
+    db('besoins_en_chaleur_batiments')
+      .select(db.raw('chauf_mwh::integer as conso_nb'))
+      .where(db.raw(getConsoCloseLineQuery(coordinates, 50))),
+  ]);
+  return {
+    longueurTotale: turfLength(multiLineString(coordinates)),
+    consommationGaz: {
+      '10m': consommationGazA10m,
+      '50m': consommationGazA50m,
+    },
+    besoinsEnChaleur: { '10m': besoinsEnChaleurA10m, '50m': besoinsEnChaleurA50m },
+  } satisfies RawLinearHeatDensity;
+});

--- a/src/pages/api/linear-heat-density.ts
+++ b/src/pages/api/linear-heat-density.ts
@@ -6,23 +6,25 @@ import { z } from 'zod';
 import { handleRouteErrors, requireGetMethod, validateObjectSchema } from '@helpers/server';
 import db from 'src/db';
 
-export type ConsommationGaz = {
+export type PointDeConsommation = {
   conso_nb: number;
 };
 
+// On garde le détail des consos dans le tableau, car on devrait prochainement retourner des infos sur le bâtiments en plus
+// pour mettre à jour les consos ou les exclure du calcul.
 export type RawLinearHeatDensity = {
   longueurTotale: number;
   consommationGaz: {
-    '10m': ConsommationGaz[];
-    '50m': ConsommationGaz[];
+    '10m': PointDeConsommation[];
+    '50m': PointDeConsommation[];
   };
   besoinsEnChaleur: {
-    '10m': ConsommationGaz[];
-    '50m': ConsommationGaz[];
+    '10m': PointDeConsommation[];
+    '50m': PointDeConsommation[];
   };
 };
 
-const getConsoCloseLineQuery = (linesCoords: number[][][], distance: number) => `
+const buildNearbyGeometriesFilter = (linesCoords: number[][][], distance: number) => `
   ST_DWithin(
     geom,
     ST_Transform(
@@ -47,16 +49,16 @@ export default handleRouteErrors(async (req: NextApiRequest) => {
   const [consommationGazA10m, consommationGazA50m, besoinsEnChaleurA10m, besoinsEnChaleurA50m] = await Promise.all([
     db('donnees_de_consos')
       .select('conso_nb')
-      .where(db.raw(getConsoCloseLineQuery(coordinates, 10))),
+      .where(db.raw(buildNearbyGeometriesFilter(coordinates, 10))),
     db('donnees_de_consos')
       .select('conso_nb')
-      .where(db.raw(getConsoCloseLineQuery(coordinates, 50))),
+      .where(db.raw(buildNearbyGeometriesFilter(coordinates, 50))),
     db('besoins_en_chaleur_batiments')
       .select(db.raw('chauf_mwh::integer as conso_nb'))
-      .where(db.raw(getConsoCloseLineQuery(coordinates, 10))),
+      .where(db.raw(buildNearbyGeometriesFilter(coordinates, 10))),
     db('besoins_en_chaleur_batiments')
       .select(db.raw('chauf_mwh::integer as conso_nb'))
-      .where(db.raw(getConsoCloseLineQuery(coordinates, 50))),
+      .where(db.raw(buildNearbyGeometriesFilter(coordinates, 50))),
   ]);
   return {
     longueurTotale: turfLength(multiLineString(coordinates)),

--- a/src/services/heatNetwork.ts
+++ b/src/services/heatNetwork.ts
@@ -1,12 +1,12 @@
 import { AxiosResponse } from 'axios';
 
 import { NetworkEligibilityStatus } from '@core/infrastructure/repository/addresseInformation';
+import { RawLinearHeatDensity } from '@pages/api/linear-heat-density';
 import { HttpClient } from 'src/services/http';
 import { EXPORT_FORMAT } from 'src/types/enum/ExportFormat';
 import { HeatNetworksResponse } from 'src/types/HeatNetworksResponse';
 import { SuggestionItem } from 'src/types/Suggestions';
 import { Summary } from 'src/types/Summary';
-import { Densite } from 'src/types/Summary/Densite';
 import { Network } from 'src/types/Summary/Network';
 
 import { ServiceError } from './errors';
@@ -82,9 +82,11 @@ export class HeatNetworkService {
     return this.httpClient.post(`/api/map/bulkEligibilityStatus/${id}`).then((response) => response.data);
   }
 
-  async densite(line: number[][][]): Promise<Densite> {
+  async getLinearHeatDensity(line: number[][][]): Promise<RawLinearHeatDensity> {
     try {
-      return await this.httpClient.get<Densite>(`/api/map/summary?type=line&coordinates=${encodeURIComponent(JSON.stringify(line))}`);
+      return await this.httpClient.get<RawLinearHeatDensity>(
+        `/api/linear-heat-density?coordinates=${encodeURIComponent(JSON.stringify(line))}`
+      );
     } catch (e) {
       throw new ServiceError(e);
     }


### PR DESCRIPTION
- Ajout de cette section à l'interface
![image](https://github.com/user-attachments/assets/4488112f-6512-47bb-bf10-8562d76e77ea)

- J'en ai profité pour refacto la requête pour récupérer les consommation. J'ai ajouté un index via migration sur la table donnees_de_consos qui divise par + que 100 le temps de requête (100ms => 0.1ms).
- Nouvelle route /api/linear-heat-density plutôt que la route legacy /api/map/summary?type=line qui mix un peu trop de choses. Elle reste pour pas casser la prod pour les utilisateurs sur la carte, mais on pourra retirer la partie line plus tard.

- Les données sont dans la nouvelle table `besoins_en_chaleur_batiments` (+ 9Go). Pour l'assembler => [Notion](https://www.notion.so/D-veloppement-e8399345919442748735de25865ebe4a?pvs=4#129c2b5c414b80e8a296fadbb0fe7e26). Dans le futur on devrait avoir la possibilité de sélectionner les bâtiments pour surcharger / omettre certaines consommations donc j'ai laissé tous les champs + géométries des bâtiments, d'où la taille importante de cette table. Au final, on ne sait pas encore exactement à quoi ressemblera la feature, mais bon...

- J'ai déjà copié cette base en dev et prod grâce à `./scripts/copyLocalTableToRemote.sh`.

- Côté BDD scalingo dev, on est à 73Go / 80, donc il faudra bientôt penser à upgrade le plan. :upside_down_face:  :moneybag: 
