### PR TITLE
Seo fix

### DIFF
--- a/src/components/HeadSliceForm/HeadSliceForm.style.tsx
+++ b/src/components/HeadSliceForm/HeadSliceForm.style.tsx
@@ -1,5 +1,7 @@
 import styled, { createGlobalStyle, css, keyframes } from 'styled-components';
 
+import Heading from '@/components/ui/Heading';
+
 export const SliceContactFormStyle: any = createGlobalStyle` /* TODO: Wait Fix from @types/styled-component : https://github.com/styled-components/styled-components/issues/3738 */
 .slice-contact-form-wrapper {
   max-height: 0px;
@@ -51,7 +53,7 @@ export const PageTitlePreTitle = styled.span`
   font-size: 2.06rem;
 `;
 
-export const PageTitle = styled.h1`
+export const PageTitle = styled(Heading)`
   color: #4550e5;
   font-size: 2.815rem;
   line-height: 3rem;

--- a/src/components/Ressources/Contents/Fundings.tsx
+++ b/src/components/Ressources/Contents/Fundings.tsx
@@ -178,7 +178,7 @@ const Fundings = () => {
       <br />
       <br />
       <a
-        href="https://www.ecologie.gouv.fr/sites/default/files/CdP%20R%C3%A9no%20Batiment%20residentiel%20collectif%20-%20Les%20offres%20Coup%20de%20pouce.pdf"
+        href="https://www.ecologie.gouv.fr/sites/default/files/documents/CdP%20Chauffage%20B%C3%A2timents%20r%C3%A9sidentiels%20collectifs%20et%20tertiaires%20-%20Les%20offres%20Coup%20de%20pouce.pdf"
         target="_blank"
         rel="noreferrer"
       >

--- a/src/components/Ressources/Header.tsx
+++ b/src/components/Ressources/Header.tsx
@@ -1,15 +1,26 @@
 import { PageBody, PageTitle } from '@/components/HeadSliceForm/HeadSliceForm.style';
 import MarkdownWrapper from '@/components/MarkdownWrapper';
 import Slice from '@/components/Slice';
+import type Heading from '@/components/ui/Heading';
 
 import { Container } from './Header.styles';
 
-const Header = ({ title, description }: { title: string; description: string }) => {
+const Header = ({
+  title,
+  description,
+  titleAs,
+}: {
+  title: string;
+  description: string;
+  titleAs?: React.ComponentProps<typeof Heading>['as'];
+}) => {
   return (
     <Slice padding={8} bg="/img/ressources-right.svg" bgPos="right center" bgSize="auto" bgColor="#CDE3F0">
       <Container>
         <div>
-          <PageTitle className="fr-mb-4w">{title}</PageTitle>
+          <PageTitle as={titleAs} className="fr-mb-4w">
+            {title}
+          </PageTitle>
           <PageBody>
             <MarkdownWrapper value={description} />
           </PageBody>

--- a/src/components/Ressources/Ressource.tsx
+++ b/src/components/Ressources/Ressource.tsx
@@ -47,6 +47,7 @@ const Ressource = ({ ressourceKey }: { ressourceKey: string }) => {
     <>
       <Header
         title="Découvrez les réseaux de chaleur"
+        titleAs={'h2'}
         description="Changez pour un chauffage écologique à prix compétitif déjà adopté par 6 millions de Français !"
       />
       <div id="contenu" />

--- a/src/components/Ressources/Ressource.tsx
+++ b/src/components/Ressources/Ressource.tsx
@@ -47,7 +47,7 @@ const Ressource = ({ ressourceKey }: { ressourceKey: string }) => {
     <>
       <Header
         title="Découvrez les réseaux de chaleur"
-        titleAs={'h2'}
+        titleAs="h2"
         description="Changez pour un chauffage écologique à prix compétitif déjà adopté par 6 millions de Français !"
       />
       <div id="contenu" />

--- a/src/components/Ressources/config.tsx
+++ b/src/components/Ressources/config.tsx
@@ -128,7 +128,7 @@ export const understandings: Record<string, Document> = {
   },
   'cout-raccordement': {
     title: 'Combien coûte un raccordement ?',
-    seoTitle: 'Des aides financières permettent de réduire significativement les coûts de raccordement au chauffage urbain.',
+    seoTitle: 'Aides financières pour réduire le coût du raccordement au chauffage urbain',
     description: (
       <>
         Le raccordement d’un bâtiment à un réseau de chaleur présente un coût non négligeable. Toutefois, des aides permettent de le réduire

--- a/src/components/shared/page/SimplePage.tsx
+++ b/src/components/shared/page/SimplePage.tsx
@@ -456,7 +456,7 @@ const PageFooter = () => (
         alt: 'DRIEAT',
         imgUrl: '/logo-DRIEAT-white.png',
         linkProps: {
-          href: 'http://www.driee.ile-de-france.developpement-durable.gouv.fr/',
+          href: 'https://www.drieat.ile-de-france.developpement-durable.gouv.fr',
           title: 'Lien vers le site du partenaire',
         },
       },

--- a/src/data/contents/index.ts
+++ b/src/data/contents/index.ts
@@ -187,6 +187,7 @@ export const articles = (
     {
       image: '/contents/webi.jpg',
       title: 'Informer les gestionnaires de bâtiments tertiaires sur les réseaux de chaleur',
+      seoTitle: 'Informer les gestionnaires de bâtiments sur les réseaux de chaleur',
       slug: 'informer-les-gestionnaires-de-batiments-tertiaires-sur-les-reseaux-de-chaleur',
       content: importFile(informerGestionnairesTertiaires),
       publishedDate: new Date('2024-11-13'),
@@ -851,6 +852,7 @@ export const articles = (
     {
       image: '/contents/24.jpg',
       title: 'Part des énergies renouvelables dans la consommation finale brute d’énergie en France',
+      seoTitle: 'Part des énergies renouvelables dans la consommation énergétique',
       slug: 'part-des-énergies-renouvelables-dans-la-consommation-finale-brute-d-énergie-en-france',
       content: importFile(readme_3_1_1),
       publishedDate: new Date('2023-05-22'),
@@ -963,6 +965,7 @@ export const articles = (
     {
       image: '/contents/11.jpg',
       title: 'Le chauffage urbain pour les bâtiments tertiaires : un contexte on ne peut plus favorable !',
+      seoTitle: 'Chauffage urbain pour les bâtiments tertiaires : contexte favorable',
       slug: 'le-chauffage-urbain-pour-les-bâtiments-tertiaires-un-contexte-on-ne-peut-plus-favorable',
       content: importFile(leChauffageUrbainPourLesBatimentsTertiairesUnContexteOnNePeutPlusFavorable),
       publishedDate: new Date('2023-04-11'),

--- a/src/pages/actus/[slug].tsx
+++ b/src/pages/actus/[slug].tsx
@@ -37,7 +37,7 @@ const ActualitePage: React.FC<{ article: Article }> = ({ article }) => {
   return (
     <SimplePage
       currentPage="/actus"
-      title={title}
+      title={article?.seoTitle || title}
       description={article.abstract}
       microdata={[
         {

--- a/src/pages/chauffage-urbain.tsx
+++ b/src/pages/chauffage-urbain.tsx
@@ -24,7 +24,7 @@ const ChauffageUrbain = () => {
     >
       <Header
         title="Découvrez le chauffage urbain"
-        titleAs={'h2'}
+        titleAs="h2"
         description="Changez pour un chauffage écologique à prix compétitif déjà adopté par 6 millions de Français !"
       />
       <div id="contenu" />

--- a/src/pages/chauffage-urbain.tsx
+++ b/src/pages/chauffage-urbain.tsx
@@ -24,6 +24,7 @@ const ChauffageUrbain = () => {
     >
       <Header
         title="Découvrez le chauffage urbain"
+        titleAs={'h2'}
         description="Changez pour un chauffage écologique à prix compétitif déjà adopté par 6 millions de Français !"
       />
       <div id="contenu" />

--- a/src/pages/reseaux-chaleur.tsx
+++ b/src/pages/reseaux-chaleur.tsx
@@ -29,6 +29,7 @@ const ChauffageUrbain = () => {
     >
       <Header
         title="Découvrez les réseaux de chaleur"
+        titleAs={'h2'}
         description="Toutes les informations dont vous avez besoin sur les réseaux de chaleur"
       />
       <div id="contenu" />

--- a/src/pages/reseaux-chaleur.tsx
+++ b/src/pages/reseaux-chaleur.tsx
@@ -29,7 +29,7 @@ const ChauffageUrbain = () => {
     >
       <Header
         title="Découvrez les réseaux de chaleur"
-        titleAs={'h2'}
+        titleAs="h2"
         description="Toutes les informations dont vous avez besoin sur les réseaux de chaleur"
       />
       <div id="contenu" />

--- a/src/pages/ressources/outils.tsx
+++ b/src/pages/ressources/outils.tsx
@@ -30,7 +30,7 @@ const OutilsPage = () => {
         </Box>
       </Box>
       <Box py="5w" className="fr-container">
-        <Heading size="h3" color="blue-france" mb="0">
+        <Heading as="h2" size="h3" color="blue-france" mb="0">
           Test d’adresses en masse
         </Heading>
         <Box display="flex" my="2w">
@@ -45,7 +45,7 @@ const OutilsPage = () => {
       </Box>
       <Box backgroundColor="blue-france-975-75">
         <Box py="5w" className="fr-container">
-          <Heading size="h3" color="blue-france" mb="0">
+          <Heading as="h2" size="h3" color="blue-france" mb="0">
             Iframes
           </Heading>
           <Box display="flex" my="2w">
@@ -60,7 +60,7 @@ const OutilsPage = () => {
         </Box>
       </Box>
       <Box py="5w" className="fr-container">
-        <Heading size="h3" color="blue-france" mb="0">
+        <Heading as="h2" size="h3" color="blue-france" mb="0">
           API
         </Heading>
         <Box display="flex" my="2w">
@@ -75,7 +75,7 @@ const OutilsPage = () => {
       </Box>
       <Box backgroundColor="blue-france-975-75">
         <Box py="5w" className="fr-container">
-          <Heading size="h3" color="blue-france" mb="0">
+          <Heading as="h2" size="h3" color="blue-france" mb="0">
             Téléchargement de données
           </Heading>
           <Box display="flex" my="2w">
@@ -90,7 +90,7 @@ const OutilsPage = () => {
         </Box>
       </Box>
       <Box py="5w" className="fr-container">
-        <Heading size="h3" color="blue-france" mb="0">
+        <Heading as="h2" size="h3" color="blue-france" mb="0">
           Simulateur d’aides
         </Heading>
         <Box display="flex" my="2w">
@@ -107,7 +107,7 @@ const OutilsPage = () => {
       {process.env.NEXT_PUBLIC_FLAG_ENABLE_COMPARATEUR === 'true' && (
         <Box backgroundColor="blue-france-975-75">
           <Box py="5w" className="fr-container">
-            <Heading size="h3" color="blue-france" mb="0">
+            <Heading as="h2" size="h3" color="blue-france" mb="0">
               Comparateur de performances
             </Heading>
             <Box display="flex" my="2w">
@@ -123,7 +123,7 @@ const OutilsPage = () => {
         </Box>
       )}
       <Box py="5w" className="fr-container">
-        <Heading size="h3" color="blue-france" mb="0" mt="8w">
+        <Heading as="h2" size="h3" color="blue-france" mb="0" mt="8w">
           Simulateur de CO2
         </Heading>
         <Box display="flex" my="2w">
@@ -138,7 +138,7 @@ const OutilsPage = () => {
       </Box>
       <Box backgroundColor="blue-france-975-75">
         <Box py="5w" className="fr-container">
-          <Heading size="h3" color="blue-france" mb="0">
+          <Heading as="h2" size="h3" color="blue-france" mb="0">
             Fiches par réseau
           </Heading>
           <Box display="flex" my="2w">
@@ -153,7 +153,7 @@ const OutilsPage = () => {
         </Box>
       </Box>
       <Box py="5w" className="fr-container">
-        <Heading size="h3" color="blue-france" mb="0">
+        <Heading as="h2" size="h3" color="blue-france" mb="0">
           Liste des réseaux de chaleur
         </Heading>
         <Box display="flex" my="2w">

--- a/src/pages/ressources/supports.tsx
+++ b/src/pages/ressources/supports.tsx
@@ -323,7 +323,7 @@ const SupportsPage = () => {
       </Box>
 
       <Box py="10w" className="fr-container" id="infographies">
-        <Heading size="h2" color="blue-france" center mb="8w">
+        <Heading as="h2" size="h2" color="blue-france" center mb="8w">
           Infographies
         </Heading>
         <Box display="flex" alignItems="baseline" gap="16px" flexWrap="wrap">
@@ -335,7 +335,7 @@ const SupportsPage = () => {
 
       <Box backgroundColor="blue-france-975-75" id="reportages">
         <Box py="10w" className="fr-container">
-          <Heading size="h2" color="blue-france" center mb="8w">
+          <Heading as="h2" size="h2" color="blue-france" center mb="8w">
             Reportages
           </Heading>
           <Box display="flex" alignItems="baseline" gap="16px" flexWrap="wrap">
@@ -347,7 +347,7 @@ const SupportsPage = () => {
       </Box>
 
       <Box py="10w" className="fr-container" id="videos">
-        <Heading size="h2" color="blue-france" center mb="8w">
+        <Heading as="h2" size="h2" color="blue-france" center mb="8w">
           Vidéos
         </Heading>
         <Box display="flex" alignItems="baseline" gap="16px" flexWrap="wrap">
@@ -359,7 +359,7 @@ const SupportsPage = () => {
 
       <Box backgroundColor="blue-france-975-75" id="guides">
         <Box py="10w" className="fr-container">
-          <Heading size="h2" color="blue-france" center mb="8w">
+          <Heading as="h2" size="h2" color="blue-france" center mb="8w">
             Guides
           </Heading>
           <Box display="flex" alignItems="baseline" gap="16px" flexWrap="wrap">

--- a/src/types/Article.d.ts
+++ b/src/types/Article.d.ts
@@ -1,6 +1,7 @@
 export interface Article {
   slug: string;
   title: string;
+  seoTitle?: string;
   image: string;
   content: string;
   publishedDate: Date;


### PR DESCRIPTION
Corrections suite à l'email de William

```
Voici quelques points à corriger : 

1. Il y a quelques pages qui ont plusieurs Balises H1.
Il faut laisser cette balise uniquement sur le titre principal du contenu. 
Par exemple, sur la page https://france-chaleur-urbaine.beta.gouv.fr/ressources/faisabilite, les Balises H1 sont sur "Découvrez les réseaux de chaleur" et "Qu’est-ce qui détermine la faisabilité du raccordement ?".

2. Il y a quelques pages qui ont une Meta Title trop longue.
Elle doit faire maximum 63 caractères, espaces compris.

3. Il y des liens externes qui sont en erreur 404.
```

[Trello Card](https://trello.com/c/eph01aQs/1411-modifs-liens-title-balises-h1-voir-mail-de-william-transmis-martin)
