### PR TITLE
Amélioration intégration traces

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -1,4 +1,3 @@
-threshold: medium
 fileignoreconfig:
 - filename: .env
   checksum: 81233fa2ce97469feae7a0b794fff052255307f658a9a5cdd7cfe54bc40fef36
@@ -21,6 +20,8 @@ fileignoreconfig:
   checksum: 2b379d50d78806a26e79c2c45562529bdac4115487af223b33863153c7be5b0d
 - filename: scripts/db_sync_common.sh
   checksum: e23e852383c7fabc2b0a1d89e63a8595cdb4b4c6959fdc8cea4491b6d292aef3
+- filename: scripts/opendata/create-opendata-archive.sh
+  checksum: c6c769ce331a64047f4847a514b570e5f084ae45813edd91b47ac1d207c17fe5
 - filename: src/components/ComparateurPublicodes/DebugDrawer.tsx
   checksum: 5e675d6da8d48880b27b4f45242dfb2ee0e30c93cf2f59f4f1795ddbef87b83f
 - filename: src/components/Map/Map.tsx
@@ -67,4 +68,5 @@ allowed_patterns:
 - (?i)https:\/\/docs\.google\.com\/.*
 - resetPasswordSchema
 - (?i)https:\/\/airtable\.com\/app9opX8gRAtBqkan.*
+threshold: medium
 version: "1.0"

--- a/scripts/helpers/geo.ts
+++ b/scripts/helpers/geo.ts
@@ -31,6 +31,19 @@ export async function readFileGeometry(fileName: string): Promise<GeometryWithSr
     geom = geom.geometries[0];
   }
 
+  // convert to multi-geometry if needed
+  if (geom.type === 'LineString') {
+    geom = {
+      type: 'MultiLineString',
+      coordinates: [geom.coordinates],
+    };
+  } else if (geom.type === 'Polygon') {
+    geom = {
+      type: 'MultiPolygon',
+      coordinates: [geom.coordinates],
+    };
+  }
+
   const srid = detectSrid(geom);
 
   logger.debug('Geometry type', { type: geom.type, srid });

--- a/scripts/networks/commands.ts
+++ b/scripts/networks/commands.ts
@@ -179,8 +179,15 @@ export function registerNetworkCommands(parentProgram: Command) {
                   { title: 'Réseau de froid (rdf)', value: 'rdf' },
                   { title: 'Plan de développement (pdp)', value: 'pdp' },
                   { title: 'Réseau futur (futur)', value: 'futur' },
+                  { title: 'Passer', value: 'skip' },
                 ],
               });
