### PR TITLE
Tracking du simulateur de coût de raccordement

### DIFF
--- a/src/components/Ressources/Contents/SimulateurCoutRaccordement.tsx
+++ b/src/components/Ressources/Contents/SimulateurCoutRaccordement.tsx
@@ -9,6 +9,7 @@ import Icon from '@components/ui/Icon';
 import Link from '@components/ui/Link';
 import Text from '@components/ui/Text';
 import { isDefined } from '@utils/core';
+import { trackEvent } from 'src/services/analytics';
 
 import { prixSpotCEE } from './Simulator';
 
@@ -33,8 +34,13 @@ const SimulateurCoutRaccordement = (props: SimulateurCoutRaccordementProps) => {
   const [formState, setFormState] = useState<FormState>({
     typeBatiment: props.typeBatiment ?? 'residentiel',
   });
+  const [hasUsedFeature, setHasUsedFeature] = useState(false);
 
   function updateState<Key extends keyof FormState>(key: Key, value: FormState[Key]) {
+    if (!hasUsedFeature) {
+      trackEvent('Outils|Simulation coût raccordement');
+    }
+    setHasUsedFeature(true);
     setFormState((state) => ({
       ...state,
       [key]: value,

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -591,6 +591,9 @@ const trackingEvents = {
   'Téléchargement|Schéma directeur': {
     matomo: ['Téléchargement', 'Schéma directeur'],
   },
+  'Outils|Simulation coût raccordement': {
+    matomo: ['Outils', 'Simulation coût raccordement'],
+  },
   Vidéo: {
     matomo: ['Vidéo'],
   },


### PR DESCRIPTION
Bon d'après ce que j'ai compris, on ne tracke qu'un seul événement par usage / visite de page. Donc j'envoie un événement dès qu'on touche au formulaire.

Aussi, c'est pas spécifié s'il faut tracker pour chaque page où ce simulateur apparait, donc tant pis. :)