### PR TITLE
Ajout d'une iframe pour le potentiel de création de réseau

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -189,6 +189,7 @@ module.exports = withBundleAnalyzer(
             '/map',
             '/page-reseaux/:network',
             '/viaseva',
+            '/iframes/potentiel-creation-reseau',
           ].map((source) => ({
             source,
             headers: securityHeadersIFramable,

--- a/src/pages/collectivites-et-exploitants/potentiel-creation-reseau/[[...slug]].tsx
+++ b/src/pages/collectivites-et-exploitants/potentiel-creation-reseau/[[...slug]].tsx
@@ -2,7 +2,7 @@ import { fr } from '@codegouvfr/react-dsfr';
 import Highlight from '@codegouvfr/react-dsfr/Highlight';
 import { type GetStaticPaths, type InferGetStaticPropsType } from 'next';
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
+import { useRouter } from 'next/router';
 import React, { useEffect } from 'react';
 import styled, { css } from 'styled-components';
 
@@ -34,17 +34,17 @@ import { notify } from '@/services/notification';
 import { type BoundingBox } from '@/types/Coords';
 import { Airtable } from '@/types/enum/Airtable';
 
-type PotentielCreationReseauPageProps = InferGetStaticPropsType<typeof getStaticProps>;
+export type PotentielCreationReseauPageProps = InferGetStaticPropsType<typeof getStaticProps>;
 
 // construit avec `SELECT box2D(st_extent(ST_Transform(geom, 4326))) FROM public.ign_communes;`
-const franceBounds: BoundingBox = [-5.14127657354623, 41.33355568615941, 9.56009360694225, 51.08898944078367];
+export const franceBounds: BoundingBox = [-5.14127657354623, 41.33355568615941, 9.56009360694225, 51.08898944078367];
 
 const modalExplanation = createModal({
   id: 'potentiel-creation-reseau-explication-modal',
   isOpenedByDefault: false,
 });
 
-const DetailsCommune: React.FC<{ commune: NonNullable<PotentielCreationReseauPageProps['commune']> }> = ({ commune }) => {
+export const DetailsCommune: React.FC<{ commune: NonNullable<PotentielCreationReseauPageProps['commune']> }> = ({ commune }) => {
   const router = useRouter();
 
   React.useEffect(() => {
@@ -54,7 +54,7 @@ const DetailsCommune: React.FC<{ commune: NonNullable<PotentielCreationReseauPag
   return (
     <>
       <Button
-        onClick={() => router.push('/collectivites-et-exploitants/potentiel-creation-reseau')}
+        onClick={() => router.push(router.asPath.split('/').slice(0, -1).join('/'))} // supprime le dernier niveau (commune)
         priority="secondary"
         size="small"
         iconId="fr-icon-arrow-left-line"
@@ -198,7 +198,7 @@ Seuls les bâtiments à chauffage collectif pourront facilement être raccordés
   );
 };
 
-const SearchCommune: React.FC = () => {
+export const SearchCommune: React.FC = () => {
   const router = useRouter();
   return (
     <Box className={fr.cx('fr-p-md-2w')}>
@@ -210,11 +210,7 @@ const SearchCommune: React.FC = () => {
         onlyCities
         nativeInputProps={{ placeholder: 'Nom de votre commune' }}
         onSelect={(address) => {
-          router.push(
-            `/collectivites-et-exploitants/potentiel-creation-reseau/${address.properties.citycode}-${encodeURIComponent(
-              address.properties.city
-            )}`
-          );
+          router.push(`${router.asPath}/${address.properties.citycode}-${encodeURIComponent(address.properties.city)}`);
         }}
       />
     </Box>
@@ -233,7 +229,7 @@ const MapBoxWrapper = styled(Box)<{ $preventTouch?: boolean }>`
   `}
 `;
 
-const Map = ({ commune, bounds }: { commune?: PotentielCreationReseauPageProps['commune']; bounds: BoundingBox }) => {
+export const Map = ({ commune, bounds }: { commune?: PotentielCreationReseauPageProps['commune']; bounds: BoundingBox }) => {
   const { updateProperty } = useFCUMap();
 
   useEffect(() => {
@@ -302,7 +298,7 @@ const PotentielCreationReseauPage: React.FC<PotentielCreationReseauPageProps> = 
             <div className="fr-col-12 fr-col-lg-4 fr-my-2w fr-px-2v fr-px-lg-0 fr-pr-lg-2w">
               {commune ? <DetailsCommune commune={commune} /> : <SearchCommune />}
             </div>
-            <div className="fr-col-12 fr-col-lg-8 ">
+            <div className="fr-col-12 fr-col-lg-8">
               <FCUMapContextProvider
                 initialMapConfiguration={createMapConfiguration({
                   reseauxDeChaleur: {
@@ -377,7 +373,7 @@ const PotentielCreationReseauPage: React.FC<PotentielCreationReseauPageProps> = 
                 <Text mt="2w">Une source d’emplois locaux non délocalisables.</Text>
               </Box>
             </Box>
-            <Highlight className="fr-mt-8w fr-pt-2w fr-pb-1v">
+            <Highlight className="fr-pt-2w fr-pb-1v fr-mt-8w">
               <Text as="span" size="lg" fontWeight="bold" display="block">
                 La chaleur représente près de 45 % de l'énergie consommée en France.
               </Text>

--- a/src/pages/iframes/potentiel-creation-reseau/[[...slug]].tsx
+++ b/src/pages/iframes/potentiel-creation-reseau/[[...slug]].tsx
@@ -1,0 +1,74 @@
+import { type GetStaticPaths } from 'next';
+
+import { createMapConfiguration } from '@/components/Map/map-configuration';
+import { FCUMapContextProvider } from '@/components/Map/MapProvider';
+import {
+  DetailsCommune,
+  franceBounds,
+  Map,
+  type PotentielCreationReseauPageProps,
+  SearchCommune,
+} from '@/pages/collectivites-et-exploitants/potentiel-creation-reseau/[[...slug]]';
+import { getCommunePotentiel } from '@/server/services/communeAPotentiel';
+
+const Page: React.FC<PotentielCreationReseauPageProps> = ({ commune }) => {
+  const bounds = commune?.bounds || franceBounds;
+  return (
+    <div className="fr-grid-row">
+      <div className="fr-col-12 fr-col-lg-4 fr-my-2w fr-px-2v fr-px-lg-0 fr-pr-lg-2w">
+        {commune ? <DetailsCommune commune={commune} /> : <SearchCommune />}
+      </div>
+      <div className="fr-col-12 fr-col-lg-8">
+        <FCUMapContextProvider
+          initialMapConfiguration={createMapConfiguration({
+            reseauxDeChaleur: {
+              show: !!commune,
+            },
+            zonesOpportunite: {
+              show: !!commune,
+            },
+            besoinsEnChaleur: !!commune,
+            reseauxEnConstruction: !!commune,
+            communesFortPotentielPourCreationReseauxChaleur: {
+              show: !commune,
+            },
+          })}
+        >
+          <Map commune={commune} bounds={bounds} />
+        </FCUMapContextProvider>
+      </div>
+    </div>
+  );
+};
+
+export const getStaticProps = async ({ params }: { params: { slug?: string } }) => {
+  const codeInsee = (params?.slug?.[0] as string)?.split('-')[0];
+
+  const commune = codeInsee ? await getCommunePotentiel(codeInsee) : null;
+
+  if (codeInsee && !commune) {
+    return {
+      redirect: {
+        destination: `/iframes/potentiel-creation-reseau?notify=error:${encodeURIComponent(
+          "Désolé, nous n'avons pas trouvé la commune en question. Réessayez avec une autre"
+        )}`,
+        permanent: false,
+      },
+    };
+  }
+
+  return {
+    props: {
+      commune,
+    },
+  };
+};
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [],
+    fallback: 'blocking',
+  };
+};
+
+export default Page;

--- a/src/services/iframe.ts
+++ b/src/services/iframe.ts
@@ -9,4 +9,6 @@ export const iframedPaths = [
   '/map',
   '/page-reseaux/*',
   '/viaseva',
+  // for future iframes, try to add them in the 'iframes' folder
+  '/iframes/potentiel-creation-reseau',
 ];


### PR DESCRIPTION
- Nouvelle iframe à l'URL /iframes/potentiel-creation-reseau (comme ça reste technique, je me suis dit qu'on pourrait les regrouper à l'avenir)
- J'ai importé directement (salement ?) les composants de la page d'origine qui m'intéressaient (exportés au passage). Dis-moi ce que tu en penses.
- J'ai adapté un peu pour que le chemin ne soit pas en dur Retour et quand on soumet le formulaire.