### PR TITLE
Fix page active de 3 pages

### DIFF
--- a/src/pages/actus/[slug].tsx
+++ b/src/pages/actus/[slug].tsx
@@ -52,7 +52,7 @@ const ActualitePage = () => {
   const content = lines.slice(1).join('\n');
 
   return (
-    <SimplePage currentPage="/ressources" title={title}>
+    <SimplePage currentPage="/actus" title={title}>
       <Box className="fr-container fr-mb-n2w fr-mb-md-n4w">
         <Breadcrumb
           currentPageLabel={title}

--- a/src/pages/collectivites-et-exploitants/potentiel-creation-reseau/[[...slug]].tsx
+++ b/src/pages/collectivites-et-exploitants/potentiel-creation-reseau/[[...slug]].tsx
@@ -268,7 +268,11 @@ const PotentielCreationReseauPage: React.FC<PotentielCreationReseauPageProps> = 
   };
 
   return (
-    <SimplePage title="Potentiel de création de réseau" mode="public-fullscreen">
+    <SimplePage
+      title="Potentiel de création de réseau"
+      mode="public-fullscreen"
+      currentPage="/collectivites-et-exploitants/potentiel-creation-reseau"
+    >
       <Newsletter onSignUp={getMoreInfo} withCheckbox>
         <div className="fr-container fr-mt-2w">
           <div className="fr-grid-row">

--- a/src/pages/reseaux/[network].tsx
+++ b/src/pages/reseaux/[network].tsx
@@ -13,7 +13,7 @@ const PageReseau = ({ network }: { network: Network }) => {
   }
 
   return (
-    <SimplePage currentPage="/carte" mode="public-fullscreen">
+    <SimplePage currentPage="/reseaux" mode="public-fullscreen">
       <Slice>
         <Breadcrumb
           currentPageLabel={network['Identifiant reseau']}
@@ -59,7 +59,7 @@ export const getStaticProps: GetStaticProps<{
   return {
     redirect: {
       permanent: false,
-      destination: '/carte',
+      destination: '/reseaux',
     },
   };
 };


### PR DESCRIPTION
Corrige la page active dans la navigation pour /reseaux/id, /actus/id et /collectivites-et-exploitants/potentiel-creation-reseau

Avec next et dsfr, pas de router spécial ou on peut dire isActive exactMatch etc.
J'ai regardé pour surcharger le type côté navigation dsfr, mais c'était chiant...
Donc là je réutilise le param currentPage de SimplePage qui permet d'activer manuellement une page de la navbar.