### PR TITLE
Affiche uniquement les réseaux avec les valeurs renseignées

### DIFF
--- a/src/components/NetworksList/NetworksList.tsx
+++ b/src/components/NetworksList/NetworksList.tsx
@@ -96,7 +96,7 @@ export function filterReseauxDeChaleur(reseauxDeChaleur: NetworkToCompare[], fil
         const filter = filters[reseauxDeChaleurFilter.confKey];
         const value = reseau[reseauxDeChaleurFilter?.valueKey];
 
-        if (value < filter[0] || value > filter[1]) {
+        if (typeof value !== 'number' || value < filter[0] || value > filter[1]) {
           showReseau = false;
         }
       });


### PR DESCRIPTION
 quand on filtre meme les valeurs nulles sonta ffichées alors qu'elles ne devraientt pas



https://trello.com/c/JZfBrMsN/1424-bug-sur-filtres-sur-la-liste-des-r%C3%A9seaux
