### PR TITLE
Fix format geojson à l'export du tracé

### DIFF
--- a/src/components/Map/components/tools/LinearHeatDensityTool.tsx
+++ b/src/components/Map/components/tools/LinearHeatDensityTool.tsx
@@ -235,7 +235,14 @@ const LinearHeatDensityTool: React.FC = () => {
     if (!mapDraw) {
       return;
     }
-    downloadObject(features, `FCU_export_tracé_${formatAsISODate(new Date())}.geojson`, 'application/geo+json');
+    downloadObject(
+      {
+        type: 'FeatureCollection',
+        features,
+      },
+      `FCU_export_tracé_${formatAsISODate(new Date())}.geojson`,
+      'application/geo+json'
+    );
     trackEvent('Carto|Densité thermique linéaire|Exporter le tracé');
   }
 


### PR DESCRIPTION
Le format était mauvais. Maintenant ça fonctionne correctement. Même si le SRID n'est pas mentionné.