### PR TITLE
Gestionnaires valides

### DIFF
--- a/src/server/services/manager.ts
+++ b/src/server/services/manager.ts
@@ -134,10 +134,10 @@ export const getDemands = async (user: User): Promise<Demand[]> => {
   if (user.role === 'admin') {
     filterFormula = '';
   } else if (user.role === 'demo') {
-    filterFormula = `REGEX_MATCH({Gestionnaires}, "(\\A|, )Paris(\\z|, )")`;
+    filterFormula = `AND({Gestionnaires validés} = TRUE(), REGEX_MATCH({Gestionnaires}, "(\\A|, )Paris(\\z|, )"))`;
   } else if (user.role === 'gestionnaire') {
     const regexPattern = user.gestionnaires.join('|');
-    filterFormula = `REGEX_MATCH({Gestionnaires}, "(\\A|, )(${regexPattern})(\\z|, )")`;
+    filterFormula = `AND({Gestionnaires validés} = TRUE(), REGEX_MATCH({Gestionnaires}, "(\\A|, )(${regexPattern})(\\z|, )"))`;
   }
 
   const records = await base(Airtable.UTILISATEURS)


### PR DESCRIPTION
https://trello.com/c/zwAO2z2D/1486-ne-rendre-les-demandes-visibles-ds-lespace-gestionnaire-que-qd-la-case-gestionnaires-valid%C3%A9s-est-coch%C3%A9e-sur-airtable

la demande ne sera visible sur l’espace gestionnaire qu’une fois la case Gestionnaires validés cochée