### PR TITLE
Linter sort imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -84,7 +84,7 @@
           "unknown" // <- unknown imports always last
         ],
         "newlines-between": "always",
-        // "named": true,
+        "named": true,
         "alphabetize": {
           "order": "asc",
           "caseInsensitive": true

--- a/scripts/networks/commands.ts
+++ b/scripts/networks/commands.ts
@@ -6,11 +6,11 @@ import { logger } from '@/server/helpers/logger';
 import { readFileGeometry } from '@cli/helpers/geo';
 
 import {
-  updateEntityGeometry,
-  insertEntityWithGeometry,
   createPDPFromCommune,
-  updateNetworkHasPDP,
+  insertEntityWithGeometry,
   type NetworkTable,
+  updateEntityGeometry,
+  updateNetworkHasPDP,
 } from './geometry-operations';
 
 const entityTypes = ['rdc', 'rdf', 'pdp', 'futur'] as const;

--- a/scripts/networks/download-network.ts
+++ b/scripts/networks/download-network.ts
@@ -4,7 +4,7 @@ import { type FieldSet } from 'airtable/lib/field_set';
 import db from '@/server/db';
 import base from '@/server/db/airtable';
 import { parentLogger } from '@/server/helpers/logger';
-import { type DatabaseTileInfo, tilesInfo, type DatabaseSourceId } from '@/server/services/tiles.config';
+import { type DatabaseSourceId, type DatabaseTileInfo, tilesInfo } from '@/server/services/tiles.config';
 
 export const TypeArray: unique symbol = Symbol('array');
 export const TypeBool: unique symbol = Symbol('bool');

--- a/src/components/Admin/BulkEligibility.tsx
+++ b/src/components/Admin/BulkEligibility.tsx
@@ -5,7 +5,7 @@ import Input from '@/components/form/dsfr/Input';
 import Box from '@/components/ui/Box';
 import Heading from '@/components/ui/Heading';
 import Icon from '@/components/ui/Icon';
-import { Table, type ColumnDef } from '@/components/ui/Table';
+import { type ColumnDef, Table } from '@/components/ui/Table';
 import { useServices } from '@/services';
 import { type EligibilityDemand } from '@/types/EligibilityDemand';
 

--- a/src/components/Admin/Users.tsx
+++ b/src/components/Admin/Users.tsx
@@ -4,7 +4,7 @@ import Input from '@/components/form/dsfr/Input';
 import AsyncButton from '@/components/ui/AsyncButton';
 import Box from '@/components/ui/Box';
 import Heading from '@/components/ui/Heading';
-import { Table, type ColumnDef } from '@/components/ui/Table';
+import { type ColumnDef, Table } from '@/components/ui/Table';
 import { type AdminManageUserItem } from '@/pages/api/admin/users';
 import { useServices } from '@/services';
 

--- a/src/components/ComparateurPublicodes/ComparateurPublicodesWidget.tsx
+++ b/src/components/ComparateurPublicodes/ComparateurPublicodesWidget.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { FormProvider } from '@/components/form/publicodes/FormProvider';
 import Heading from '@/components/ui/Heading';
-import { Table, type ColumnDef } from '@/components/ui/Table';
+import { type ColumnDef, Table } from '@/components/ui/Table';
 import { type LocationInfoResponse } from '@/pages/api/location-infos';
 import { postFetchJSON } from '@/utils/network';
 import { ObjectEntries } from '@/utils/typescript';

--- a/src/components/ComparateurPublicodes/ModesDeChauffageAComparer.tsx
+++ b/src/components/ComparateurPublicodes/ModesDeChauffageAComparer.tsx
@@ -9,7 +9,7 @@ import useArrayQueryState from '@/hooks/useArrayQueryState';
 import { type LocationInfoResponse } from '@/pages/api/location-infos';
 
 import { Title } from './ComparateurPublicodes.style';
-import { modesDeChauffage, type ModeDeChauffage } from './mappings';
+import { type ModeDeChauffage, modesDeChauffage } from './mappings';
 import { DisclaimerButton } from './Placeholder';
 import SelectClimatisation from './SelectClimatisation';
 import SelectProductionECS from './SelectProductionECS';

--- a/src/components/ComparateurPublicodes/ParametresDesModesDeChauffage.tsx
+++ b/src/components/ComparateurPublicodes/ParametresDesModesDeChauffage.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import Input from '@/components/form/publicodes/Input';
 import RadioInput from '@/components/form/publicodes/Radio';
 import Select from '@/components/form/publicodes/Select';
-import { UrlStateAccordion as Accordion, UrlStateAccordion } from '@/components/ui/Accordion';
+import { UrlStateAccordion, UrlStateAccordion as Accordion } from '@/components/ui/Accordion';
 import useArrayQueryState from '@/hooks/useArrayQueryState';
 
 import { Title } from './ComparateurPublicodes.style';

--- a/src/components/Coproprietaire/Interviews.tsx
+++ b/src/components/Coproprietaire/Interviews.tsx
@@ -1,4 +1,4 @@
-import { Logo, Container, Quote, Author, Icon } from './Interviews.styles';
+import { Author, Container, Icon, Logo, Quote } from './Interviews.styles';
 import InterviewsVideos from './InterviewsVideos';
 
 const quotes = {

--- a/src/components/EligibilityForm/index.ts
+++ b/src/components/EligibilityForm/index.ts
@@ -1,4 +1,4 @@
-export { default as EligibilityFormAddress, default } from './EligibilityFormAddress';
+export { default, default as EligibilityFormAddress } from './EligibilityFormAddress';
 export type { EnergyInputsLabelsType } from './EligibilityFormAddress';
 export { default as EligibilityFormContact } from './EligibilityFormContact';
 export { default as EligibilityFormMessageConfirmation } from './EligibilityFormMessageConfirmation';

--- a/src/components/Manager/Manager.tsx
+++ b/src/components/Manager/Manager.tsx
@@ -8,7 +8,7 @@ import Map from '@/components/Map/Map';
 import { createMapConfiguration } from '@/components/Map/map-configuration';
 import Box from '@/components/ui/Box';
 import Icon from '@/components/ui/Icon';
-import { Table, type ColumnDef } from '@/components/ui/Table';
+import { type ColumnDef, Table } from '@/components/ui/Table';
 import { useServices } from '@/services';
 import { type MapMarkerInfos } from '@/types/MapComponentsInfos';
 import { type Point } from '@/types/Point';

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -6,16 +6,16 @@ import { type LayerSpecification, type MapLibreEvent } from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { useRouter } from 'next/router';
 import { parseAsJson, parseAsString, useQueryStates } from 'nuqs';
-import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState, type RefObject } from 'react';
+import { type ReactNode, type RefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ReactDOMServer from 'react-dom/server';
 import MapReactGL, {
   AttributionControl,
   GeolocateControl,
   MapProvider,
-  NavigationControl,
-  ScaleControl,
   type MapRef,
   type MapSourceDataEvent,
+  NavigationControl,
+  ScaleControl,
 } from 'react-map-gl/maplibre';
 
 import FileDragNDrop from '@/components/Map/components/FileDragNDrop';
@@ -65,7 +65,7 @@ import useFCUMap, { FCUMapContextProvider } from './MapProvider';
 // https://openmaptiles.geo.data.gouv.fr/styles/osm-bright/style.json
 import rawOsmConfig from './osm.config.json';
 import rawSatelliteConfig from './satellite.config.json';
-import { MapboxStyleSwitcherControl, type MapboxStyleDefinition } from './StyleSwitcher';
+import { type MapboxStyleDefinition, MapboxStyleSwitcherControl } from './StyleSwitcher';
 
 const mapSettings = {
   defaultLongitude: 2.3,

--- a/src/components/Map/StyleSwitcher/index.ts
+++ b/src/components/Map/StyleSwitcher/index.ts
@@ -1,4 +1,4 @@
-import { type Map, type ControlPosition, type IControl } from 'maplibre-gl';
+import { type ControlPosition, type IControl, type Map } from 'maplibre-gl';
 
 /*
 Lib CSS not compatible with v3 of maplibre

--- a/src/components/Map/components/ModalCarteFrance.tsx
+++ b/src/components/Map/components/ModalCarteFrance.tsx
@@ -17,12 +17,12 @@ import CarteFrance, { type DataByArea } from './CarteFrance';
 import {
   BigBlueNumber,
   BigGreyNumber,
+  Bin as DataBin,
   BlackNumber,
   BlackNumbersLine,
   BlackText,
   BlueNumber,
   BlueText,
-  Bin as DataBin,
   DataLink,
   DistanceLineText,
   ExtraBigBlueText,

--- a/src/components/Map/components/SimpleMapLegend.tsx
+++ b/src/components/Map/components/SimpleMapLegend.tsx
@@ -27,13 +27,13 @@ import {
   DeactivatableBox,
   parseURLTabs,
   SingleCheckbox,
+  type TabId,
+  type TabObject,
   Tabs,
   tabs,
   TabScrollablePart,
   Title,
   TrackableCheckableAccordion,
-  type TabId,
-  type TabObject,
 } from './SimpleMapLegend.style';
 import { besoinsEnChaleurIntervals, besoinsEnFroidIntervals } from '../layers/besoinsEnChaleur';
 import { besoinsEnChaleurIndustrieCommunesIntervals } from '../layers/besoinsEnChaleurIndustrieCommunes';

--- a/src/components/Map/layers/adressesEligibles.tsx
+++ b/src/components/Map/layers/adressesEligibles.tsx
@@ -1,4 +1,4 @@
-import { ifHoverElse, type PopupStyleHelpers, type MapSourceLayersSpecification } from './common';
+import { ifHoverElse, type MapSourceLayersSpecification, type PopupStyleHelpers } from './common';
 
 export const adressesEligiblesLayersSpec = [
   {

--- a/src/components/Map/layers/batimentsRaccordesReseauxChaleurFroid.tsx
+++ b/src/components/Map/layers/batimentsRaccordesReseauxChaleurFroid.tsx
@@ -2,7 +2,7 @@ import Button from '@/components/ui/Button';
 import { formatMWhAn } from '@/utils/strings';
 import { type ExtractKeysOfType } from '@/utils/typescript';
 
-import { ifHoverElse, type PopupStyleHelpers, type MapSourceLayersSpecification } from './common';
+import { ifHoverElse, type MapSourceLayersSpecification, type PopupStyleHelpers } from './common';
 import { type MapConfiguration } from '../map-configuration';
 import { type MapLayerSpecification } from '../map-layers';
 

--- a/src/components/Map/layers/besoinsEnChaleur.tsx
+++ b/src/components/Map/layers/besoinsEnChaleur.tsx
@@ -3,7 +3,7 @@ import { type DataDrivenPropertyValueSpecification } from 'maplibre-gl';
 import { darken } from '@/utils/color';
 import { formatMWhAn, formatMWhString } from '@/utils/strings';
 
-import { type LegendInterval, type ColorThreshold, type MapSourceLayersSpecification, ifHoverElse, type PopupStyleHelpers } from './common';
+import { type ColorThreshold, ifHoverElse, type LegendInterval, type MapSourceLayersSpecification, type PopupStyleHelpers } from './common';
 
 const besoinsBatimentsDefaultColor = '#ffffff';
 const besoinsEnChaleurMaxValue = 6_000;

--- a/src/components/Map/layers/besoinsEnChaleurIndustrieCommunes.tsx
+++ b/src/components/Map/layers/besoinsEnChaleurIndustrieCommunes.tsx
@@ -1,7 +1,7 @@
 import { darken } from '@/utils/color';
 import { formatMWhAn, formatMWhString } from '@/utils/strings';
 
-import { type LegendInterval, type ColorThreshold, type MapSourceLayersSpecification, ifHoverElse, type PopupStyleHelpers } from './common';
+import { type ColorThreshold, ifHoverElse, type LegendInterval, type MapSourceLayersSpecification, type PopupStyleHelpers } from './common';
 
 const besoinsEnChaleurIndustrieCommunesDefaultColor = '#fbf2e7';
 const besoinsEnChaleurIndustrieCommunesMaxValue = 1_500_000;

--- a/src/components/Map/layers/caracteristiquesBatiments.tsx
+++ b/src/components/Map/layers/caracteristiquesBatiments.tsx
@@ -6,7 +6,7 @@ import { darken } from '@/utils/color';
 import { formatTypeEnergieChauffage } from '@/utils/format';
 import { ObjectEntries } from '@/utils/typescript';
 
-import { type MapSourceLayersSpecification, type PopupStyleHelpers, ifHoverElse, intermediateTileLayersMinZoom } from './common';
+import { ifHoverElse, intermediateTileLayersMinZoom, type MapSourceLayersSpecification, type PopupStyleHelpers } from './common';
 
 export const caracteristiquesBatimentsLayerStyle = {
   a: '#0D8A61',

--- a/src/components/Map/layers/common.tsx
+++ b/src/components/Map/layers/common.tsx
@@ -1,5 +1,5 @@
 import { type DataDrivenPropertyValueSpecification, type SourceSpecification } from 'maplibre-gl';
-import { isValidElement, type ComponentProps, type PropsWithChildren } from 'react';
+import { type ComponentProps, isValidElement, type PropsWithChildren } from 'react';
 
 import { type MapLayerSpecification } from '@/components/Map/map-layers';
 import Box from '@/components/ui/Box';

--- a/src/components/Map/layers/communesFortPotentielPourCreationReseauxChaleur.tsx
+++ b/src/components/Map/layers/communesFortPotentielPourCreationReseauxChaleur.tsx
@@ -1,7 +1,7 @@
 import { type Interval } from '@/utils/interval';
 import { formatMWhAn } from '@/utils/strings';
 
-import { ifHoverElse, type PopupStyleHelpers, type MapSourceLayersSpecification } from './common';
+import { ifHoverElse, type MapSourceLayersSpecification, type PopupStyleHelpers } from './common';
 
 export const communesFortPotentielPourCreationReseauxChaleurLayerColor = '#FF8329';
 export const communesFortPotentielPourCreationReseauxChaleurLayerOpacity = 0.7;

--- a/src/components/Map/layers/consommationsGaz.tsx
+++ b/src/components/Map/layers/consommationsGaz.tsx
@@ -4,7 +4,7 @@ import { type GasSummary } from '@/types/Summary/Gas';
 import { formatMWhAn } from '@/utils/strings';
 import { ObjectEntries } from '@/utils/typescript';
 
-import { ifHoverElse, intermediateTileLayersMinZoom, type PopupStyleHelpers, type MapSourceLayersSpecification } from './common';
+import { ifHoverElse, intermediateTileLayersMinZoom, type MapSourceLayersSpecification, type PopupStyleHelpers } from './common';
 
 export const consommationsGazLayerStyle = {
   T: '#0032E5',

--- a/src/components/Map/layers/customGeojson.tsx
+++ b/src/components/Map/layers/customGeojson.tsx
@@ -1,6 +1,6 @@
 import { ObjectEntries } from '@/utils/typescript';
 
-import { type MapSourceLayersSpecification, ifHoverElse, type PopupStyleHelpers } from './common';
+import { ifHoverElse, type MapSourceLayersSpecification, type PopupStyleHelpers } from './common';
 
 export const customGeojsonLayersSpec = [
   {

--- a/src/components/Map/layers/demandesEligibilite.tsx
+++ b/src/components/Map/layers/demandesEligibilite.tsx
@@ -1,6 +1,6 @@
 import { formatTypeEnergieChauffage } from '@/utils/format';
 
-import { ifHoverElse, type PopupStyleHelpers, type MapSourceLayersSpecification } from './common';
+import { ifHoverElse, type MapSourceLayersSpecification, type PopupStyleHelpers } from './common';
 
 export const demandesEligibiliteLayerStyle = {
   fill: { color: '#FFFFFF', size: 4 },

--- a/src/components/Map/layers/enrr-mobilisables/chaleurFatale.tsx
+++ b/src/components/Map/layers/enrr-mobilisables/chaleurFatale.tsx
@@ -1,8 +1,8 @@
 import { type MapConfiguration } from '@/components/Map/map-configuration';
-import { type PopupHandler, type MapLayerSpecification } from '@/components/Map/map-layers';
+import { type MapLayerSpecification, type PopupHandler } from '@/components/Map/map-layers';
 import Text from '@/components/ui/Text';
 
-import { ifHoverElse, type PopupStyleHelpers, type LayerSymbolSpecification, type MapSourceLayersSpecification } from '../common';
+import { ifHoverElse, type LayerSymbolSpecification, type MapSourceLayersSpecification, type PopupStyleHelpers } from '../common';
 
 export const enrrMobilisablesChaleurFataleLayerSymbols = [
   {

--- a/src/components/Map/layers/enrr-mobilisables/friches.tsx
+++ b/src/components/Map/layers/enrr-mobilisables/friches.tsx
@@ -1,6 +1,6 @@
 import { darken } from '@/utils/color';
 
-import { ifHoverElse, type PopupStyleHelpers, type MapSourceLayersSpecification } from '../common';
+import { ifHoverElse, type MapSourceLayersSpecification, type PopupStyleHelpers } from '../common';
 
 export const enrrMobilisablesFrichesLayerColor = '#dc958e';
 export const enrrMobilisablesFrichesLayerOpacity = 0.7;

--- a/src/components/Map/layers/enrr-mobilisables/parkings.tsx
+++ b/src/components/Map/layers/enrr-mobilisables/parkings.tsx
@@ -1,6 +1,6 @@
 import { darken } from '@/utils/color';
 
-import { ifHoverElse, type PopupStyleHelpers, type MapSourceLayersSpecification } from '../common';
+import { ifHoverElse, type MapSourceLayersSpecification, type PopupStyleHelpers } from '../common';
 
 export const enrrMobilisablesParkingsLayerColor = '#d0643e';
 export const enrrMobilisablesParkingsLayerOpacity = 0.7;

--- a/src/components/Map/layers/enrr-mobilisables/thalassothermie.tsx
+++ b/src/components/Map/layers/enrr-mobilisables/thalassothermie.tsx
@@ -1,6 +1,6 @@
 import { darken } from '@/utils/color';
 
-import { ifHoverElse, type PopupStyleHelpers, type MapSourceLayersSpecification } from '../common';
+import { ifHoverElse, type MapSourceLayersSpecification, type PopupStyleHelpers } from '../common';
 
 export const enrrMobilisablesThalassothermieLayerColor = '#4c64c9';
 export const enrrMobilisablesThalassothermieLayerOpacity = 0.6;

--- a/src/components/Map/layers/filters.ts
+++ b/src/components/Map/layers/filters.ts
@@ -1,6 +1,6 @@
 import { type ExpressionSpecification } from 'maplibre-gl';
 
-import { filtresEnergies, percentageMaxInterval, type MapConfiguration } from '@/components/Map/map-configuration';
+import { filtresEnergies, type MapConfiguration, percentageMaxInterval } from '@/components/Map/map-configuration';
 import { gestionnairesFilters } from '@/services';
 import { type Network } from '@/types/Summary/Network';
 import { type Interval, intervalsEqual } from '@/utils/interval';

--- a/src/components/Map/layers/installationsGeothermie.tsx
+++ b/src/components/Map/layers/installationsGeothermie.tsx
@@ -1,6 +1,6 @@
 import Button from '@/components/ui/Button';
 
-import { ifHoverElse, type PopupStyleHelpers, type MapSourceLayersSpecification } from './common';
+import { ifHoverElse, type MapSourceLayersSpecification, type PopupStyleHelpers } from './common';
 
 export const installationsGeothermieProfondeLayerColor = '#8400a8';
 export const installationsGeothermieProfondeLayerOpacity = 0.8;

--- a/src/components/Map/layers/quartiersPrioritairesPolitiqueVille.tsx
+++ b/src/components/Map/layers/quartiersPrioritairesPolitiqueVille.tsx
@@ -2,7 +2,7 @@ import Button from '@/components/ui/Button';
 import Link from '@/components/ui/Link';
 import { darken } from '@/utils/color';
 
-import { ifHoverElse, type PopupStyleHelpers, type MapSourceLayersSpecification } from './common';
+import { ifHoverElse, type MapSourceLayersSpecification, type PopupStyleHelpers } from './common';
 
 export const quartiersPrioritairesPolitiqueVille2015anruColor = '#d16d26';
 export const quartiersPrioritairesPolitiqueVille2024Color = '#2f5390';

--- a/src/components/Map/layers/reseauxDeChaleur.tsx
+++ b/src/components/Map/layers/reseauxDeChaleur.tsx
@@ -3,7 +3,7 @@ import { type NetworkSummary } from '@/types/Summary/Network';
 import { isDefined } from '@/utils/core';
 import { prettyFormatNumber } from '@/utils/strings';
 
-import { ifHoverElse, type PopupStyleHelpers, type MapSourceLayersSpecification } from './common';
+import { ifHoverElse, type MapSourceLayersSpecification, type PopupStyleHelpers } from './common';
 import { buildFiltreGestionnaire, buildFiltreIdentifiantReseau, buildReseauxDeChaleurFilters } from './filters';
 
 export const reseauDeChaleurClasseColor = '#079067';

--- a/src/components/Map/layers/reseauxDeFroid.tsx
+++ b/src/components/Map/layers/reseauxDeFroid.tsx
@@ -3,7 +3,7 @@ import { type NetworkSummary } from '@/types/Summary/Network';
 import { isDefined } from '@/utils/core';
 import { prettyFormatNumber } from '@/utils/strings';
 
-import { ifHoverElse, type PopupStyleHelpers, type MapSourceLayersSpecification } from './common';
+import { ifHoverElse, type MapSourceLayersSpecification, type PopupStyleHelpers } from './common';
 import { buildFiltreGestionnaire, buildFiltreIdentifiantReseau } from './filters';
 
 export const reseauxDeFroidColor = '#0094FF';

--- a/src/components/Map/layers/reseauxEnConstruction.tsx
+++ b/src/components/Map/layers/reseauxEnConstruction.tsx
@@ -1,6 +1,6 @@
 import { type FuturNetworkSummary } from '@/types/Summary/FuturNetwork';
 
-import { ifHoverElse, type PopupStyleHelpers, type MapSourceLayersSpecification } from './common';
+import { ifHoverElse, type MapSourceLayersSpecification, type PopupStyleHelpers } from './common';
 import { buildFiltreGestionnaire } from './filters';
 
 export const reseauxEnConstructionColor = '#DA5DD5';

--- a/src/components/Map/layers/typeChauffageBatimentsCollectifs.tsx
+++ b/src/components/Map/layers/typeChauffageBatimentsCollectifs.tsx
@@ -7,7 +7,7 @@ import { deepMergeObjects } from '@/utils/core';
 import { formatTypeEnergieChauffage } from '@/utils/format';
 import { ObjectEntries } from '@/utils/typescript';
 
-import { ifHoverElse, intermediateTileLayersMinZoom, type PopupStyleHelpers, type MapSourceLayersSpecification } from './common';
+import { ifHoverElse, intermediateTileLayersMinZoom, type MapSourceLayersSpecification, type PopupStyleHelpers } from './common';
 import { type MapLayerSpecification } from '../map-layers';
 
 export const minIconSize = 12;

--- a/src/components/Map/layers/zonesPotentielChaud.tsx
+++ b/src/components/Map/layers/zonesPotentielChaud.tsx
@@ -1,7 +1,7 @@
 import { darken } from '@/utils/color';
 import { formatMWhAn, prettyFormatNumber } from '@/utils/strings';
 
-import { ifHoverElse, type PopupStyleHelpers, type MapSourceLayersSpecification } from './common';
+import { ifHoverElse, type MapSourceLayersSpecification, type PopupStyleHelpers } from './common';
 
 export const zonePotentielChaudColor = '#b0cc4e';
 export const zonePotentielFortChaudColor = '#448d60';

--- a/src/components/Map/map-events.tsx
+++ b/src/components/Map/map-events.tsx
@@ -4,10 +4,10 @@ import { explode } from '@turf/explode';
 import { lineString, point } from '@turf/helpers';
 import { nearestPoint } from '@turf/nearest-point';
 import { nearestPointOnLine } from '@turf/nearest-point-on-line';
-import { type GeometryCollection, type Point, type Position, type Geometry, type Feature } from 'geojson';
+import { type Feature, type Geometry, type GeometryCollection, type Point, type Position } from 'geojson';
 import { type MapGeoJSONFeature } from 'maplibre-gl';
 import { useEffect, useRef, useState } from 'react';
-import { Popup, type MapMouseEvent, type MapRef } from 'react-map-gl/maplibre';
+import { type MapMouseEvent, type MapRef, Popup } from 'react-map-gl/maplibre';
 
 import { isDevModeEnabled } from '@/hooks/useDevMode';
 import { type SourceId } from '@/server/services/tiles.config';

--- a/src/components/MarkdownWrapper/MarkdownWrapper.style.tsx
+++ b/src/components/MarkdownWrapper/MarkdownWrapper.style.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import styled, { css } from 'styled-components';
 
 import { legacyColors } from '@/components/ui/helpers/colors';
-import { type TrackingEvent, trackEvent } from '@/services/analytics';
+import { trackEvent, type TrackingEvent } from '@/services/analytics';
 
 export const isExternalLink = (href: string) => href && href.search(/(^http)|(^mailto)|(^\/documentation)/) >= 0;
 

--- a/src/components/MarkdownWrapper/MarkdownWrapper.tsx
+++ b/src/components/MarkdownWrapper/MarkdownWrapper.tsx
@@ -15,9 +15,10 @@ import {
   ButtonLink,
   Cartridge,
   CheckItem,
-  CountItem,
   CounterItem,
+  CountItem,
   ExtraLink,
+  isExternalLink,
   KnowMoreLink,
   MarkdownWrapperStyled,
   PuceIcon,
@@ -25,7 +26,6 @@ import {
   ThumbItem,
   WhiteArrowItem,
   WhiteCheckItem,
-  isExternalLink,
 } from './MarkdownWrapper.style';
 
 export const RoutedLink = (props: any) => {

--- a/src/components/NetworksList/NetworksList.tsx
+++ b/src/components/NetworksList/NetworksList.tsx
@@ -1,6 +1,6 @@
 import Button from '@codegouvfr/react-dsfr/Button';
 import Input from '@codegouvfr/react-dsfr/Input';
-import { type ColumnDefTemplate, type CellContext } from '@tanstack/react-table';
+import { type CellContext, type ColumnDefTemplate } from '@tanstack/react-table';
 import { useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import XLSX from 'xlsx';
@@ -19,7 +19,7 @@ import { gestionnairesFilters, useServices } from '@/services';
 import { type NetworkToCompare } from '@/types/Summary/Network';
 import { downloadFile } from '@/utils/browser';
 import { isDefined } from '@/utils/core';
-import { intervalsEqual, type Interval } from '@/utils/interval';
+import { type Interval, intervalsEqual } from '@/utils/interval';
 import { compareFrenchStrings } from '@/utils/strings';
 
 import NetworkName from './NetworkName';

--- a/src/components/Partners/Partners.tsx
+++ b/src/components/Partners/Partners.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useState } from 'react';
 
 import Box from '@/components/ui/Box';
 import Icon from '@/components/ui/Icon';
-import Section, { SectionSubtitle, SectionTitle, type SectionProps } from '@/components/ui/Section';
+import Section, { type SectionProps, SectionSubtitle, SectionTitle } from '@/components/ui/Section';
 import { partenaires } from '@/data/partenaires/partnerData';
 import { shuffleArray } from '@/utils/array';
 

--- a/src/components/SimulatorCO2/SimulatorCO2.tsx
+++ b/src/components/SimulatorCO2/SimulatorCO2.tsx
@@ -4,7 +4,7 @@ import { type ReactNode, useCallback, useMemo, useState } from 'react';
 import Box, { ResponsiveRow } from '@/components/ui/Box';
 import Text from '@/components/ui/Text';
 
-import { TypeEnergy, TypeSurf, dataEnergy, getConso, getEconomy, getEmissionCO2, getPercentGasReduct } from './SimulatorCO2.businessRule';
+import { dataEnergy, getConso, getEconomy, getEmissionCO2, getPercentGasReduct, TypeEnergy, TypeSurf } from './SimulatorCO2.businessRule';
 import { dataSimulator, dataSimulatorTertiaire } from './SimulatorCO2.data';
 import {
   BigResult,

--- a/src/components/Slice/index.ts
+++ b/src/components/Slice/index.ts
@@ -1,1 +1,1 @@
-export { SliceImg, default } from './Slice';
+export { default, SliceImg } from './Slice';

--- a/src/components/Theme/ThemeProvider.tsx
+++ b/src/components/Theme/ThemeProvider.tsx
@@ -4,7 +4,7 @@ import '@reach/combobox/styles.css';
 import { useLocalStorageValue } from '@react-hookz/web';
 import Link from 'next/link';
 import React from 'react';
-import { createGlobalStyle, ThemeProvider as StyledComponentsThemeProvider, StyleSheetManager } from 'styled-components';
+import { createGlobalStyle, StyleSheetManager, ThemeProvider as StyledComponentsThemeProvider } from 'styled-components';
 import { createEmotionSsrAdvancedApproach } from 'tss-react/next/pagesDir';
 
 import { MuiDsfrThemeProvider } from './MuiDsfrThemeProvider';

--- a/src/components/connexion/RegisterForm.tsx
+++ b/src/components/connexion/RegisterForm.tsx
@@ -11,7 +11,7 @@ import { toastErrors } from '@/services/notification';
 import { userRolesInscription } from '@/types/enum/UserRole';
 import { postFetchJSON } from '@/utils/network';
 import { upperCaseFirstChar } from '@/utils/strings';
-import { zCredentialsSchema, zIdentitySchema, type CredentialsSchema, type IdentitySchema } from '@/validation/user';
+import { type CredentialsSchema, type IdentitySchema, zCredentialsSchema, zIdentitySchema } from '@/validation/user';
 
 type FormStep = {
   label: string;

--- a/src/components/dashboard/professionnel/ProEligibilityTestItem.tsx
+++ b/src/components/dashboard/professionnel/ProEligibilityTestItem.tsx
@@ -1,9 +1,9 @@
 import Badge from '@codegouvfr/react-dsfr/Badge';
 import Tabs from '@codegouvfr/react-dsfr/Tabs';
 import { useQueryClient } from '@tanstack/react-query';
-import { type SortingState, type ColumnFiltersState } from '@tanstack/react-table';
+import { type ColumnFiltersState, type SortingState } from '@tanstack/react-table';
 import { useQueryState } from 'nuqs';
-import { useState, useMemo, useEffect, Fragment } from 'react';
+import { Fragment, useEffect, useMemo, useState } from 'react';
 
 import CompleteEligibilityTestForm from '@/components/dashboard/professionnel/eligibility-test/CompleteEligibilityTestForm';
 import RenameEligibilityTestForm from '@/components/dashboard/professionnel/eligibility-test/RenameEligibilityTestForm';
@@ -26,7 +26,7 @@ import { getProEligibilityTestAsXlsx } from '@/services/xlsx/test-adresses';
 import { downloadString } from '@/utils/browser';
 import { formatAsISODate, formatFrenchDate, formatFrenchDateTime } from '@/utils/date';
 import { compareFrenchStrings } from '@/utils/strings';
-import { ObjectEntries, type FlattenKeys } from '@/utils/typescript';
+import { type FlattenKeys, ObjectEntries } from '@/utils/typescript';
 
 const columns: ColumnDef<ProEligibilityTestWithAddresses['addresses'][number]>[] = [
   {

--- a/src/components/dashboard/professionnel/eligibility-test/RenameEligibilityTestForm.tsx
+++ b/src/components/dashboard/professionnel/eligibility-test/RenameEligibilityTestForm.tsx
@@ -3,7 +3,7 @@ import Button from '@/components/ui/Button';
 import { useModal } from '@/components/ui/ModalSimple';
 import { usePost } from '@/hooks/useApi';
 import { notify, toastErrors } from '@/services/notification';
-import { zRenameProEligibilityTestRequest, type RenameProEligibilityTestRequest } from '@/validation/pro-eligibility-test';
+import { type RenameProEligibilityTestRequest, zRenameProEligibilityTestRequest } from '@/validation/pro-eligibility-test';
 
 type RenameEligibilityTestFormProps = {
   testId: string;

--- a/src/components/dsfr/Header.tsx
+++ b/src/components/dsfr/Header.tsx
@@ -12,7 +12,7 @@ import { useTranslation as useSearchBarTranslation } from '@codegouvfr/react-dsf
 import { SearchButton } from '@codegouvfr/react-dsfr/SearchBar/SearchButton';
 import { cx } from '@codegouvfr/react-dsfr/tools/cx';
 import { setBrandTopAndHomeLinkProps } from '@codegouvfr/react-dsfr/zz_internal/brandTopAndHomeLinkProps';
-import { cloneElement, forwardRef, memo, type ComponentProps, type CSSProperties, type ReactNode } from 'react';
+import { cloneElement, type ComponentProps, type CSSProperties, forwardRef, memo, type ReactNode } from 'react';
 import type { Equals } from 'tsafe';
 import { assert } from 'tsafe/assert';
 import { symToStr } from 'tsafe/symToStr';

--- a/src/components/form/dsfr/Input.tsx
+++ b/src/components/form/dsfr/Input.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react';
 
-import { Input as StyledDSFRInput, type InputSize, type InputProps as InputPropsStyled } from './Input.styles';
+import { Input as StyledDSFRInput, type InputProps as InputPropsStyled, type InputSize } from './Input.styles';
 
 export type InputProps = InputPropsStyled & {
   size?: InputSize;

--- a/src/components/form/dsfr/PasswordInput.tsx
+++ b/src/components/form/dsfr/PasswordInput.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react';
 
-import { PasswordInput as StyledDSFRPasswordInput, type InputSize } from './Input.styles';
+import { type InputSize, PasswordInput as StyledDSFRPasswordInput } from './Input.styles';
 
 export type InputProps = React.ComponentProps<typeof StyledDSFRPasswordInput> & {
   size?: InputSize;

--- a/src/components/form/react-form/useForm.tsx
+++ b/src/components/form/react-form/useForm.tsx
@@ -1,10 +1,10 @@
 import { type SelectProps as DSFRSelectProps } from '@codegouvfr/react-dsfr/SelectNext';
 import {
-  useForm as useTanStackForm,
+  type AnyFieldApi,
+  type FormAsyncValidateOrFn,
   type FormOptions,
   type FormValidateOrFn,
-  type FormAsyncValidateOrFn,
-  type AnyFieldApi,
+  useForm as useTanStackForm,
   useStore,
 } from '@tanstack/react-form';
 import { useEffect } from 'react';

--- a/src/components/shared/page/SimplePage.tsx
+++ b/src/components/shared/page/SimplePage.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 
 import { FooterConsentManagementItem } from '@/components/ConsentBanner';
-import { HeaderQuickAccessItem, type HeaderProps } from '@/components/dsfr/Header';
+import { type HeaderProps, HeaderQuickAccessItem } from '@/components/dsfr/Header';
 import SEO, { type SEOProps } from '@/components/SEO';
 import Box from '@/components/ui/Box';
 import Link from '@/components/ui/Link';

--- a/src/components/ui/CheckableAccordion.tsx
+++ b/src/components/ui/CheckableAccordion.tsx
@@ -5,7 +5,7 @@
 
 import { fr } from '@codegouvfr/react-dsfr';
 import Checkbox, { type CheckboxProps } from '@codegouvfr/react-dsfr/Checkbox';
-import React, { forwardRef, memo, useEffect, useId, useRef, useState, type CSSProperties, type ReactNode } from 'react';
+import React, { type CSSProperties, forwardRef, memo, type ReactNode, useEffect, useId, useRef, useState } from 'react';
 import styled from 'styled-components';
 import type { Equals } from 'tsafe';
 import { assert } from 'tsafe/assert';

--- a/src/components/ui/Drawer.tsx
+++ b/src/components/ui/Drawer.tsx
@@ -1,5 +1,5 @@
 import { cva } from 'class-variance-authority';
-import { Drawer as DrawerVaul, type DialogProps } from 'vaul'; // Use vaul instead of @radix-ui/react-dialog because it does not do nice transitions
+import { type DialogProps, Drawer as DrawerVaul } from 'vaul'; // Use vaul instead of @radix-ui/react-dialog because it does not do nice transitions
 
 import cx from '@/utils/cx';
 

--- a/src/components/ui/Link.tsx
+++ b/src/components/ui/Link.tsx
@@ -1,7 +1,7 @@
 import NextLink from 'next/link';
 import { type PropsWithChildren } from 'react';
 
-import { type TrackingEvent, trackEvent } from '@/services/analytics';
+import { trackEvent, type TrackingEvent } from '@/services/analytics';
 
 import { type SpacingProperties, spacingsToClasses } from './helpers/spacings';
 

--- a/src/components/ui/ModalSimple.tsx
+++ b/src/components/ui/ModalSimple.tsx
@@ -1,4 +1,4 @@
-import { type PropsWithChildren, useCallback, useMemo, useState, createContext, useContext, type MouseEvent } from 'react';
+import { createContext, type MouseEvent, type PropsWithChildren, useCallback, useContext, useMemo, useState } from 'react';
 
 import Modal, { createModal } from './Modal';
 

--- a/src/components/ui/Table.tsx
+++ b/src/components/ui/Table.tsx
@@ -3,13 +3,13 @@ import { Pagination, type PaginationProps } from '@codegouvfr/react-dsfr/Paginat
 import LinearProgress from '@mui/material/LinearProgress';
 import {
   DataGrid,
-  gridPageCountSelector,
-  gridPaginationModelSelector,
-  useGridApiContext,
-  useGridSelector,
   type DataGridProps,
   type GridColDef,
+  gridPageCountSelector,
+  gridPaginationModelSelector,
   type GridValidRowModel,
+  useGridApiContext,
+  useGridSelector,
 } from '@mui/x-data-grid';
 
 import { ColHeader } from './Table.style';

--- a/src/components/ui/TableSimple.tsx
+++ b/src/components/ui/TableSimple.tsx
@@ -1,18 +1,18 @@
 import { fr } from '@codegouvfr/react-dsfr';
 import Input from '@codegouvfr/react-dsfr/Input';
 import {
+  type Cell,
+  type ColumnDef as ColumnDefOriginal,
+  type ColumnFiltersState,
+  type FilterFn,
   flexRender,
   getCoreRowModel,
   getFilteredRowModel,
   getSortedRowModel,
-  useReactTable,
-  type Cell,
-  type ColumnDef as ColumnDefOriginal,
-  type SortingFn,
-  type ColumnFiltersState,
   type RowData,
+  type SortingFn,
   type SortingState,
-  type FilterFn,
+  useReactTable,
 } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { cva } from 'class-variance-authority';

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Content, Portal, Provider, Root, Trigger, type TooltipContentProps } from '@radix-ui/react-tooltip';
+import { Content, Portal, Provider, Root, type TooltipContentProps, Trigger } from '@radix-ui/react-tooltip';
 import * as React from 'react';
 
 import Icon, { type IconProps } from '@/components/ui/Icon';

--- a/src/hooks/useReseauxDeChaleurFilters.tsx
+++ b/src/hooks/useReseauxDeChaleurFilters.tsx
@@ -3,7 +3,7 @@ import { parseAsJson, useQueryState } from 'nuqs';
 import { useEffect, useMemo, useState } from 'react';
 
 import { type ReseauxDeChaleurLimits } from '@/components/Map/layers/filters';
-import { defaultInterval, percentageMaxInterval, type FiltreEnergieConfKey } from '@/components/Map/map-configuration';
+import { defaultInterval, type FiltreEnergieConfKey, percentageMaxInterval } from '@/components/Map/map-configuration';
 import { deepMergeObjects, setProperty } from '@/utils/core';
 import { fetchJSON } from '@/utils/network';
 import { deepIntersection } from '@/utils/objects';

--- a/src/pages/admin/test-coordonnees-geographiques.tsx
+++ b/src/pages/admin/test-coordonnees-geographiques.tsx
@@ -1,5 +1,5 @@
 import Papa from 'papaparse';
-import { useState, type ChangeEvent } from 'react';
+import { type ChangeEvent, useState } from 'react';
 
 import Upload from '@/components/form/dsfr/Upload';
 import SimplePage from '@/components/shared/page/SimplePage';

--- a/src/pages/api/admin/impersonate.ts
+++ b/src/pages/api/admin/impersonate.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { type JWT, decode, encode } from 'next-auth/jwt';
+import { decode, encode, type JWT } from 'next-auth/jwt';
 import { z } from 'zod';
 
 import { logger } from '@/server/helpers/logger';

--- a/src/pages/api/contribution.ts
+++ b/src/pages/api/contribution.ts
@@ -1,7 +1,7 @@
 import formidable from 'formidable';
 import { z } from 'zod';
 
-import { riskyExtensions, filesLimits, zContributionFormData } from '@/components/ContributionForm/ContributionForm';
+import { filesLimits, riskyExtensions, zContributionFormData } from '@/components/ContributionForm/ContributionForm';
 import { AirtableDB } from '@/server/db/airtable';
 import { logger } from '@/server/helpers/logger';
 import { createRateLimiter } from '@/server/helpers/rate-limit';

--- a/src/pages/api/modification-reseau.ts
+++ b/src/pages/api/modification-reseau.ts
@@ -4,7 +4,7 @@ import formidable from 'formidable';
 import { z } from 'zod';
 
 import { clientConfig } from '@/client-config';
-import { uploadAttachment, AirtableDB } from '@/server/db/airtable';
+import { AirtableDB, uploadAttachment } from '@/server/db/airtable';
 import { logger } from '@/server/helpers/logger';
 import { createRateLimiter } from '@/server/helpers/rate-limit';
 import { handleRouteErrors, requirePostMethod, validateObjectSchema } from '@/server/helpers/server';

--- a/src/pages/pro/tests-adresses.tsx
+++ b/src/pages/pro/tests-adresses.tsx
@@ -1,4 +1,4 @@
-import { motion, AnimatePresence } from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
 import { useEffect, useState } from 'react';
 
 import CreateEligibilityTestForm from '@/components/dashboard/professionnel/eligibility-test/CreateEligibilityTestForm';

--- a/src/server/email/EmailInscription.tsx
+++ b/src/server/email/EmailInscription.tsx
@@ -1,6 +1,6 @@
 import { Text } from '@react-email/components';
 
-import { DSFRButton, EmailTemplate, type EmailProps } from './helpers';
+import { DSFRButton, type EmailProps, EmailTemplate } from './helpers';
 
 type EmailInscriptionProps = EmailProps<{
   activationToken: string;

--- a/src/server/email/helpers.tsx
+++ b/src/server/email/helpers.tsx
@@ -1,5 +1,5 @@
 import { Body, Button, Container, Head, Html, Img, Preview, Section } from '@react-email/components';
-import { type PropsWithChildren, type ComponentProps, type CSSProperties } from 'react';
+import { type ComponentProps, type CSSProperties, type PropsWithChildren } from 'react';
 
 export const commonEmailsProps = {
   websiteUrl: process.env.NEXT_PUBLIC_MAP_ORIGIN as string,

--- a/src/server/helpers/server.ts
+++ b/src/server/helpers/server.ts
@@ -3,7 +3,7 @@ import { HttpStatusCode } from 'axios';
 import { errors as formidableErrors } from 'formidable';
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
 import { type User } from 'next-auth';
-import { type ZodRawShape, z } from 'zod';
+import { z, type ZodRawShape } from 'zod';
 
 import { getServerSession } from '@/server/authentication';
 import { type UserRole } from '@/types/enum/UserRole';

--- a/src/server/services/jobs/pro_eligibility_test_jobs.ts
+++ b/src/server/services/jobs/pro_eligibility_test_jobs.ts
@@ -1,8 +1,8 @@
-import { sql, type Selectable } from 'kysely';
+import { type Selectable, sql } from 'kysely';
 import { limitFunction } from 'p-limit';
 import { type Logger } from 'winston';
 
-import { kdb, type Jobs } from '@/server/db/kysely';
+import { type Jobs, kdb } from '@/server/db/kysely';
 import { getEligilityStatus } from '@/server/services/addresseInformation';
 import { type APIAdresseResult, getAddressesCoordinates } from '@/server/services/api-adresse';
 import { chunk } from '@/utils/array';

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,4 +1,4 @@
-import z, { type ZodTypeAny, ZodObject, type ZodRawShape, ZodEffects } from 'zod';
+import z, { ZodEffects, ZodObject, type ZodRawShape, type ZodTypeAny } from 'zod';
 
 /**
  * Recursively unwraps ZodEffects to get the base schema.


### PR DESCRIPTION
Dernière étape pour avoir un formattage complètement automatique pour les imports, le tri se fait au niveau d'une ligne également désormais.