### PR TITLE
Envoi des emails à la création des demandes

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dev": "next dev --turbo",
     "scan": "pnpm dev & npx react-scan@latest localhost:3000",
     "dev:webpack": "next dev",
-    "dev:email": "email dev --dir src/server/email/react-email/templates",
+    "dev:email": "NODE_ENV=test email dev --dir src/server/email/react-email/templates",
     "build": "NODE_OPTIONS=\"--max-old-space-size=8192\" next build",
     "build:analyze": "ANALYZE=true pnpm build",
     "deadcode": "npx knip",

--- a/src/pages/api/airtable/records/index.ts
+++ b/src/pages/api/airtable/records/index.ts
@@ -75,7 +75,7 @@ export default handleRouteErrors(async function PostRecords(req: NextApiRequest)
         { typecast: true }
       );
 
-      await sendEmailTemplate('creation-demande', { id: 'unknown', email: values.Mail }, { demand: values });
+      await sendEmailTemplate('creation-demande', { email: values.Mail }, { demand: values });
       return { id: demandId };
     }
 

--- a/src/pages/api/airtable/records/index.ts
+++ b/src/pages/api/airtable/records/index.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest } from 'next';
 import { v4 as uuidv4 } from 'uuid';
 
 import base, { AirtableDB } from '@/server/db/airtable';
+import { sendEmailTemplate } from '@/server/email';
 import { logger } from '@/server/helpers/logger';
 import { BadRequestError, handleRouteErrors, requirePostMethod } from '@/server/helpers/server';
 import { getConso, getNbLogement } from '@/server/services/addresseInformation';
@@ -73,6 +74,8 @@ export default handleRouteErrors(async function PostRecords(req: NextApiRequest)
         },
         { typecast: true }
       );
+
+      await sendEmailTemplate('creation-demande', { id: 'unknown', email: values.Mail }, { demand: values });
       return { id: demandId };
     }
 

--- a/src/server/email/index.tsx
+++ b/src/server/email/index.tsx
@@ -1,11 +1,10 @@
 import nodemailer from 'nodemailer';
 
 import { logger } from '@/server/helpers/logger';
-import { type User } from '@/types/User';
 
 import { type EmailType, renderEmail } from './react-email';
 
-type EmailUser = Pick<User, 'id' | 'email'>;
+type EmailUser = { id?: string; email: string };
 
 type EmailParams = Parameters<typeof mailTransport.sendMail>[0];
 

--- a/src/server/email/react-email/index.tsx
+++ b/src/server/email/react-email/index.tsx
@@ -1,6 +1,8 @@
 import { render } from '@react-email/components';
 import React from 'react';
 
+import CreationDemandeEmail from '@/server/email/react-email/templates/creation-demande';
+
 import ActivationEmail from './templates/activation';
 import InscriptionEmail from './templates/inscription';
 import ManagerEmail from './templates/manager-email';
@@ -44,6 +46,11 @@ export const emails = {
     subject: '[France Chaleur Urbaine] Votre demande',
     preview: 'Mise à jour importante concernant votre demande de raccordement',
     Component: RelanceEmail,
+  },
+  'creation-demande': {
+    subject: '[France Chaleur Urbaine] Votre demande de contact',
+    preview: 'Votre demande de contact',
+    Component: CreationDemandeEmail,
   },
 } as const;
 

--- a/src/server/email/react-email/templates/creation-demande.tsx
+++ b/src/server/email/react-email/templates/creation-demande.tsx
@@ -111,7 +111,7 @@ const CreationDemandeEmail = ({ demand }: CreationDemandeEmailProps) => {
         </>
       )}
 
