### PR TITLE
Fix typage website_gestionnaire char => varchar

### DIFF
--- a/src/db/migrations/20241119000001_update_networks_website_type.ts
+++ b/src/db/migrations/20241119000001_update_networks_website_type.ts
@@ -1,0 +1,10 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE public.reseaux_de_chaleur ALTER COLUMN website_gestionnaire TYPE varchar(254);
+    UPDATE public.reseaux_de_chaleur SET website_gestionnaire = trim(website_gestionnaire);
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {} // eslint-disable-line

--- a/src/pages/api/networks/search.ts
+++ b/src/pages/api/networks/search.ts
@@ -46,7 +46,6 @@ export default handleRouteErrors(async (req) => {
     .sort((a, b) => (a['Identifiant reseau'] < b['Identifiant reseau'] ? -1 : 1))
     .slice(0, 10)
     .map((network) => {
-      network.website_gestionnaire = network.website_gestionnaire?.trim(); // type postgresql character... should be varying character
       if (!network.nom_reseau) {
         network.nom_reseau = 'Nom inconnu';
       }


### PR DESCRIPTION
Petite correction d'un type en base.
Pour info, char(254) = toujours 254 caractères, complétés avec des espaces. J'aurais bien voulu utiliser le type text pour pas s'embêter, mais comme l'équivalent côté reseaux_de_froid est varchar(254), j'ai préféré harmoniser avec.