### PR TITLE
Remplissage airtable date actualisation

### DIFF
--- a/scripts/networks/commands.ts
+++ b/scripts/networks/commands.ts
@@ -52,7 +52,7 @@ export function registerNetworkCommands(parentProgram: Command) {
     .argument('<fileName>', 'input file (format GeoJSON)')
     .argument('<id_fcu_or_sncu>', 'id_fcu ou SNCU du réseau')
     .action(async (type, fileName, id_fcu_or_sncu) => {
-      const isIdSNCU = id_fcu_or_sncu.endsWith('C');
+      const isIdSNCU = id_fcu_or_sncu.endsWith('C') || id_fcu_or_sncu.endsWith('F');
       const idField = isIdSNCU ? 'Identifiant reseau' : 'id_fcu';
       const idValue = isIdSNCU ? id_fcu_or_sncu : parseInt(id_fcu_or_sncu);
       const geometryConfig = await readFileGeometry(fileName);
@@ -65,7 +65,7 @@ export function registerNetworkCommands(parentProgram: Command) {
     .argument('<type>', "type d'entité", (v) => z.enum(entityTypes).parse(v))
     .argument('<id_fcu_or_sncu>', 'id_fcu ou SNCU du réseau')
     .action(async (type, id_fcu_or_sncu) => {
-      const isIdSNCU = id_fcu_or_sncu.endsWith('C');
+      const isIdSNCU = id_fcu_or_sncu.endsWith('C') || id_fcu_or_sncu.endsWith('F');
       const idField = isIdSNCU ? 'Identifiant reseau' : 'id_fcu';
       const idValue = isIdSNCU ? id_fcu_or_sncu : parseInt(id_fcu_or_sncu);
       await updateEntityWithoutGeometry(entityTypeToTable[type], idField, idValue);

--- a/scripts/networks/commands.ts
+++ b/scripts/networks/commands.ts
@@ -10,6 +10,7 @@ import {
   insertEntityWithGeometry,
   type NetworkTable,
   updateEntityGeometry,
+  updateEntityWithoutGeometry,
   updateNetworkHasPDP,
 } from './geometry-operations';
 
@@ -56,6 +57,18 @@ export function registerNetworkCommands(parentProgram: Command) {
       const idValue = isIdSNCU ? id_fcu_or_sncu : parseInt(id_fcu_or_sncu);
       const geometryConfig = await readFileGeometry(fileName);
       await updateEntityGeometry(entityTypeToTable[type], idField, idValue, geometryConfig);
+    });
+
+  program
+    .command('refresh-infos')
+    .description("Met à jour les informations d'une entité sans modifier sa géométrie (communes, départements, etc.)")
+    .argument('<type>', "type d'entité", (v) => z.enum(entityTypes).parse(v))
+    .argument('<id_fcu_or_sncu>', 'id_fcu ou SNCU du réseau')
+    .action(async (type, id_fcu_or_sncu) => {
+      const isIdSNCU = id_fcu_or_sncu.endsWith('C');
+      const idField = isIdSNCU ? 'Identifiant reseau' : 'id_fcu';
+      const idValue = isIdSNCU ? id_fcu_or_sncu : parseInt(id_fcu_or_sncu);
+      await updateEntityWithoutGeometry(entityTypeToTable[type], idField, idValue);
     });
 
   program

--- a/scripts/networks/download-network.ts
+++ b/scripts/networks/download-network.ts
@@ -28,6 +28,8 @@ const conversionConfigReseauxDeChaleur = {
   // id: TypeNumber,
   'Identifiant reseau': TypeString,
   //has_trace: TypeBool,
+  // date_actualisation_trace: TypeString,
+  // date_actualisation_pdp: TypeString,
   //'non ref 2022': TypeBool,
   'reseaux classes': TypeBool,
   has_PDP: TypeBool,
@@ -112,6 +114,7 @@ const conversionConfigReseauxDeFroid = {
   nom_reseau: TypeString,
   //'non ref 2022': TypeBool,
   //has_trace: TypeBool,
+  // date_actualisation_trace: TypeString,
   'Taux EnR&R': TypeNumber,
   Gestionnaire: TypeString,
   // communes: TypeStringToArray,
@@ -146,6 +149,7 @@ const conversionConfigReseauxDeFroid = {
 const conversionConfigAutres = {
   mise_en_service: TypeString,
   gestionnaire: TypeString,
+  // date_actualisation_trace: TypeString,
   // communes: TypeStringToArray,
   // is_zone: TypeBool,
 } as const;

--- a/scripts/networks/geometry-operations.ts
+++ b/scripts/networks/geometry-operations.ts
@@ -197,6 +197,24 @@ export async function updateEntityGeometry(
 }
 
 /**
+ * Met à jour les informations d'une entité sans modifier sa géométrie.
+ * Par exemple après avoir fait une opération manuelle pour fusionner des entités.
+ */
+export async function updateEntityWithoutGeometry(tableName: NetworkTable, idField: string, idValue: string | number): Promise<void> {
+  const existingEntity = await kdb
+    .selectFrom(tableName as any)
+    .select(sql<GeoJSON.Geometry>`ST_AsGeoJSON(geom)::json`.as('geom'))
+    .where(idField, '=', idValue)
+    .executeTakeFirst();
+
+  if (!existingEntity) {
+    throw new Error(`Aucune entité trouvée avec ${idField} = ${idValue}`);
+  }
+
+  await updateEntityGeometry(tableName, idField, idValue, { geom: existingEntity.geom, srid: 2154 });
+}
+
+/**
  * Crée un PDP à partir d'une commune
  */
 export async function createPDPFromCommune(code_insee: string, id_sncu?: string) {

--- a/scripts/networks/geometry-operations.ts
+++ b/scripts/networks/geometry-operations.ts
@@ -97,11 +97,10 @@ async function updateLabelsCommunesDepartementAndRegion(tableName: NetworkTable,
     .where('id_fcu', '=', id_fcu)
     .set({
       communes: sql<string[]>`(
-        SELECT DISTINCT ic.nom
+        SELECT array_agg(ic.nom ORDER BY ic.nom)
         FROM unnest(${sql.raw(tableName)}.communes_insee) as ci
         JOIN ign_communes ic ON ic.insee_com = ci
         WHERE ${sql.raw(tableName)}.id_fcu = ${id_fcu}
-        ORDER BY ic.nom
       )`,
       departement: sql<string>`(
         SELECT string_agg(DISTINCT id.nom, ', ' ORDER BY id.nom)

--- a/scripts/networks/geometry-updates.ts
+++ b/scripts/networks/geometry-updates.ts
@@ -3,6 +3,7 @@ import { createLogger, format, transports } from 'winston';
 
 import db from '@/server/db';
 import { AirtableDB, type AirtableTable } from '@/server/db/airtable';
+import { formatAsISODate } from '@/utils/date';
 
 import { type Type, TypeBool, TypeString } from './download-network';
 
@@ -67,7 +68,7 @@ export const tableConfigs: TableConfig[] = [
     tableCible: 'public.reseaux_de_chaleur',
     tableChangements: 'wip_traces.changements_reseaux_de_chaleur',
     tableChangementsSelectFields: ['id_sncu_new as id_sncu'],
-    pgToAirtableSyncAdditionalFields: ['has_PDP'],
+    pgToAirtableSyncAdditionalFields: ['has_PDP', 'date_actualisation_trace', 'date_actualisation_pdp'],
     postgres: {
       getCreateProps: (changement) => ({
         'Identifiant reseau': changement.id_sncu,
@@ -97,6 +98,8 @@ export const tableConfigs: TableConfig[] = [
         has_PDP: changement.has_PDP,
         departement: changement.departement,
         region: changement.region,
+        date_actualisation_trace: changement.date_actualisation_trace ? formatAsISODate(changement.date_actualisation_trace) : null,
+        date_actualisation_pdp: changement.date_actualisation_pdp ? formatAsISODate(changement.date_actualisation_pdp) : null,
       }),
       fieldsConversion: {
         id_fcu: TypeString,
@@ -105,6 +108,8 @@ export const tableConfigs: TableConfig[] = [
         departement: TypeString,
         region: TypeString,
         has_PDP: TypeBool,
+        date_actualisation_trace: TypeString,
+        date_actualisation_pdp: TypeString,
       },
     },
   },
@@ -112,6 +117,7 @@ export const tableConfigs: TableConfig[] = [
     tableCible: 'public.reseaux_de_froid',
     tableChangements: 'wip_traces.changements_reseaux_de_froid',
     tableChangementsSelectFields: ['id_sncu_new as id_sncu'],
+    pgToAirtableSyncAdditionalFields: ['date_actualisation_trace'],
     postgres: {
       getCreateProps: (changement) => ({
         'Identifiant reseau': changement.id_sncu,
@@ -141,6 +147,7 @@ export const tableConfigs: TableConfig[] = [
         communes: changement.ign_communes.join(','),
         departement: changement.departement,
         region: changement.region,
+        date_actualisation_trace: changement.date_actualisation_trace ? formatAsISODate(changement.date_actualisation_trace) : null,
       }),
       fieldsConversion: {
         id_fcu: TypeString,
@@ -148,6 +155,7 @@ export const tableConfigs: TableConfig[] = [
         communes: TypeString,
         departement: TypeString,
         region: TypeString,
+        date_actualisation_trace: TypeString,
       },
     },
   },
@@ -158,7 +166,7 @@ export const tableConfigs: TableConfig[] = [
   {
     tableCible: 'public.zones_et_reseaux_en_construction',
     tableChangements: 'wip_traces.changements_zones_et_reseaux_en_construction',
-    pgToAirtableSyncAdditionalFields: ['is_zone'],
+    pgToAirtableSyncAdditionalFields: ['is_zone', 'date_actualisation_trace'],
     postgres: {
       getCreateProps: (changement) => ({
         is_zone: !changement.is_line,
@@ -182,6 +190,7 @@ export const tableConfigs: TableConfig[] = [
         communes: changement.ign_communes.join(','),
         departement: changement.departement,
         region: changement.region,
+        date_actualisation_trace: changement.date_actualisation_trace ? formatAsISODate(changement.date_actualisation_trace) : null,
       }),
       fieldsConversion: {
         id_fcu: TypeString,
@@ -189,6 +198,7 @@ export const tableConfigs: TableConfig[] = [
         communes: TypeString,
         departement: TypeString,
         region: TypeString,
+        date_actualisation_trace: TypeString,
       },
     },
   },

--- a/src/components/Map/components/tools/LinearHeatDensityTool.tsx
+++ b/src/components/Map/components/tools/LinearHeatDensityTool.tsx
@@ -18,7 +18,7 @@ import { type PointDeConsommation } from '@/pages/api/linear-heat-density';
 import { useServices } from '@/services';
 import { trackEvent } from '@/services/analytics';
 import { downloadObject } from '@/utils/browser';
-import { formatAsISODate } from '@/utils/date';
+import { formatAsISODateMinutes } from '@/utils/date';
 import { formatDistance } from '@/utils/geo';
 
 import { type MeasureFeature, type MeasureLabelFeature } from './measure';
@@ -240,7 +240,7 @@ const LinearHeatDensityTool: React.FC = () => {
         type: 'FeatureCollection',
         features,
       },
-      `FCU_export_tracé_${formatAsISODate(new Date())}.geojson`,
+      `FCU_export_tracé_${formatAsISODateMinutes(new Date())}.geojson`,
       'application/geo+json'
     );
     trackEvent('Carto|Densité thermique linéaire|Exporter le tracé');

--- a/src/components/dashboard/professionnel/ProEligibilityTestItem.tsx
+++ b/src/components/dashboard/professionnel/ProEligibilityTestItem.tsx
@@ -25,7 +25,7 @@ import { type ProEligibilityTestWithAddresses } from '@/pages/api/pro-eligibilit
 import { notify, toastErrors } from '@/services/notification';
 import { getProEligibilityTestAsXlsx } from '@/services/xlsx/test-adresses';
 import { downloadString } from '@/utils/browser';
-import { formatAsISODate, formatFrenchDate, formatFrenchDateTime } from '@/utils/date';
+import { formatAsISODateMinutes, formatFrenchDate, formatFrenchDateTime } from '@/utils/date';
 import { compareFrenchStrings } from '@/utils/strings';
 import { type FlattenKeys, ObjectEntries } from '@/utils/typescript';
 
@@ -412,7 +412,7 @@ function ProEligibilityTestItem({ test }: ProEligibilityTestItemProps) {
 
     downloadString(
       xlsx,
-      `fcu-${test.name}-adresses-${formatAsISODate(new Date())}.xlsx`,
+      `fcu-${test.name}-adresses-${formatAsISODateMinutes(new Date())}.xlsx`,
       'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
     );
   });

--- a/src/server/db/kysely/database.ts
+++ b/src/server/db/kysely/database.ts
@@ -3027,6 +3027,8 @@ export interface ReseauxDeChaleur {
   contenu_CO2_2023_tmp: number | null;
   contenu_CO2_ACV_2023_tmp: number | null;
   CP_MO: string | null;
+  date_actualisation_pdp: Timestamp | null;
+  date_actualisation_trace: Timestamp | null;
   departement: string | null;
   'Dev_reseau%': number | null;
   eau_chaude: string | null;
@@ -3124,6 +3126,7 @@ export interface ReseauxDeFroid {
   contenu_CO2_2023_tmp: number | null;
   contenu_CO2_ACV_2023_tmp: number | null;
   CP_MO: string | null;
+  date_actualisation_trace: Timestamp | null;
   departement: string | null;
   fichiers: Json | null;
   geom: string | null;
@@ -3249,6 +3252,7 @@ export interface ZoneAPotentielFortChaudTiles {
 export interface ZoneDeDeveloppementPrioritaire {
   communes: string[] | null;
   communes_insee: string[] | null;
+  date_actualisation_trace: Timestamp | null;
   departement: string | null;
   geom: string | null;
   id_fcu: number;
@@ -3266,6 +3270,7 @@ export interface ZoneDeDeveloppementPrioritaireTiles {
 export interface ZonesEtReseauxEnConstruction {
   communes: string[] | null;
   communes_insee: string[] | null;
+  date_actualisation_trace: Timestamp | null;
   departement: string | null;
   geom: string;
   gestionnaire: string | null;

--- a/src/server/db/migrations/20250327000005_add_networks_date_actualisation.ts
+++ b/src/server/db/migrations/20250327000005_add_networks_date_actualisation.ts
@@ -3,12 +3,12 @@ import { type Knex } from 'knex';
 export async function up(knex: Knex): Promise<void> {
   // ces champs seront mis à jour dès qu'une géométrie est mise à jour.
   await knex.raw(`
-    ALTER TABLE public.reseaux_de_chaleur ADD COLUMN date_actualisation_trace timestamptz;
-    ALTER TABLE public.reseaux_de_froid ADD COLUMN date_actualisation_trace timestamptz;
-    ALTER TABLE public.zone_de_developpement_prioritaire ADD COLUMN date_actualisation_trace timestamptz;
-    ALTER TABLE public.zones_et_reseaux_en_construction ADD COLUMN date_actualisation_trace timestamptz;
+    ALTER TABLE public.reseaux_de_chaleur ADD COLUMN IF NOT EXISTS date_actualisation_trace timestamptz;
+    ALTER TABLE public.reseaux_de_froid ADD COLUMN IF NOT EXISTS date_actualisation_trace timestamptz;
+    ALTER TABLE public.zone_de_developpement_prioritaire ADD COLUMN IF NOT EXISTS date_actualisation_trace timestamptz;
+    ALTER TABLE public.zones_et_reseaux_en_construction ADD COLUMN IF NOT EXISTS date_actualisation_trace timestamptz;
 
-    ALTER TABLE public.reseaux_de_chaleur ADD COLUMN date_actualisation_pdp timestamptz;
+    ALTER TABLE public.reseaux_de_chaleur ADD COLUMN IF NOT EXISTS date_actualisation_pdp timestamptz;
   `);
 }
 

--- a/src/server/db/migrations/20250327000005_add_networks_date_actualisation.ts
+++ b/src/server/db/migrations/20250327000005_add_networks_date_actualisation.ts
@@ -1,0 +1,15 @@
+import { type Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  // ces champs seront mis à jour dès qu'une géométrie est mise à jour.
+  await knex.raw(`
+    ALTER TABLE public.reseaux_de_chaleur ADD COLUMN date_actualisation_trace timestamptz;
+    ALTER TABLE public.reseaux_de_froid ADD COLUMN date_actualisation_trace timestamptz;
+    ALTER TABLE public.zone_de_developpement_prioritaire ADD COLUMN date_actualisation_trace timestamptz;
+    ALTER TABLE public.zones_et_reseaux_en_construction ADD COLUMN date_actualisation_trace timestamptz;
+
+    ALTER TABLE public.reseaux_de_chaleur ADD COLUMN date_actualisation_pdp timestamptz;
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {} // eslint-disable-line

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -2,8 +2,16 @@
  * Formatte une date en string au format ISO jusqu'à la minute.
  * Exemple : 2024-01-25T16:48
  */
-export function formatAsISODate(date: Date): string {
+export function formatAsISODateMinutes(date: Date): string {
   return date.toISOString().slice(0, 16);
+}
+
+/**
+ * Formatte une date en string au format ISO uniquement pour la date.
+ * Exemple : 2024-01-25
+ */
+export function formatAsISODate(date: Date): string {
+  return date.toISOString().slice(0, 10);
 }
 
 /**


### PR DESCRIPTION
- La suite + un fix de #1040
- L'idée est d'ajouter un champ date qui sera mis à jour quand on modifie la géométrie (ou on considède que le tracé est à jour).
- Encore une fois, ça va être un peu chiant pour ces histoires de migration car je dois changer des colonnes, or les migrations ne sont pas appliquées sur les review app et je vais devoir copier / dumper les données sur dev pour faire review par Florence...