### PR TITLE
Permettre de réenvoyer un lien de confirmation d'email

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -50,5 +50,12 @@ allowed_patterns:
 - pass
 - (?i).*key.*
 - PasswordInput
+- passwordService\.changePassword
+- await\s+passwordService\.changePassword
+- value\.password
+- await\s+\w+Service\.changePassword
+- "changePassword"
+- "token"
+- "value"
 - (?i)https:\/\/airtable\.com\/app9opX8gRAtBqkan.* # Links to airtable in docs
 version: "1.0"

--- a/.talismanrc
+++ b/.talismanrc
@@ -57,5 +57,6 @@ allowed_patterns:
 - "changePassword"
 - "token"
 - "value"
+- resetPasswordSchema
 - (?i)https:\/\/airtable\.com\/app9opX8gRAtBqkan.* # Links to airtable in docs
 version: "1.0"

--- a/src/components/connexion/Form.styles.ts
+++ b/src/components/connexion/Form.styles.ts
@@ -1,4 +1,3 @@
-import { Alert } from '@codegouvfr/react-dsfr/Alert';
 import styled from 'styled-components';
 
 export const Container = styled.form<{ fullWidth?: boolean }>`
@@ -8,26 +7,4 @@ export const Container = styled.form<{ fullWidth?: boolean }>`
   button {
     margin: auto;
   }
-`;
-
-export const PasswordInput = styled.div`
-  position: relative;
-`;
-
-export const PasswordIcon = styled.div`
-  cursor: pointer;
-  bottom: 9px;
-  position: absolute;
-  right: 9px;
-`;
-
-export const Password = styled.div`
-  margin-top: -16px;
-  margin-bottom: 16px;
-  text-align: right;
-  font-size: 12px;
-`;
-
-export const PasswordAlert = styled(Alert)`
-  margin-bottom: 16px;
 `;

--- a/src/components/connexion/ResetPasswordForm.tsx
+++ b/src/components/connexion/ResetPasswordForm.tsx
@@ -1,55 +1,51 @@
-import { Alert } from '@codegouvfr/react-dsfr/Alert';
-import { Button } from '@codegouvfr/react-dsfr/Button';
-import { type FormEvent, useState } from 'react';
+import React from 'react';
+import { z } from 'zod';
 
-import Input from '@/components/form/dsfr/Input';
+import useForm from '@/components/form/react-form/useForm';
+import CenterLayout from '@/components/shared/page/CenterLayout';
+import Alert from '@/components/ui/Alert';
+import Heading from '@/components/ui/Heading';
 import { useServices } from '@/services';
-
-import { Container } from './Form.styles';
+import { toastErrors } from '@/services/notification';
+const resetPasswordSchema = z.object({
+  email: z.string().email('Veuillez entrer une adresse email valide'),
+});
 
 const ResetPasswordForm = () => {
   const { passwordService } = useServices();
+  const [success, setSuccess] = React.useState(false);
 
-  const [email, setEmail] = useState('');
-  const [success, setSuccess] = useState(false);
+  const { Form, EmailInput, Submit } = useForm({
+    schema: resetPasswordSchema,
+    onSubmit: toastErrors(async ({ value }) => {
+      await passwordService.resetPassword(value.email);
+      setSuccess(true);
+    }),
+  });
 
-  const reset = (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setSuccess(false);
-    passwordService.resetPassword(email).then(() => setSuccess(true));
-  };
+  if (success) {
+    return (
+      <Alert variant="success" className="max-w-lg mx-auto my-12">
+        Un email pour réinitialiser votre mot de passe vous a été envoyé, pensez à vérifier vos spams. Si vous ne recevez pas de mail de
+        réinitialisation, merci de nous contacter :{' '}
+        <a href="mailto:france-chaleur-urbaine@developpement-durable.gouv.fr" target="_blank" rel="noopener noreferrer">
+          france-chaleur-urbaine@developpement-durable.gouv.fr
+        </a>
+        .
+      </Alert>
+    );
+  }
 
   return (
-    <Container onSubmit={reset} fullWidth={success}>
-      {success ? (
-        <Alert
-          severity="success"
-          title={
-            <>
-              Un email pour réinitialiser votre mot de passe vous a été envoyé, pensez à vérifier vos spams. Si vous ne recevez pas de mail
-              de réinitialisation, merci de nous contacter :{' '}
-              <a href="mailto:france-chaleur-urbaine@developpement-durable.gouv.fr" target="_blank" rel="noopener noreferrer">
-                france-chaleur-urbaine@developpement-durable.gouv.fr
-              </a>
-              .
-            </>
-          }
-        />
-      ) : (
-        <>
-          <Input
-            label="Votre email :"
-            nativeInputProps={{
-              required: true,
-              type: 'email',
-              value: email,
-              onChange: (e) => setEmail(e.target.value),
-            }}
-          />
-          <Button type="submit">Réinitialiser</Button>
-        </>
-      )}
-    </Container>
+    <CenterLayout maxWidth="500px">
+      <Heading as="h1" size="h2">
+        Réinitialisation du mot de passe
+      </Heading>
+      <Form>
+        <EmailInput name="email" label="Votre email :" />
+        <Submit>Réinitialiser</Submit>
+      </Form>
+    </CenterLayout>
   );
 };
 


### PR DESCRIPTION
Si jamais quelqu’un se crée un compte, mais ne clique pas sur le lien de confirmation envoyé par email, alors il ne pourra jamais se connecter, car son compte existe mais n’est pas validé.

J’ai pris le parti d’utiliser l’ecran de rinitialisation du mot de passe

En effet, celui-ci envoie déjà un lien par email qui doit être cliqué, on est donc sur, quend l’utilisateur recrée un nouveau mot de passe, qu’il a le bon email et donc on l’active

J'en ai profité pour utiliser `useForm` pour supprimer un peu de code legacy