### PR TITLE
Amélioration affichage lien site gestionnaire

### DIFF
--- a/src/components/Network/Network.tsx
+++ b/src/components/Network/Network.tsx
@@ -3,7 +3,7 @@ import { ReactElement } from 'react';
 
 import Map from '@components/Map/Map';
 import Accordion from '@components/ui/Accordion';
-import Box from '@components/ui/Box';
+import Box, { BoxProps } from '@components/ui/Box';
 import Heading from '@components/ui/Heading';
 import Icon from '@components/ui/Icon';
 import Link from '@components/ui/Link';
@@ -461,6 +461,12 @@ const NetworkPanel = ({
                       {url}
                     </Link>
                   )}
+                  valueRenderer={(v) => (
+                    <Box textAlign="right" overflow="hidden">
+                      {v}
+                    </Box>
+                  )}
+                  flexWrap="wrap"
                 />
               </BoxSection>
             )}
@@ -575,7 +581,7 @@ const NetworkPanel = ({
 
 export default NetworkPanel;
 
-interface PropertyProps<T> {
+type PropertyProps<T> = {
   label: string | ReactElement;
   value: T | undefined;
   unit?: string; // overridden by the formatter if present
@@ -584,10 +590,22 @@ interface PropertyProps<T> {
   tooltip?: string | ReactElement;
   simpleLabel?: boolean;
   skipEmpty?: boolean;
-}
-const Property = <T,>({ label, value, unit, formatter, tooltip, round, simpleLabel, skipEmpty }: PropertyProps<T>) =>
+  valueRenderer?: (valueContent: string | ReactElement) => ReactElement;
+} & BoxProps;
+const Property = <T,>({
+  label,
+  value,
+  unit,
+  formatter,
+  tooltip,
+  round,
+  simpleLabel,
+  skipEmpty,
+  valueRenderer = (valueContent: string | ReactElement) => <Box textAlign="right">{valueContent}</Box>,
+  ...props
+}: PropertyProps<T>) =>
   ((skipEmpty && isDefined(value) && value !== 0) || !skipEmpty) && (
-    <Box display="flex" justifyContent="space-between" alignItems="center" gap="8px">
+    <Box display="flex" justifyContent="space-between" alignItems="center" columnGap="8px" {...props}>
       <Box display="flex" alignItems="center">
         {typeof label === 'string' ? simpleLabel ? label : <strong>{label}</strong> : label}
         {tooltip && (
@@ -599,13 +617,13 @@ const Property = <T,>({ label, value, unit, formatter, tooltip, round, simpleLab
           />
         )}
       </Box>
-      <div>
-        {isDefined(value)
+      {valueRenderer(
+        isDefined(value)
           ? isDefined(formatter)
             ? formatter(value)
             : `${typeof value === 'number' ? prettyFormatNumber(value, round ? 0 : undefined) : value} ${unit ?? ''}`
-          : 'Non connu'}
-      </div>
+          : 'Non connu'
+      )}
     </Box>
   );
 

--- a/src/components/ui/Box.tsx
+++ b/src/components/ui/Box.tsx
@@ -38,6 +38,7 @@ type StyleProps = {
   gridTemplateColumns?: CSSProperties['gridTemplateColumns'];
   columnGap?: CSSProperties['columnGap'];
   cursor?: CSSProperties['cursor'];
+  overflow?: CSSProperties['overflow'];
 };
 
 const StyledBox = styled.div<StyleProps>`
@@ -72,6 +73,7 @@ const StyledBox = styled.div<StyleProps>`
   grid-template-columns: ${({ gridTemplateColumns }) => gridTemplateColumns};
   column-gap: ${({ columnGap }) => columnGap};
   cursor: ${({ cursor }) => cursor};
+  overflow: ${({ overflow }) => overflow};
   :
 `;
 
@@ -120,6 +122,7 @@ function Box(props: PropsWithChildren<BoxProps>) {
       gridTemplateColumns={props.gridTemplateColumns}
       columnGap={props.columnGap}
       cursor={props.cursor}
+      overflow={props.overflow}
       className={`${className ?? ''} ${props.fontWeight ? `fr-text--${props.fontWeight}` : ''} ${props.iconLeft ?? ''} ${spacingsToClasses(
         props
       )}`}


### PR DESCRIPTION
Permet de passer de 
![image](https://github.com/user-attachments/assets/64cf4f43-cc4f-4960-8923-6702c62eb8da)
à
![image](https://github.com/user-attachments/assets/1d9782fa-8599-4c2c-bbca-e9b43e69d2b4)


overflow hidden permet au texte d'être coupé un peu n'importe où. J'ai pas mis d'ellipsis non plus car c'est bien de voir le lien je pense. Ou sinon il faudrait voir le début et la fin.

J'ai permet une fonction valueRenderer pour surcharger l'élément wrapper. J'aurais bien voulu juste pouvoir remplacer l'élement, sans utiliser de fonction, mais j'ai pas réussi avec typescript, donc si t'as des idées, je suis preneur. :)