-      {(demand.Structure === 'Tertiaire' || demand.Structure === 'Bailleur social') && (
+      {(demand.Structure === 'Tertiaire' || demand.Structure === 'Bailleur social' || demand.Structure === 'Autre') && (
         <>
           {demand['Type de chauffage'] === 'Collectif' &&
             (demand['Distance au réseau'] < distanceThreshold ? (

--- a/src/server/email/react-email/templates/creation-demande.tsx
+++ b/src/server/email/react-email/templates/creation-demande.tsx
@@ -19,7 +19,7 @@ const CreationDemandeEmail = ({ demand }: CreationDemandeEmailProps) => {
   const intermediateDistanceThreshold = demand['Departement'] === 'Paris' ? 100 : 200;
   return (
     <Layout>
-      {process.env.NODE_ENV === 'test' && <pre>Paramètres : {JSON.stringify(demand, null, 2)}</pre>}
+      {process.env.NODE_ENV === 'test' && <pre>Paramètres (affiché seulement sur mailpit) : {JSON.stringify(demand, null, 2)}</pre>}
       <Text>Bonjour,</Text>
       <Text>
         Nous vous remercions pour votre demande de contact sur <Link href={clientConfig.websiteOrigin}>France Chaleur Urbaine</Link> pour le{' '}

--- a/src/server/email/react-email/templates/creation-demande.tsx
+++ b/src/server/email/react-email/templates/creation-demande.tsx
@@ -1,0 +1,200 @@
+import * as React from 'react';
+
+import { clientConfig } from '@/client-config';
+import { type formatHeatingTypeToAirtable } from '@/services/airtable';
+import { type AvailableStructure } from '@/types/AddressData';
+import { type Demand } from '@/types/Summary/Demand';
+
+import { Layout, Link, Text } from '../components';
+
+type CreationDemandeEmailProps = {
+  demand: Pick<Demand, 'Adresse' | 'Distance au réseau' | 'Structure' | 'Departement'> & {
+    Structure: AvailableStructure;
+    'Type de chauffage': ReturnType<typeof formatHeatingTypeToAirtable>;
+  };
+};
+
+const CreationDemandeEmail = ({ demand }: CreationDemandeEmailProps) => {
+  const distanceThreshold = demand['Departement'] === 'Paris' ? 60 : 100;
+  const intermediateDistanceThreshold = demand['Departement'] === 'Paris' ? 100 : 200;
+  return (
+    <Layout>
+      {process.env.NODE_ENV === 'test' && <pre>Paramètres : {JSON.stringify(demand, null, 2)}</pre>}
+      <Text>Bonjour,</Text>
+      <Text>
+        Nous vous remercions pour votre demande de contact sur <Link href={clientConfig.websiteOrigin}>France Chaleur Urbaine</Link> pour le{' '}
+        {demand.Adresse}.
+      </Text>
+
+      {demand.Structure === 'Copropriété' && (
+        <>
+          {demand['Type de chauffage'] === 'Collectif' &&
+            (demand['Distance au réseau'] < distanceThreshold ? (
+              <>
+                <Text>
+                  Votre copropriété est située à proximité d’un réseau de chaleur (moins de {distanceThreshold} m). De plus, au vu de votre
+                  mode de chauffage actuel, votre immeuble dispose déjà d’un réseau de distribution interne et d’équipements adaptés au sein
+                  des logements : il s’agit du cas le plus favorable pour un raccordement.
+                </Text>
+                <Text>
+                  Nous transmettons donc votre demande de raccordement au gestionnaire du réseau le plus proche afin qu’il puisse confirmer
+                  la faisabilité technique du raccordement, et vous fournir une première estimation financière. Il sera en charge de vous
+                  recontacter.
+                </Text>
+                <Text>
+                  Sans attendre, nous vous invitons à{' '}
+                  <Link href={`${clientConfig.websiteOrigin}/documentation/guide-france-chaleur-urbaine.pdf`}>télécharger notre guide</Link>
+                  , qui récapitule les grandes étapes pour se raccorder à un réseau de chaleur, ainsi que les principales aides financières
+                  disponibles.
+                </Text>
+              </>
+            ) : demand['Distance au réseau'] < intermediateDistanceThreshold ? (
+              <>
+                <Text>
+                  Votre copropriété n'est pas à proximité immédiate d'un réseau de chaleur. Cependant, elle reste suffisamment proche pour
+                  qu'un raccordement soit potentiellement envisageable, mais seul le gestionnaire du réseau pourra vous confirmer la
+                  faisabilité technique du raccordement (en fonction de la taille de votre copropriété, de sa consommation d'énergie, des
+                  autres bâtiments raccordables à proximité,...), et vous fournir une première estimation financière.
+                </Text>
+                <Text>
+                  Nous transmettons votre demande au gestionnaire du réseau de chaleur le plus proche de votre adresse, qui sera en charge
+                  de vous recontacter.
+                </Text>
+              </>
+            ) : (
+              <>
+                <Text>Malheureusement, il n'existe pas de réseau de chaleur à proximité de votre bâtiment à ce jour.</Text>
+                <Text>
+                  Votre demande permettra tout de même à votre commune ou au gestionnaire du réseau le plus proche de prendre connaissance
+                  de votre intérêt pour ce mode de chauffage. Vous pourrez ainsi être recontacté(e) s'il existe des projets de développement
+                  de réseaux dans votre quartier.
+                </Text>
+                <Text>
+                  L’amélioration de l’isolation thermique de votre immeuble constitue un autre levier pour réduire votre facture énergétique
+                  et limiter votre impact écologique. Pour être accompagné dans vos projets de rénovation énergétique, rendez-vous sur{' '}
+                  <Link href="https://france-renov.gouv.fr/">France Rénov</Link>.
+                </Text>
+              </>
+            ))}
+
+          {demand['Type de chauffage'] === 'Individuel' &&
+            (demand['Distance au réseau'] < intermediateDistanceThreshold ? (
+              <>
+                <Text>
+                  Votre copropriété se situe à proximité d'un réseau de chaleur. Cependant, au vu de votre mode de chauffage actuel, des
+                  travaux conséquents et coûteux seraient nécessaires pour le développement d'un réseau interne de chauffage dans votre
+                  immeuble, indispensable dans le cas d'un raccordement à un réseau de chaleur.
+                </Text>
+                <Text>
+                  Nous transmettons tout de même votre demande de raccordement au gestionnaire du réseau le plus proche afin qu’il puisse
+                  prendre connaissance de votre intérêt pour un raccordement.
+                </Text>
+              </>
+            ) : (
+              <>
+                <Text>
+                  Malheureusement, il n'existe pas de réseau de chaleur à proximité de votre bâtiment à ce jour. De plus, au vu de votre
+                  mode de chauffage actuel, même en présence d’un réseau de chaleur à proximité, des travaux conséquents et coûteux seraient
+                  nécessaires au sein de votre immeuble pour la mise en place d’un réseau de distribution interne de la chaleur.
+                </Text>
+                <Text>
+                  Votre demande permettra tout de même à votre commune ou au gestionnaire du réseau le plus proche de prendre connaissance
+                  de votre intérêt pour ce mode de chauffage.
+                </Text>
+                <Text>
+                  L’amélioration de l’isolation thermique de votre immeuble constitue un autre levier pour réduire votre facture énergétique
+                  et limiter votre impact écologique. Pour être accompagné dans vos projets de rénovation énergétique, rendez-vous sur{' '}
+                  <Link href="https://france-renov.gouv.fr/">France Rénov</Link>.
+                </Text>
+              </>
+            ))}
+        </>
+      )}
+
+      {demand.Structure === 'Tertiaire' && (
+        <>
+          {demand['Type de chauffage'] === 'Collectif' &&
+            (demand['Distance au réseau'] < distanceThreshold ? (
+              <>
+                <Text>
+                  Votre adresse est située à proximité d’un réseau de chaleur (moins de {distanceThreshold} m). De plus, au vu de votre mode
+                  de chauffage actuel, votre immeuble dispose déjà d’équipements adaptés, notamment d’un réseau de distribution interne : il
+                  s’agit du cas le plus favorable pour un raccordement.
+                </Text>
+                <Text>
+                  Nous transmettons donc votre demande de raccordement au gestionnaire du réseau le plus proche afin qu’il puisse confirmer
+                  la faisabilité technique du raccordement, et vous fournir une première estimation financière. Il sera en charge de vous
+                  recontacter.
+                </Text>
+              </>
+            ) : demand['Distance au réseau'] < intermediateDistanceThreshold ? (
+              <>
+                <Text>
+                  Votre bâtiment n'est pas à proximité immédiate d'un réseau de chaleur. Cependant, il reste suffisamment proche pour qu'un
+                  raccordement soit potentiellement envisageable, mais seul le gestionnaire du réseau pourra vous confirmer la faisabilité
+                  technique du raccordement et vous fournir une première estimation financière.
+                </Text>
+                <Text>
+                  Nous transmettons donc votre demande au gestionnaire du réseau de chaleur le plus proche de votre adresse, qui sera en
+                  charge de vous recontacter.
+                </Text>
+              </>
+            ) : (
+              <>
+                <Text>Malheureusement, il n'existe pas de réseau de chaleur à proximité de votre bâtiment à ce jour.</Text>
+                <Text>
+                  Votre demande permettra tout de même à votre commune ou au gestionnaire du réseau le plus proche de prendre connaissance
+                  de votre intérêt pour ce mode de chauffage. Vous pourrez ainsi être recontacté(e) s'il existe des projets de développement
+                  de réseaux dans votre quartier.
+                </Text>
+                <Text>
+                  L’amélioration de l’isolation thermique de votre immeuble constitue un autre levier pour réduire votre facture énergétique
+                  et limiter votre impact écologique.
+                </Text>
+              </>
+            ))}
+
+          {demand['Type de chauffage'] === 'Individuel' &&
+            (demand['Distance au réseau'] < intermediateDistanceThreshold ? (
+              <>
+                <Text>
+                  Votre bâtiment se situe à proximité d'un réseau de chaleur. Cependant, au vu de votre mode de chauffage actuel, des
+                  travaux conséquents et coûteux seraient nécessaires pour le développement d'un réseau interne de chauffage dans votre
+                  immeuble, indispensable dans le cas d'un raccordement à un réseau de chaleur.
+                </Text>
+                <Text>
+                  Nous transmettons tout de même votre demande de raccordement au gestionnaire du réseau le plus proche afin qu’il puisse
+                  prendre connaissance de votre intérêt pour un raccordement.
+                </Text>
+                <Text>
+                  L’amélioration de l’isolation thermique constitue un autre levier pour réduire votre facture énergétique et limiter votre
+                  impact écologique.
+                </Text>
+              </>
+            ) : (
+              <>
+                <Text>
+                  Malheureusement, il n'existe pas de réseau de chaleur à proximité de votre bâtiment à ce jour. De plus, au vu de votre
+                  mode de chauffage actuel, même en présence d’un réseau de chaleur à proximité, des travaux conséquents et coûteux seraient
+                  nécessaires au sein de votre immeuble pour la mise en place d’un réseau de distribution interne de la chaleur.
+                </Text>
+                <Text>
+                  Votre demande permettra tout de même à votre commune ou au gestionnaire du réseau le plus proche de prendre connaissance
+                  de votre intérêt pour ce mode de chauffage.
+                </Text>
+                <Text>
+                  L’amélioration de l’isolation thermique constitue un autre levier pour réduire votre facture énergétique et limiter votre
+                  impact écologique.
+                </Text>
+              </>
+            ))}
+        </>
+      )}
+
+      <Text>Bien cordialement,</Text>
+      <Text>L'équipe France Chaleur Urbaine</Text>
+    </Layout>
+  );
+};
+
+export default CreationDemandeEmail;

--- a/src/server/email/react-email/templates/creation-demande.tsx
+++ b/src/server/email/react-email/templates/creation-demande.tsx
@@ -111,7 +111,7 @@ const CreationDemandeEmail = ({ demand }: CreationDemandeEmailProps) => {
         </>
       )}
 
-      {demand.Structure === 'Tertiaire' && (
+      {(demand.Structure === 'Tertiaire' || demand.Structure === 'Bailleur social') && (
         <>
           {demand['Type de chauffage'] === 'Collectif' &&
             (demand['Distance au réseau'] < distanceThreshold ? (
@@ -188,6 +188,36 @@ const CreationDemandeEmail = ({ demand }: CreationDemandeEmailProps) => {
                 </Text>
               </>
             ))}
+        </>
+      )}
+
+      {demand.Structure === 'Maison individuelle' && (
+        <>
+          {demand['Distance au réseau'] < intermediateDistanceThreshold ? (
+            <>
+              <Text>
+                Votre adresse se situe à proximité d'un réseau de chaleur. Cependant, le raccordement des maisons individuelles aux réseaux
+                de chaleur reste rare à ce jour, pour des raisons techniques et économiques. Nous transmettons tout de même votre demande au
+                gestionnaire du réseau, mais il est probable qu'il ne puisse y donner suite.
+              </Text>
+            </>
+          ) : (
+            <>
+              <Text>
+                Malheureusement, il n'existe pas de réseau de chaleur à proximité de votre adresse à ce jour. De plus, le raccordement des
+                maisons individuelles aux réseaux de chaleur reste rare aujourd'hui, pour des raisons techniques et économiques.
+              </Text>
+              <Text>
+                Votre demande permettra tout de même à votre commune ou au gestionnaire du réseau le plus proche de prendre connaissance de
+                votre intérêt pour ce mode de chauffage.
+              </Text>
+            </>
+          )}
+          <Text>
+            L’amélioration de l’isolation thermique de votre maison constitue un autre levier pour réduire votre facture énergétique et
+            limiter votre impact écologique. Pour être accompagné dans vos projets de rénovation énergétique,, rendez-vous sur{' '}
+            <Link href="https://france-renov.gouv.fr/">France Rénov</Link>.
+          </Text>
         </>
       )}
 

--- a/src/server/email/react-email/templates/tests/creation-demande_copropriete_collectif_inf100m.tsx
+++ b/src/server/email/react-email/templates/tests/creation-demande_copropriete_collectif_inf100m.tsx
@@ -1,0 +1,17 @@
+import CreationDemandeEmail from '@/server/email/react-email/templates/creation-demande';
+
+const CreationDemandeEmailDebug = () => {
+  return (
+    <CreationDemandeEmail
+      demand={{
+        Adresse: '123 Rue de la Paix, 75000 Paris',
+        Departement: 'Haut-Garonne',
+        Structure: 'Copropriété',
+        'Type de chauffage': 'Collectif',
+        'Distance au réseau': 80,
+      }}
+    />
+  );
+};
+
+export default CreationDemandeEmailDebug;

--- a/src/server/email/react-email/templates/tests/creation-demande_copropriete_collectif_inf200m.tsx
+++ b/src/server/email/react-email/templates/tests/creation-demande_copropriete_collectif_inf200m.tsx
@@ -1,0 +1,17 @@
+import CreationDemandeEmail from '@/server/email/react-email/templates/creation-demande';
+
+const CreationDemandeEmailDebug = () => {
+  return (
+    <CreationDemandeEmail
+      demand={{
+        Adresse: '123 Rue de la Paix, 75000 Paris',
+        Departement: 'Haut-Garonne',
+        Structure: 'Copropriété',
+        'Type de chauffage': 'Collectif',
+        'Distance au réseau': 150,
+      }}
+    />
+  );
+};
+
+export default CreationDemandeEmailDebug;

--- a/src/server/email/react-email/templates/tests/creation-demande_copropriete_collectif_sup200m.tsx
+++ b/src/server/email/react-email/templates/tests/creation-demande_copropriete_collectif_sup200m.tsx
@@ -1,0 +1,17 @@
+import CreationDemandeEmail from '@/server/email/react-email/templates/creation-demande';
+
+const CreationDemandeEmailDebug = () => {
+  return (
+    <CreationDemandeEmail
+      demand={{
+        Adresse: '123 Rue de la Paix, 75000 Paris',
+        Departement: 'Haut-Garonne',
+        Structure: 'Copropriété',
+        'Type de chauffage': 'Collectif',
+        'Distance au réseau': 250,
+      }}
+    />
+  );
+};
+
+export default CreationDemandeEmailDebug;

--- a/src/server/email/react-email/templates/tests/creation-demande_copropriete_individuel_inf200m.tsx
+++ b/src/server/email/react-email/templates/tests/creation-demande_copropriete_individuel_inf200m.tsx
@@ -1,0 +1,17 @@
+import CreationDemandeEmail from '@/server/email/react-email/templates/creation-demande';
+
+const CreationDemandeEmailDebug = () => {
+  return (
+    <CreationDemandeEmail
+      demand={{
+        Adresse: '123 Rue de la Paix, 75000 Paris',
+        Departement: 'Haut-Garonne',
+        Structure: 'Copropriété',
+        'Type de chauffage': 'Individuel',
+        'Distance au réseau': 150,
+      }}
+    />
+  );
+};
+
+export default CreationDemandeEmailDebug;

--- a/src/server/email/react-email/templates/tests/creation-demande_copropriete_individuel_sup200m.tsx
+++ b/src/server/email/react-email/templates/tests/creation-demande_copropriete_individuel_sup200m.tsx
@@ -1,0 +1,17 @@
+import CreationDemandeEmail from '@/server/email/react-email/templates/creation-demande';
+
+const CreationDemandeEmailDebug = () => {
+  return (
+    <CreationDemandeEmail
+      demand={{
+        Adresse: '123 Rue de la Paix, 75000 Paris',
+        Departement: 'Haut-Garonne',
+        Structure: 'Copropriété',
+        'Type de chauffage': 'Individuel',
+        'Distance au réseau': 250,
+      }}
+    />
+  );
+};
+
+export default CreationDemandeEmailDebug;

--- a/src/server/email/react-email/templates/tests/creation-demande_maison_individuel_inf200m.tsx
+++ b/src/server/email/react-email/templates/tests/creation-demande_maison_individuel_inf200m.tsx
@@ -1,0 +1,17 @@
+import CreationDemandeEmail from '@/server/email/react-email/templates/creation-demande';
+
+const CreationDemandeEmailDebug = () => {
+  return (
+    <CreationDemandeEmail
+      demand={{
+        Adresse: '123 Rue de la Paix, 75000 Paris',
+        Departement: 'Haut-Garonne',
+        Structure: 'Maison individuelle',
+        'Type de chauffage': 'Individuel',
+        'Distance au réseau': 150,
+      }}
+    />
+  );
+};
+
+export default CreationDemandeEmailDebug;

--- a/src/server/email/react-email/templates/tests/creation-demande_maison_individuel_sup200m.tsx
+++ b/src/server/email/react-email/templates/tests/creation-demande_maison_individuel_sup200m.tsx
@@ -1,0 +1,17 @@
+import CreationDemandeEmail from '@/server/email/react-email/templates/creation-demande';
+
+const CreationDemandeEmailDebug = () => {
+  return (
+    <CreationDemandeEmail
+      demand={{
+        Adresse: '123 Rue de la Paix, 75000 Paris',
+        Departement: 'Haut-Garonne',
+        Structure: 'Maison individuelle',
+        'Type de chauffage': 'Individuel',
+        'Distance au réseau': 250,
+      }}
+    />
+  );
+};
+
+export default CreationDemandeEmailDebug;

--- a/src/server/email/react-email/templates/tests/creation-demande_paris_copropriete_collectif_inf100m.tsx
+++ b/src/server/email/react-email/templates/tests/creation-demande_paris_copropriete_collectif_inf100m.tsx
@@ -1,0 +1,17 @@
+import CreationDemandeEmail from '@/server/email/react-email/templates/creation-demande';
+
+const CreationDemandeEmailDebug = () => {
+  return (
+    <CreationDemandeEmail
+      demand={{
+        Adresse: '123 Rue de la Paix, 75000 Paris',
+        Departement: 'Paris',
+        Structure: 'Copropriété',
+        'Type de chauffage': 'Collectif',
+        'Distance au réseau': 80,
+      }}
+    />
+  );
+};
+
+export default CreationDemandeEmailDebug;

--- a/src/server/email/react-email/templates/tests/creation-demande_paris_copropriete_collectif_inf60m.tsx
+++ b/src/server/email/react-email/templates/tests/creation-demande_paris_copropriete_collectif_inf60m.tsx
@@ -1,0 +1,17 @@
+import CreationDemandeEmail from '@/server/email/react-email/templates/creation-demande';
+
+const CreationDemandeEmailDebug = () => {
+  return (
+    <CreationDemandeEmail
+      demand={{
+        Adresse: '123 Rue de la Paix, 75000 Paris',
+        Departement: 'Paris',
+        Structure: 'Copropriété',
+        'Type de chauffage': 'Collectif',
+        'Distance au réseau': 40,
+      }}
+    />
+  );
+};
+
+export default CreationDemandeEmailDebug;

--- a/src/server/email/react-email/templates/tests/creation-demande_paris_copropriete_collectif_sup100m.tsx
+++ b/src/server/email/react-email/templates/tests/creation-demande_paris_copropriete_collectif_sup100m.tsx
@@ -1,0 +1,17 @@
+import CreationDemandeEmail from '@/server/email/react-email/templates/creation-demande';
+
+const CreationDemandeEmailDebug = () => {
+  return (
+    <CreationDemandeEmail
+      demand={{
+        Adresse: '123 Rue de la Paix, 75000 Paris',
+        Departement: 'Paris',
+        Structure: 'Copropriété',
+        'Type de chauffage': 'Collectif',
+        'Distance au réseau': 150,
+      }}
+    />
+  );
+};
+
+export default CreationDemandeEmailDebug;

--- a/src/server/email/react-email/templates/tests/creation-demande_paris_copropriete_individuel_inf100m.tsx
+++ b/src/server/email/react-email/templates/tests/creation-demande_paris_copropriete_individuel_inf100m.tsx
@@ -1,0 +1,17 @@
+import CreationDemandeEmail from '@/server/email/react-email/templates/creation-demande';
+
+const CreationDemandeEmailDebug = () => {
+  return (
+    <CreationDemandeEmail
+      demand={{
+        Adresse: '123 Rue de la Paix, 75000 Paris',
+        Departement: 'Paris',
+        Structure: 'Copropriété',
+        'Type de chauffage': 'Individuel',
+        'Distance au réseau': 80,
+      }}
+    />
+  );
+};
+
+export default CreationDemandeEmailDebug;

--- a/src/server/email/react-email/templates/tests/creation-demande_paris_copropriete_individuel_sup100m.tsx
+++ b/src/server/email/react-email/templates/tests/creation-demande_paris_copropriete_individuel_sup100m.tsx
@@ -1,0 +1,17 @@
+import CreationDemandeEmail from '@/server/email/react-email/templates/creation-demande';
+
+const CreationDemandeEmailDebug = () => {
+  return (
+    <CreationDemandeEmail
+      demand={{
+        Adresse: '123 Rue de la Paix, 75000 Paris',
+        Departement: 'Paris',
+        Structure: 'Copropriété',
+        'Type de chauffage': 'Individuel',
+        'Distance au réseau': 150,
+      }}
+    />
+  );
+};
+
+export default CreationDemandeEmailDebug;

--- a/src/server/email/react-email/templates/tests/creation-demande_paris_tertiaire_collectif_inf100m.tsx
+++ b/src/server/email/react-email/templates/tests/creation-demande_paris_tertiaire_collectif_inf100m.tsx
@@ -1,0 +1,17 @@
+import CreationDemandeEmail from '@/server/email/react-email/templates/creation-demande';
+
+const CreationDemandeEmailDebug = () => {
+  return (
+    <CreationDemandeEmail
+      demand={{
+        Adresse: '123 Rue de la Paix, 75000 Paris',
+        Departement: 'Paris',
+        Structure: 'Tertiaire',
+        'Type de chauffage': 'Collectif',
+        'Distance au réseau': 80,
+      }}
+    />
+  );
+};
+
+export default CreationDemandeEmailDebug;

--- a/src/server/email/react-email/templates/tests/creation-demande_paris_tertiaire_collectif_inf60m.tsx
+++ b/src/server/email/react-email/templates/tests/creation-demande_paris_tertiaire_collectif_inf60m.tsx
@@ -1,0 +1,17 @@
+import CreationDemandeEmail from '@/server/email/react-email/templates/creation-demande';
+
+const CreationDemandeEmailDebug = () => {
+  return (
+    <CreationDemandeEmail
+      demand={{
+        Adresse: '123 Rue de la Paix, 75000 Paris',
+        Departement: 'Paris',
+        Structure: 'Tertiaire',
+        'Type de chauffage': 'Collectif',
+        'Distance au réseau': 50,
+      }}
+    />
+  );
+};
+
+export default CreationDemandeEmailDebug;

--- a/src/server/email/react-email/templates/tests/creation-demande_paris_tertiaire_collectif_sup100m.tsx
+++ b/src/server/email/react-email/templates/tests/creation-demande_paris_tertiaire_collectif_sup100m.tsx
@@ -1,0 +1,17 @@
+import CreationDemandeEmail from '@/server/email/react-email/templates/creation-demande';
+
+const CreationDemandeEmailDebug = () => {
+  return (
+    <CreationDemandeEmail
+      demand={{
+        Adresse: '123 Rue de la Paix, 75000 Paris',
+        Departement: 'Paris',
+        Structure: 'Tertiaire',
+        'Type de chauffage': 'Collectif',
+        'Distance au réseau': 150,
+      }}
+    />
+  );
+};
+
+export default CreationDemandeEmailDebug;

--- a/src/server/email/react-email/templates/tests/creation-demande_paris_tertiaire_individuel_inf100m.tsx
+++ b/src/server/email/react-email/templates/tests/creation-demande_paris_tertiaire_individuel_inf100m.tsx
@@ -1,0 +1,17 @@
+import CreationDemandeEmail from '@/server/email/react-email/templates/creation-demande';
+
+const CreationDemandeEmailDebug = () => {
+  return (
+    <CreationDemandeEmail
+      demand={{
+        Adresse: '123 Rue de la Paix, 75000 Paris',
+        Departement: 'Paris',
+        Structure: 'Tertiaire',
+        'Type de chauffage': 'Individuel',
+        'Distance au réseau': 50,
+      }}
+    />
+  );
+};
+
+export default CreationDemandeEmailDebug;

--- a/src/server/email/react-email/templates/tests/creation-demande_paris_tertiaire_individuel_sup100m.tsx
+++ b/src/server/email/react-email/templates/tests/creation-demande_paris_tertiaire_individuel_sup100m.tsx
@@ -1,0 +1,17 @@
+import CreationDemandeEmail from '@/server/email/react-email/templates/creation-demande';
+
+const CreationDemandeEmailDebug = () => {
+  return (
+    <CreationDemandeEmail
+      demand={{
+        Adresse: '123 Rue de la Paix, 75000 Paris',
+        Departement: 'Paris',
+        Structure: 'Tertiaire',
+        'Type de chauffage': 'Individuel',
+        'Distance au réseau': 150,
+      }}
+    />
+  );
+};
+
+export default CreationDemandeEmailDebug;

--- a/src/server/email/react-email/templates/tests/creation-demande_tertiaire_collectif_inf100m.tsx
+++ b/src/server/email/react-email/templates/tests/creation-demande_tertiaire_collectif_inf100m.tsx
@@ -1,0 +1,17 @@
+import CreationDemandeEmail from '@/server/email/react-email/templates/creation-demande';
+
+const CreationDemandeEmailDebug = () => {
+  return (
+    <CreationDemandeEmail
+      demand={{
+        Adresse: '123 Rue de la Paix, 75000 Paris',
+        Departement: 'Haut-Garonne',
+        Structure: 'Tertiaire',
+        'Type de chauffage': 'Collectif',
+        'Distance au réseau': 80,
+      }}
+    />
+  );
+};
+
+export default CreationDemandeEmailDebug;

--- a/src/server/email/react-email/templates/tests/creation-demande_tertiaire_collectif_inf200m.tsx
+++ b/src/server/email/react-email/templates/tests/creation-demande_tertiaire_collectif_inf200m.tsx
@@ -1,0 +1,17 @@
+import CreationDemandeEmail from '@/server/email/react-email/templates/creation-demande';
+
+const CreationDemandeEmailDebug = () => {
+  return (
+    <CreationDemandeEmail
+      demand={{
+        Adresse: '123 Rue de la Paix, 75000 Paris',
+        Departement: 'Haut-Garonne',
+        Structure: 'Tertiaire',
+        'Type de chauffage': 'Collectif',
+        'Distance au réseau': 150,
+      }}
+    />
+  );
+};
+
+export default CreationDemandeEmailDebug;

--- a/src/server/email/react-email/templates/tests/creation-demande_tertiaire_collectif_sup200m.tsx
+++ b/src/server/email/react-email/templates/tests/creation-demande_tertiaire_collectif_sup200m.tsx
@@ -1,0 +1,17 @@
+import CreationDemandeEmail from '@/server/email/react-email/templates/creation-demande';
+
+const CreationDemandeEmailDebug = () => {
+  return (
+    <CreationDemandeEmail
+      demand={{
+        Adresse: '123 Rue de la Paix, 75000 Paris',
+        Departement: 'Haut-Garonne',
+        Structure: 'Tertiaire',
+        'Type de chauffage': 'Collectif',
+        'Distance au réseau': 250,
+      }}
+    />
+  );
+};
+
+export default CreationDemandeEmailDebug;

--- a/src/server/email/react-email/templates/tests/creation-demande_tertiaire_individuel_inf200m.tsx
+++ b/src/server/email/react-email/templates/tests/creation-demande_tertiaire_individuel_inf200m.tsx
@@ -1,0 +1,17 @@
+import CreationDemandeEmail from '@/server/email/react-email/templates/creation-demande';
+
+const CreationDemandeEmailDebug = () => {
+  return (
+    <CreationDemandeEmail
+      demand={{
+        Adresse: '123 Rue de la Paix, 75000 Paris',
+        Departement: 'Haut-Garonne',
+        Structure: 'Tertiaire',
+        'Type de chauffage': 'Individuel',
+        'Distance au réseau': 150,
+      }}
+    />
+  );
+};
+
+export default CreationDemandeEmailDebug;

--- a/src/server/email/react-email/templates/tests/creation-demande_tertiaire_individuel_sup200m.tsx
+++ b/src/server/email/react-email/templates/tests/creation-demande_tertiaire_individuel_sup200m.tsx
@@ -1,0 +1,17 @@
+import CreationDemandeEmail from '@/server/email/react-email/templates/creation-demande';
+
+const CreationDemandeEmailDebug = () => {
+  return (
+    <CreationDemandeEmail
+      demand={{
+        Adresse: '123 Rue de la Paix, 75000 Paris',
+        Departement: 'Haut-Garonne',
+        Structure: 'Tertiaire',
+        'Type de chauffage': 'Individuel',
+        'Distance au réseau': 250,
+      }}
+    />
+  );
+};
+
+export default CreationDemandeEmailDebug;

--- a/src/services/airtable.ts
+++ b/src/services/airtable.ts
@@ -1,7 +1,7 @@
 import { type Airtable } from '@/types/enum/Airtable';
 import { type AirtableDemandCreation, type FormDemandCreation } from '@/types/Summary/Demand';
 
-const formatHeatingEnergyToAirtable: (heatingEnergy: string) => string = (heatingEnergy) => {
+const formatHeatingEnergyToAirtable = (heatingEnergy: string) => {
   switch (heatingEnergy) {
     case 'électricité':
       return 'Électricité';
@@ -13,7 +13,7 @@ const formatHeatingEnergyToAirtable: (heatingEnergy: string) => string = (heatin
       return 'Autre / Je ne sais pas';
   }
 };
-const formatHeatingTypeToAirtable: (heatingType?: string) => string = (heatingType) => {
+export const formatHeatingTypeToAirtable = (heatingType?: string) => {
   switch (heatingType) {
     case 'individuel':
       return 'Individuel';

--- a/src/types/AddressData.d.ts
+++ b/src/types/AddressData.d.ts
@@ -2,7 +2,7 @@ import { type HeatNetworksResponse } from './HeatNetworksResponse';
 import { type SuggestionItem } from './Suggestions';
 
 export type AvailableHeating = 'collectif' | 'individuel' | undefined;
-export type AvailableStructure = 'Tertiaire' | 'Copropriété' | undefined;
+export type AvailableStructure = 'Tertiaire' | 'Copropriété' | 'Bailleur social' | 'Maison individuelle' | 'Autre' | undefined;
 export type AddressDataType = {
   address?: string;
   coords?: { lat: number; lon: number };


### PR DESCRIPTION
- Envoi des emails à la création des demandes plutôt qu'avec les automatisations airtable (qui seront à désactiver au moment du déploiement)
- Gestion des 20 cas différents avec le template.
- via dev:email les différents cas sont visibles dans le sous-dossier tests