### PR TITLE
Fix des filtres RDC écrasés par la map-configuration

### DIFF
--- a/src/components/Map/MapProvider.tsx
+++ b/src/components/Map/MapProvider.tsx
@@ -48,7 +48,9 @@ export const FCUMapContextProvider: React.FC<React.PropsWithChildren<{ initialMa
   const [mapDraw, setMapDraw] = React.useState<MapboxDraw | null>(null);
   const [isDrawing, setIsDrawing] = React.useState(false);
   const [mapLayersLoaded, setMapLayersLoaded] = React.useState(false);
-  const [originalMapConfiguration, setMapConfiguration] = React.useState<MapConfiguration>(defaultMapConfiguration);
+  const [originalMapConfiguration, setMapConfiguration] = React.useState<MapConfiguration>(
+    (initialMapConfiguration ?? defaultMapConfiguration) as MapConfiguration
+  );
   const reseauxDeChaleurFilters = useReseauxDeChaleurFilters();
 
   const mapConfiguration = deepMergeObjects(originalMapConfiguration, reseauxDeChaleurFilters.filters);
@@ -58,27 +60,14 @@ export const FCUMapContextProvider: React.FC<React.PropsWithChildren<{ initialMa
   }
 
   React.useEffect(() => {
-    if (!initialMapConfiguration) {
-      return;
-    }
-    const { anneeConstruction, contenuCO2, emissionsCO2, livraisonsAnnuelles, prixMoyen, tauxENRR } =
-      reseauxDeChaleurFilters.limits.reseauxDeChaleur;
-
     setMapConfiguration({
-      ...initialMapConfiguration,
+      ...originalMapConfiguration,
       reseauxDeChaleur: {
-        ...initialMapConfiguration.reseauxDeChaleur,
-        limits: {
-          anneeConstruction,
-          contenuCO2,
-          emissionsCO2,
-          livraisonsAnnuelles,
-          prixMoyen,
-          tauxENRR,
-        },
+        ...originalMapConfiguration.reseauxDeChaleur,
+        ...reseauxDeChaleurFilters.filters,
       },
     });
-  }, []);
+  }, [reseauxDeChaleurFilters.filters]);
 
   const toggleLayer: UseFCUMapResult['toggleLayer'] = (property) => {
     toggleBoolean(mapConfiguration, property);

--- a/src/components/Map/components/MapLegendReseaux.tsx
+++ b/src/components/Map/components/MapLegendReseaux.tsx
@@ -42,8 +42,7 @@ const MapLegendReseaux: React.FC<SimpleMapLegendProps> = ({
   isIframeContext,
   ...props
 }) => {
-  const { mapConfiguration, toggleLayer, countFilters } = useFCUMap();
-  const nbFilters = countFilters('reseauxDeChaleur');
+  const { mapConfiguration, toggleLayer, nbFilters } = useFCUMap();
 
   const enabledFeatures = useMemo(() => {
     return props.enabledFeatures ?? mapLegendFeatures;

--- a/src/components/Map/map-configuration.ts
+++ b/src/components/Map/map-configuration.ts
@@ -52,8 +52,8 @@ export type MapConfiguration = {
   filtreGestionnaire: string[];
   reseauxDeChaleur: {
     show: boolean;
-    isClassed?: boolean;
-    energieMobilisee?: FiltreEnergieConfKey[];
+    isClassed: boolean;
+    energieMobilisee: FiltreEnergieConfKey[];
     tauxENRR: Interval;
     emissionsCO2: Interval;
     contenuCO2: Interval;
@@ -160,6 +160,7 @@ export const emptyMapConfiguration: EmptyMapConfiguration = {
   reseauxDeChaleur: {
     show: false,
     energieMobilisee: [],
+    isClassed: false,
     energie_ratio_biomasse: percentageMaxInterval,
     energie_ratio_geothermie: percentageMaxInterval,
     energie_ratio_uve: percentageMaxInterval,

--- a/src/components/NetworksList/NetworksList.tsx
+++ b/src/components/NetworksList/NetworksList.tsx
@@ -555,7 +555,7 @@ const NetworksList = () => {
 
   return (
     <NetworksListContainer>
-      <Drawer open={isDrawerOpened} onClose={() => toggleDrawer(false)} direction="right">
+      <Drawer open={isDrawerOpened} onClose={() => toggleDrawer(false)} direction="right" handleOnly={true}>
         <FiltersBox>
           <h3>Filtres{nbFilters > 0 ? ` (${nbFilters})` : ''}</h3>
           <Text fontSize="13px" lineHeight="18px" mb="2w">

--- a/src/components/NetworksList/NetworksList.tsx
+++ b/src/components/NetworksList/NetworksList.tsx
@@ -84,7 +84,7 @@ const FiltersBox = styled(Box)`
     font-size: 0.9rem;
   }
 `;
-export function filterReseauxDeChaleur(reseauxDeChaleur: NetworkToCompare[], filters: Filters['reseauxDeChaleur']): NetworkToCompare[] {
+export function filterReseauxDeChaleur(reseauxDeChaleur: NetworkToCompare[], filters: Filters): NetworkToCompare[] {
   const filterKeys = Object.keys(filters);
 
   return reseauxDeChaleur.filter((reseau) => {
@@ -94,7 +94,7 @@ export function filterReseauxDeChaleur(reseauxDeChaleur: NetworkToCompare[], fil
       .filter(({ confKey }) => filterKeys.includes(confKey))
       .forEach((reseauxDeChaleurFilter) => {
         const filter = filters[reseauxDeChaleurFilter.confKey];
-        const value = reseau[reseauxDeChaleurFilter?.valueKey];
+        const value = reseau[reseauxDeChaleurFilter.valueKey];
 
         if (typeof value !== 'number' || value < filter[0] || value > filter[1]) {
           showReseau = false;
@@ -109,16 +109,16 @@ export function filterReseauxDeChaleur(reseauxDeChaleur: NetworkToCompare[], fil
           showReseau = false;
         }
       });
-    (filters.energieMobilisee || []).forEach((energieMobilisee) => {
+    filters.energieMobilisee.forEach((energieMobilisee) => {
       if (reseau[`energie_ratio_${energieMobilisee}`] <= 0) {
         showReseau = false;
       }
     });
-    if (filters.regions && !filters.regions.includes(reseau.region)) {
+    if (filters.regions.length > 0 && !filters.regions.includes(reseau.region)) {
       showReseau = false;
     }
 
-    if (filters.gestionnaires) {
+    if (filters.gestionnaires.length > 0) {
       if (filters.gestionnaires.includes('autre')) {
         // If 'autre' is selected, exclude networks whose gestionnaire matches any unselected filter
         const gestionnairesToExclude = gestionnairesFilters
@@ -296,13 +296,9 @@ const NetworksList = () => {
   const [regionsList, setRegionsList] = useState<ReseauxDeChaleurFiltersProps['regionsList']>([]);
   const [allNetworks, setAllNetworks] = useState<NetworkToCompare[]>([]);
   const [searchValue, setSearchValue] = useState<string>('');
-  const { filters: objectFilters, countFilters } = useReseauxDeChaleurFilters();
-  const nbFilters = countFilters('reseauxDeChaleur');
+  const { filters: objectFilters, nbFilters } = useReseauxDeChaleurFilters();
 
-  let filteredNetworks = filterReseauxDeChaleur(
-    allNetworks,
-    objectFilters?.reseauxDeChaleur || ({} as NonNullable<typeof objectFilters.reseauxDeChaleur>)
-  );
+  let filteredNetworks = filterReseauxDeChaleur(allNetworks, objectFilters || ({} as NonNullable<typeof objectFilters>));
 
   if (searchValue) {
     const searchValueLowerCase = searchValue.toLocaleLowerCase();
@@ -580,7 +576,7 @@ const NetworksList = () => {
               }}
             >
               <Icon size="md" name="fr-icon-filter-line" color="var(--text-action-high-blue-france)" />
-              Tous les filtres ({countFilters('reseauxDeChaleur')})
+              Tous les filtres ({nbFilters})
             </Button>
             <Button
               disabled={!filteredNetworks.length}

--- a/src/components/ReseauxDeChaleurFilters.tsx
+++ b/src/components/ReseauxDeChaleurFilters.tsx
@@ -43,8 +43,8 @@ const ReseauxDeChaleurFilters: React.FC<ReseauxDeChaleurFiltersProps> = ({ regio
           {
             label: 'Réseaux classés',
             nativeInputProps: {
-              checked: filters?.reseauxDeChaleur?.isClassed,
-              onChange: (e) => updateFilter('reseauxDeChaleur.isClassed', e.target.checked),
+              checked: filters.isClassed,
+              onChange: (e) => updateFilter('isClassed', e.target.checked),
             },
           },
         ]}
@@ -58,15 +58,15 @@ const ReseauxDeChaleurFilters: React.FC<ReseauxDeChaleurFiltersProps> = ({ regio
             acc.push({
               label,
               nativeInputProps: {
-                checked: filters?.reseauxDeChaleur?.energieMobilisee?.includes(confKey) || false,
+                checked: filters.energieMobilisee.includes(confKey),
                 onChange: () => {
-                  const currentItems = filters?.reseauxDeChaleur?.energieMobilisee || [];
+                  const currentItems = filters.energieMobilisee;
 
                   const newItems = currentItems.includes(confKey)
                     ? currentItems.filter((key) => key !== confKey) // Remove if already selected
                     : [...currentItems, confKey]; // Add if not selected
 
-                  updateFilter('reseauxDeChaleur.energieMobilisee', newItems.length ? newItems : undefined);
+                  updateFilter('energieMobilisee', newItems.length ? newItems : undefined);
                 },
               },
             });
@@ -89,9 +89,9 @@ const ReseauxDeChaleurFilters: React.FC<ReseauxDeChaleurFiltersProps> = ({ regio
             small
             key={filtreEnergie.confKey}
             label={filtreEnergie.label}
-            domain={limits.reseauxDeChaleur[`energie_ratio_${filtreEnergie.confKey}`]}
-            value={filters?.reseauxDeChaleur?.[`energie_ratio_${filtreEnergie.confKey}`]}
-            onChange={(interval) => updateFilter(`reseauxDeChaleur.energie_ratio_${filtreEnergie.confKey}`, interval)}
+            domain={limits[`energie_ratio_${filtreEnergie.confKey}`]}
+            value={filters[`energie_ratio_${filtreEnergie.confKey}`]}
+            onChange={(interval) => updateFilter(`energie_ratio_${filtreEnergie.confKey}`, interval)}
             unit="%"
             className={fr.cx(index > 0 ? 'fr-mt-2w' : null)}
           />
@@ -111,15 +111,15 @@ const ReseauxDeChaleurFilters: React.FC<ReseauxDeChaleurFiltersProps> = ({ regio
                   acc.push({
                     label: regionName,
                     nativeInputProps: {
-                      checked: filters?.reseauxDeChaleur?.regions?.includes(regionName) || false,
+                      checked: filters.regions.includes(regionName),
                       onChange: () => {
-                        const currentItems = filters?.reseauxDeChaleur?.regions || [];
+                        const currentItems = filters.regions;
 
                         const newItems = currentItems.includes(regionName)
                           ? currentItems.filter((key) => key !== regionName) // Remove if already selected
                           : [...currentItems, regionName]; // Add if not selected
 
-                        updateFilter('reseauxDeChaleur.regions', newItems.length ? newItems : undefined);
+                        updateFilter('regions', newItems.length ? newItems : undefined);
                       },
                     },
                   });
@@ -142,15 +142,15 @@ const ReseauxDeChaleurFilters: React.FC<ReseauxDeChaleurFiltersProps> = ({ regio
                 acc.push({
                   label,
                   nativeInputProps: {
-                    checked: filters?.reseauxDeChaleur?.gestionnaires?.includes(value) || false,
+                    checked: filters.gestionnaires.includes(value),
                     onChange: () => {
-                      const currentItems = filters?.reseauxDeChaleur?.gestionnaires || [];
+                      const currentItems = filters.gestionnaires;
 
                       const newItems = currentItems.includes(value)
                         ? currentItems.filter((key) => key !== value) // Remove if already selected
                         : [...currentItems, value]; // Add if not selected
 
-                      updateFilter('reseauxDeChaleur.gestionnaires', newItems.length ? newItems : undefined);
+                      updateFilter('gestionnaires', newItems.length ? newItems : undefined);
                     },
                   },
                 });
@@ -166,9 +166,9 @@ const ReseauxDeChaleurFilters: React.FC<ReseauxDeChaleurFiltersProps> = ({ regio
         loading={loading}
         small
         label="Taux d’EnR&R"
-        domain={limits.reseauxDeChaleur.tauxENRR}
-        value={filters?.reseauxDeChaleur?.tauxENRR}
-        onChange={(interval) => updateFilter('reseauxDeChaleur.tauxENRR', interval)}
+        domain={limits.tauxENRR}
+        value={filters.tauxENRR}
+        onChange={(interval) => updateFilter('tauxENRR', interval)}
         unit="%"
       />
       <br />
@@ -176,9 +176,9 @@ const ReseauxDeChaleurFilters: React.FC<ReseauxDeChaleurFiltersProps> = ({ regio
         loading={loading}
         small
         label="Contenu CO2 ACV"
-        domain={limits.reseauxDeChaleur.emissionsCO2}
-        value={filters?.reseauxDeChaleur?.emissionsCO2}
-        onChange={(interval) => updateFilter('reseauxDeChaleur.emissionsCO2', interval)}
+        domain={limits.emissionsCO2}
+        value={filters.emissionsCO2}
+        onChange={(interval) => updateFilter('emissionsCO2', interval)}
         unit="gCO2/kWh"
         tooltip="Émissions en analyse du cycle de vie (directes et indirectes)"
       />
@@ -187,9 +187,9 @@ const ReseauxDeChaleurFilters: React.FC<ReseauxDeChaleurFiltersProps> = ({ regio
         loading={loading}
         small
         label="Contenu CO2"
-        domain={limits.reseauxDeChaleur.contenuCO2}
-        value={filters?.reseauxDeChaleur?.contenuCO2}
-        onChange={(interval) => updateFilter('reseauxDeChaleur.contenuCO2', interval)}
+        domain={limits.contenuCO2}
+        value={filters.contenuCO2}
+        onChange={(interval) => updateFilter('contenuCO2', interval)}
         unit="gCO2/kWh"
         tooltip="Émissions en analyse du cycle de vie (directes et indirectes)"
       />
@@ -198,9 +198,9 @@ const ReseauxDeChaleurFilters: React.FC<ReseauxDeChaleurFiltersProps> = ({ regio
         loading={loading}
         small
         label="Prix moyen de la chaleur"
-        domain={limits.reseauxDeChaleur.prixMoyen}
-        value={filters?.reseauxDeChaleur?.prixMoyen}
-        onChange={(interval) => updateFilter('reseauxDeChaleur.prixMoyen', interval)}
+        domain={limits.prixMoyen}
+        value={filters.prixMoyen}
+        onChange={(interval) => updateFilter('prixMoyen', interval)}
         unit="€TTC/MWh"
         tooltip="La comparaison avec le prix d'autres modes de chauffage n’est pertinente qu’en coût global annuel, en intégrant les coûts d’exploitation, de maintenance et d’investissement, amortis sur la durée de vie des installations."
       />
@@ -209,9 +209,9 @@ const ReseauxDeChaleurFilters: React.FC<ReseauxDeChaleurFiltersProps> = ({ regio
         loading={loading}
         small
         label="Livraisons annuelles de chaleur"
-        domain={limits.reseauxDeChaleur.livraisonsAnnuelles}
-        value={filters?.reseauxDeChaleur?.livraisonsAnnuelles}
-        onChange={(interval) => updateFilter('reseauxDeChaleur.livraisonsAnnuelles', interval)}
+        domain={limits.livraisonsAnnuelles}
+        value={filters.livraisonsAnnuelles}
+        onChange={(interval) => updateFilter('livraisonsAnnuelles', interval)}
         domainTransform={{
           percentToValue: (v) => roundNumberProgressively(getLivraisonsAnnuellesFromPercentage(v)),
           valueToPercent: (v) => roundNumberProgressively(getPercentageFromLivraisonsAnnuelles(v)),
@@ -223,9 +223,9 @@ const ReseauxDeChaleurFilters: React.FC<ReseauxDeChaleurFiltersProps> = ({ regio
         loading={loading}
         small
         label="Année de construction"
-        domain={limits.reseauxDeChaleur.anneeConstruction}
-        value={filters?.reseauxDeChaleur?.anneeConstruction}
-        onChange={(interval) => updateFilter('reseauxDeChaleur.anneeConstruction', interval)}
+        domain={limits.anneeConstruction}
+        value={filters.anneeConstruction}
+        onChange={(interval) => updateFilter('anneeConstruction', interval)}
       />
       <FilterResetButtonWrapper>
         {nbFilters > 0 && (
@@ -239,9 +239,8 @@ const ReseauxDeChaleurFilters: React.FC<ReseauxDeChaleurFiltersProps> = ({ regio
             onClick={() =>
               router.push(
                 `/carte?rdc_filters=${filtersQueryParam}&tabId=reseaux/filtres${
-                  filters?.reseauxDeChaleur?.regions?.length && regionsList
-                    ? `&zoom=${bestZoomForRegions}&coord=` +
-                      regionsList.find(({ name }) => name === filters?.reseauxDeChaleur?.regions[0])?.coord
+                  filters.regions.length && regionsList
+                    ? `&zoom=${bestZoomForRegions}&coord=` + regionsList.find(({ name }) => name === filters.regions[0])?.coord
                     : ''
                 }`
               )

--- a/src/components/ui/Drawer.tsx
+++ b/src/components/ui/Drawer.tsx
@@ -31,15 +31,27 @@ const drawerContentVariants = cva('bg-white h-full fixed outline-none z-[1750] f
   },
 });
 
-const Drawer = ({ children, open, onClose, direction = 'right', className, full = false }: DrawerProps) => {
+const Drawer = ({ children, open, onClose, direction = 'right', className, full = false, handleOnly = false, ...props }: DrawerProps) => {
+  const orientation = direction === 'left' || direction === 'right' ? 'horizontal' : 'vertical';
+
   return (
-    <DrawerVaul.Root open={open} onOpenChange={(open) => !open && onClose?.()} direction={direction}>
+    <DrawerVaul.Root open={open} onOpenChange={(open) => !open && onClose?.()} direction={direction} handleOnly={handleOnly} {...props}>
       <DrawerVaul.Portal>
         <DrawerVaul.Overlay className="fixed inset-0 bg-black/40 z-[1750]" />
         <DrawerVaul.Content className={cx(drawerContentVariants({ direction, full }), className)}>
           <div className="text-right px-3 pt-3">
             <Icon name="fr-icon-close-line" size="lg" onClick={onClose} className="cursor-pointer hover:opacity-70 inline-block" />
           </div>
+          {!props.dismissible && (
+            <DrawerVaul.Handle
+              className={cx(
+                '!mx-0 absolute', // override default values which prevent right positioning
+                'flex-shrink-0 rounded-full bg-zinc-300',
+                orientation === 'horizontal' ? '!w-1.5 !h-12 top-1/2 -translate-y-1/2' : '!w-12 !h-1.5 left-1/2 -translate-x-1/2',
+                direction === 'right' ? 'left-1.5' : direction === 'left' ? 'right-1.5' : direction === 'bottom' ? 'top-1.5' : 'bottom-1.5'
+              )}
+            />
+          )}
           <div className="flex-1 px-3 pb-3 overflow-y-auto ">{children}</div>
         </DrawerVaul.Content>
       </DrawerVaul.Portal>

--- a/src/hooks/useReseauxDeChaleurFilters.tsx
+++ b/src/hooks/useReseauxDeChaleurFilters.tsx
@@ -1,49 +1,50 @@
 import { useSearchParams } from 'next/navigation';
 import { parseAsJson, useQueryState } from 'nuqs';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { type ReseauxDeChaleurLimits } from '@/components/Map/layers/filters';
 import { defaultInterval, percentageMaxInterval, type FiltreEnergieConfKey } from '@/components/Map/map-configuration';
-import { deepMergeObjects, getProperty, setProperty } from '@/utils/core';
+import { deepMergeObjects, setProperty } from '@/utils/core';
 import { fetchJSON } from '@/utils/network';
 import { deepIntersection } from '@/utils/objects';
 import { type FlattenKeys } from '@/utils/typescript';
 
-const countNotArrayLeaves = <T extends Record<string, any>>(obj: T = {} as T): number =>
-  obj && typeof obj === 'object' && !Array.isArray(obj) ? Object.values(obj).reduce((acc, v) => acc + countNotArrayLeaves(v), 0) : 1;
-
 export const emptyFilterLimits = {
-  reseauxDeChaleur: {
-    energieMobilisee: [] as FiltreEnergieConfKey[],
-    energie_ratio_biomasse: percentageMaxInterval,
-    energie_ratio_geothermie: percentageMaxInterval,
-    energie_ratio_uve: percentageMaxInterval,
-    energie_ratio_chaleurIndustrielle: percentageMaxInterval,
-    energie_ratio_solaireThermique: percentageMaxInterval,
-    energie_ratio_pompeAChaleur: percentageMaxInterval,
-    energie_ratio_gaz: percentageMaxInterval,
-    energie_ratio_fioul: percentageMaxInterval,
-    tauxENRR: percentageMaxInterval,
-    emissionsCO2: defaultInterval,
-    contenuCO2: defaultInterval,
-    prixMoyen: defaultInterval,
-    livraisonsAnnuelles: defaultInterval,
-    anneeConstruction: defaultInterval,
-    gestionnaires: [] as string[],
-    isClassed: false,
-    regions: [] as string[],
-  },
+  energieMobilisee: [] as FiltreEnergieConfKey[],
+  energie_ratio_biomasse: percentageMaxInterval,
+  energie_ratio_geothermie: percentageMaxInterval,
+  energie_ratio_uve: percentageMaxInterval,
+  energie_ratio_chaleurIndustrielle: percentageMaxInterval,
+  energie_ratio_solaireThermique: percentageMaxInterval,
+  energie_ratio_pompeAChaleur: percentageMaxInterval,
+  energie_ratio_gaz: percentageMaxInterval,
+  energie_ratio_fioul: percentageMaxInterval,
+  tauxENRR: percentageMaxInterval,
+  emissionsCO2: defaultInterval,
+  contenuCO2: defaultInterval,
+  prixMoyen: defaultInterval,
+  livraisonsAnnuelles: defaultInterval,
+  anneeConstruction: defaultInterval,
+  gestionnaires: [] as string[],
+  isClassed: false,
+  regions: [] as string[],
 };
 
 export type Filters = typeof emptyFilterLimits;
 export type FilterKeys = FlattenKeys<Filters>;
 
+type FilterWithLimits = Filters & { limits: ReseauxDeChaleurLimits };
+
 const useReseauxDeChaleurFilters = ({ queryParamName = 'rdc_filters' }: { queryParamName?: string } = {}) => {
-  const [filtersOrNull, setFilters] = useQueryState(queryParamName, parseAsJson<Partial<Filters>>().withDefault({} as Filters));
-  const filters = filtersOrNull ?? ({} as Filters);
-  const [limits, setLimits] = useState(emptyFilterLimits);
+  const [urlFilters, setUrlFilters] = useQueryState(queryParamName, parseAsJson<Partial<Filters>>().withDefault({} as Filters));
+  const [defaultFilters, setDefaultFilters] = useState<FilterWithLimits>({ ...emptyFilterLimits, limits: {} as ReseauxDeChaleurLimits }); // pas génial, mais un refacto s'imposera pour avoir un typage correct
   const searchParams = useSearchParams();
   const [loaded, setLoaded] = useState(false);
+
+  const filters: FilterWithLimits = useMemo(
+    () => deepMergeObjects(defaultFilters, urlFilters),
+    [defaultFilters, JSON.stringify(urlFilters)]
+  );
 
   useEffect(() => {
     if (loaded) {
@@ -51,14 +52,12 @@ const useReseauxDeChaleurFilters = ({ queryParamName = 'rdc_filters' }: { queryP
     }
     (async () => {
       try {
-        const specialLimits = await fetchJSON<ReseauxDeChaleurLimits>('/api/map/network-limits');
+        const networkLimits = await fetchJSON<ReseauxDeChaleurLimits>('/api/map/network-limits');
 
-        setLimits({
-          ...limits,
-          reseauxDeChaleur: {
-            ...limits.reseauxDeChaleur,
-            ...specialLimits,
-          },
+        setDefaultFilters({
+          ...defaultFilters,
+          ...networkLimits,
+          limits: networkLimits,
         });
         setLoaded(true);
       } finally {
@@ -67,35 +66,30 @@ const useReseauxDeChaleurFilters = ({ queryParamName = 'rdc_filters' }: { queryP
         });
       }
     })();
-  }, [limits]);
+  }, [defaultFilters]);
 
   const updateFilter = (property: FilterKeys, value?: any) => {
-    const updatedFilters = { ...filters };
-    setProperty(updatedFilters, property as keyof typeof filters, value);
+    const updatedFilters = { ...urlFilters };
+    setProperty(updatedFilters, property as keyof typeof urlFilters, value);
     updateFilters(updatedFilters as Filters);
   };
 
   const updateFilters = (updatedFilters: Filters) => {
-    const fullFilters = deepMergeObjects(filters, updatedFilters);
-    const changedFilters = deepIntersection(limits, fullFilters, { keepArray: true });
+    const fullFilters = deepMergeObjects(urlFilters, updatedFilters);
+    const changedFilters = deepIntersection(defaultFilters, fullFilters, { keepArray: true });
 
-    setFilters(Object.keys(changedFilters).length === 0 ? null : changedFilters);
+    setUrlFilters(Object.keys(changedFilters).length === 0 ? null : changedFilters);
   };
 
-  const countFilters = (startKey?: keyof Filters) => {
-    return countNotArrayLeaves(startKey ? getProperty(filters, startKey) : filters);
-  };
-
-  const resetFilters = () => setFilters(null);
+  const resetFilters = () => setUrlFilters(null);
 
   return {
-    limits,
+    limits: defaultFilters,
     filters,
     resetFilters,
     updateFilter,
-    nbFilters: countFilters(),
+    nbFilters: Object.keys(urlFilters).length,
     loading: !loaded,
-    countFilters,
     filtersQueryParam: searchParams.get(queryParamName),
   };
 };

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -54,13 +54,19 @@ export function deepMergeObjects<T, U>(obj1: T, obj2: U): T & U {
   const result: any = cloneDeep(obj1);
 
   for (const key in obj2) {
-    if (obj2[key] !== null && typeof obj2[key] === 'object' && !Array.isArray(obj2[key])) {
-      if (key in result && typeof result[key] === 'object' && !Array.isArray(result[key])) {
+    if (obj2[key] !== null && typeof obj2[key] === 'object') {
+      if (Array.isArray(obj2[key])) {
+        // Handle arrays by cloning them
+        result[key] = cloneDeep(obj2[key]);
+      } else if (key in result && typeof result[key] === 'object') {
+        // Recursively merge objects
         result[key] = deepMergeObjects(result[key], obj2[key]);
       } else {
-        result[key] = { ...obj2[key] };
+        // Clone objects that don't exist in result
+        result[key] = cloneDeep(obj2[key]);
       }
     } else {
+      // Handle primitive values
       result[key] = obj2[key];
     }
   }

--- a/src/utils/interval.ts
+++ b/src/utils/interval.ts
@@ -1,4 +1,4 @@
-export type Interval = [number, number];
+export type Interval = [min: number, max: number];
 
 /**
  * Returns true if two intervals are equal, false otherwise.


### PR DESCRIPTION
Réorganise un peu les choses pour faire fonctionner comme il faut :
- conserve uniquement les filtres RDC dans l'URL s'ils sont définis (avec au passage un niveau en moins), on espère trop rien casser si des gens ont gardé ça en favoris...)
- les filtres sont toujours typés et jamais non définis. Il y a juste les limites qui sont ajoutées par la suite. Là c'était un peu le bordel, mais l'idée d'origine était d'avoir la config de carte, puis d'obtenir la config de carte avec les limites et enfin la rendre prête à l'usage.
- le deepMergeObjects n'avait pas l'air de trop fonctionner sur les tableaux... donc j'ai modifié un peu ça.