### PR TITLE
Maj version postgres 16

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,20 +23,6 @@ services:
     volumes:
       - mailpit:/data
 
-  web:
-    build: ./docker/web
-    command: sh -c "yarn dev"
-    environment:
-      DATABASE_URL: postgres://postgres:postgres_fcu@db:5432/postgres
-      MAIL_HOST: mailpit
-      MAIL_PORT: 1025
-    ports:
-      - '3000:3000'
-    volumes:
-      - .:/app
-    depends_on: # https://docs.docker.com/compose/startup-order/
-      - db
-
 volumes:
   db:
   mailpit:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgis/postgis:14-3.4-alpine
+    image: postgis/postgis:16-3.5-alpine
     shm_size: 256m
     command: postgres -c config_file=/etc/postgresql/postgresql.conf
     environment:


### PR DESCRIPTION
- Passage à la version 16 pour être iso avec la prod. (+/- car l'image postgis sur le hub docker est un peu en retard)
- Suppression du conteneur web car non utilisé (de ton côté aussi il me semble)

J'en ai profité pour repartir d'une base vierge (via dump) pour passer de 109 tables à 76.