+              if (entityType === 'skip') {
+                logger.info('👌 Action passée');
+                fs.unlinkSync(localPath);
+                logger.debug('🧹 Fichier temporaire supprimé');
+                continue;
+              }
 
               const { action } = await prompts({
                 type: 'select',

--- a/scripts/networks/commands.ts
+++ b/scripts/networks/commands.ts
@@ -48,7 +48,7 @@ export function registerNetworkCommands(parentProgram: Command) {
         logger.error("Variables d'environnement TRELLO_API_KEY et TRELLO_TOKEN requises");
         logger.info('📋 Configuration requise :');
         logger.info(`1. Allez sur ${TRELLO_POWER_UP_URL}`);
-        logger.info('2. Cliquez sur "Token"');
+        logger.info('2. Cliquez sur lien "Token" dans le texte à droite de "API key"');
         logger.info('3. Connectez votre compte');
         logger.info('4. Ajoutez ces variables à votre fichier .env.local :');
         logger.info('   TRELLO_API_KEY=votre_api_key');

--- a/scripts/networks/commands.ts
+++ b/scripts/networks/commands.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 
 import { kdb, sql } from '@/server/db/kysely';
 import { logger } from '@/server/helpers/logger';
-import { TrelloService } from '@/services/TrelloService';
+import { type TrelloCard, type TrelloLabel, TrelloService } from '@/services/TrelloService';
 import { readFileGeometry } from '@cli/helpers/geo';
 import { runBash } from '@cli/helpers/shell';
 
@@ -75,9 +75,56 @@ export function registerNetworkCommands(parentProgram: Command) {
 
         logger.info(`\n📋 ${cards.length} carte(s) trouvée(s) dans "${COLUMN_TO_PROCESS}":\n`);
 
-        for (const card of cards.filter((card) => card.attachments.some((attachment) => attachment.fileName.endsWith('.geojson')))) {
+        const getCardPriority = (card: TrelloCard): number => {
+          const labelNames = card.labels.map((label) => label.name);
+          const hasReseauChaleur = labelNames.includes('Réseau chaleur');
+          const hasReseauFroid = labelNames.includes('Réseau froid');
+          const hasReseauConstruction = labelNames.includes('Réseau en construction');
+          const hasPDP = labelNames.includes('PDP');
+          const labelCount = labelNames.length;
+
+          // 1. "Réseau chaleur" (uniquement)
+          if (hasReseauChaleur && labelCount === 1) return 1;
+
+          // 2. "Réseau en construction" (uniquement)
+          if (hasReseauConstruction && labelCount === 1) return 2;
+
+          // 3. "Réseau chaleur" (au moins)
+          if (hasReseauChaleur && labelCount > 1) return 3;
+
+          // 4. "Réseau froid" (au moins)
+          if (hasReseauFroid) return 4;
+
+          // 5. "Réseau en construction" (au moins)
+          if (hasReseauConstruction && labelCount > 1) return 5;
+
+          // 6. "PDP" (au moins)
+          if (hasPDP) return 6;
+
+          return 999;
+        };
+
+        const sortedCards = cards
+          .filter((card) => card.attachments.some((attachment) => attachment.fileName.endsWith('.geojson')))
+          .sort((a, b) => getCardPriority(a) - getCardPriority(b));
+
+        const colorizeLabel = (label: TrelloLabel): string => {
+          const colorMap: Record<string, string> = {
+            green_dark: '\x1b[32m', // réseaux de chaleur
+            blue_dark: '\x1b[34m', // réseaux de froid
+            pink: '\x1b[95m', // réseaux en construction
+            yellow: '\x1b[33m', // PDP
+          };
+          const reset = '\x1b[0m';
+          const color = colorMap[label.color] || '';
+          return `${color}${label.name}${reset}`;
+        };
+
+        logger.info(`🔄 Cartes triées par priorité de labels`);
+
+        for (const card of sortedCards) {
           const name = card.name;
-          const labels = card.labels.map((label) => label.name).join(', ');
+          const labels = card.labels.map(colorizeLabel).join(', ');
           const onlyOneLabel = card.labels.length === 1;
           const suggestedId = onlyOneLabel ? name.match(/ID\s*(?:FCU\s*)?(\d+[CF]?)/)?.[1] : undefined;
           const isIdSNCU = suggestedId?.endsWith('C') || suggestedId?.endsWith('F');
@@ -105,7 +152,8 @@ export function registerNetworkCommands(parentProgram: Command) {
                   : undefined
             : undefined;
           logger.info(`══════════════════════════`);
-          logger.info(`Processing "${name}" (${labels})`);
+          logger.info(labels);
+          logger.info(`# ${name}`);
           logger.info(
             [
               card.desc,
@@ -183,12 +231,12 @@ export function registerNetworkCommands(parentProgram: Command) {
                     throw new Error(`Action non reconnue: ${action}`);
                 }
 
-                logger.info(`🚀 Exécution: ${command}`);
+                logger.debug(`🚀 Exécution: ${command}`);
                 await runBash(command);
-                logger.info('✅ Action terminée avec succès');
+                logger.debug('✅ Action terminée avec succès');
 
                 fs.unlinkSync(localPath);
-                logger.info('🧹 Fichier temporaire supprimé');
+                logger.debug('🧹 Fichier temporaire supprimé');
               }
             } catch (error) {
               logger.error(`❌ Erreur lors du traitement de ${localPath}:`, error);

--- a/scripts/opendata/create-opendata-archive.sh
+++ b/scripts/opendata/create-opendata-archive.sh
@@ -325,5 +325,9 @@ cp scripts/opendata/nomenclature_shapefile_des_reseaux_de_chaleur_et_froid.xlsx 
 archiveName=$(date +%d%m%y)-opendata-fcu.zip
 rm -f "$archiveName"
 zip -j "$archiveName" "$opendata_dir"/*
-echo -e "\nArchive opendata prête pour envoi à Florence sur Mattermost => $archiveName"
+echo -e "\nArchive opendata prête pour envoi => $archiveName
+Prérequis : avoir un compte sur data.gouv.fr et avoir accès au compte France Chaleur Urbaine
+1. Aller sur le jeu de données Tracés des réseaux de chaleur et de froid : https://www.data.gouv.fr/admin/datasets/64f05d3568e4d575eb454ffe
+2. Ajouter une mise à jour avec l'archive avec le nom du fichier. Préciser le contenu de la mise à jour dans le champ 'Description'.
+3. Enfin, modifier le fichier principal (opendata-fcu.zip) avec l'archive."
 rm -r "$opendata_dir"

--- a/scripts/opendata/create-opendata-archive.sh
+++ b/scripts/opendata/create-opendata-archive.sh
@@ -322,7 +322,7 @@ ogr2ogr -f "ESRI Shapefile" -lco ENCODING=UTF-8 /output/reseaux_en_construction_
 cp scripts/opendata/nomenclature_shapefile_des_reseaux_de_chaleur_et_froid.xlsx "$opendata_dir/"
 
 # Création de l'archive
-archiveName=opendata-fcu-$(date +%d%m%y).zip
+archiveName=$(date +%d%m%y)-opendata-fcu.zip
 rm -f "$archiveName"
 zip -j "$archiveName" "$opendata_dir"/*
 echo -e "\nArchive opendata prête pour envoi à Florence sur Mattermost => $archiveName"

--- a/scripts/opendata/create-opendata-archive.sh
+++ b/scripts/opendata/create-opendata-archive.sh
@@ -21,7 +21,7 @@ fi
 psql="docker run -i --rm --network host postgis/postgis:16-3.5-alpine psql"
 
 ogr2ogr() {
-  docker run -i --rm -v "$opendata_dir":/output "$GDAL_IMAGE" ogr2ogr "$@"
+  docker run -i --rm --network host -v "$opendata_dir":/output "$GDAL_IMAGE" ogr2ogr "$@"
 }
 
 # Création des vues

--- a/src/server/helpers/file.ts
+++ b/src/server/helpers/file.ts
@@ -12,7 +12,7 @@ type DownloadFileOptions = {
 
 export async function downloadFile({ url, fileName, headers }: DownloadFileOptions): Promise<string> {
   const filePath = fileName || `temp_${Date.now()}.geojson`;
-  logger.info(`📥 Téléchargement de ${url} dans ${filePath}`);
+  logger.debug(`📥 Téléchargement de ${url} dans ${filePath}`);
 
   try {
     const response = await axios.get(url, { responseType: 'stream', headers });
@@ -25,7 +25,7 @@ export async function downloadFile({ url, fileName, headers }: DownloadFileOptio
       writeStream.on('error', reject);
     });
 
-    logger.info(`✅ Fichier téléchargé: ${filePath}`);
+    logger.debug(`✅ Fichier téléchargé: ${filePath}`);
     return filePath;
   } catch (error) {
     logger.error(`❌ Erreur lors du téléchargement de ${url}:`, error);

--- a/src/services/TrelloService.ts
+++ b/src/services/TrelloService.ts
@@ -12,17 +12,19 @@ export type TrelloCard = {
   url: string;
   due: string | null;
   dateLastActivity: string;
-  labels: Array<{
-    id: string;
-    name: string;
-    color: string;
-  }>;
+  labels: TrelloLabel[];
   attachments: Array<{
     id: string;
     name: string;
     url: string;
     fileName: string;
   }>;
+};
+
+export type TrelloLabel = {
+  id: string;
+  name: string;
+  color: string;
 };
 
 export type TrelloList = {
@@ -54,14 +56,14 @@ export class TrelloService {
 
   private async getUrl<T>(path: string, queryParams: Record<string, string> = {}): Promise<T> {
     const url = `https://api.trello.com/1${path}?${this.getAuthParams()}&${new URLSearchParams(queryParams).toString()}`;
-    logger.info(`GET ${url}`);
+    logger.debug(`GET ${url}`);
     const { data } = await axios.get<T>(url);
     return data;
   }
 
   private async putUrl<T>(path: string, queryParams: Record<string, string> = {}): Promise<T> {
     const url = `https://api.trello.com/1${path}?${this.getAuthParams()}&${new URLSearchParams(queryParams).toString()}`;
-    logger.info(`PUT ${url}`);
+    logger.debug(`PUT ${url}`);
     const { data } = await axios.put<T>(url);
     return data;
   }

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -93,13 +93,15 @@ export const convertLambert93GeoJSONToWGS84 = async (geojson: any): Promise<any>
   return {
     ...geojson,
     crs: { type: 'name', properties: { name: 'EPSG:4326' } },
-    features: geojson.features.map((feature: any) => ({
-      ...feature,
-      geometry: {
-        ...feature.geometry,
-        coordinates: convertCoordinates(feature.geometry.coordinates, 'EPSG:2154', 'EPSG:4326'),
-      },
-    })),
+    features: geojson.features
+      .filter((feature: any) => feature.geometry !== null)
+      .map((feature: any) => ({
+        ...feature,
+        geometry: {
+          ...feature.geometry,
+          coordinates: convertCoordinates(feature.geometry.coordinates, 'EPSG:2154', 'EPSG:4326'),
+        },
+      })),
   };
 };
 


### PR DESCRIPTION
- gestion automatique des géométries qui ne sont pas en Multi
- ajout de couleurs pour afficher les labels des cartes Trello
- revue de l'affichage un peu pour être plus clair (bon c'est pas encore trop ça...)
- ajout d'une action pour passer un fichier (quand on doit faire des choses à la main)

Il y a au moins un cas où j'ai pas pu utiliser directement la CLI trello. Quand je voulais ajouter des PDP avec un id_sncu (car il faut faire les liens).
un équivalent de `pnpm cli geom insert pdp 0 1234C`
Pour le moment j'ai fait à la main en utilisant l'action skip.