### PR TITLE
[NE PAS MERGER] Utilise la dernière version des règles publicodes # dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ scripts/simulateur/codes-insee.json
 
 # Version check cache
 .ai/.version-check
+
+# CI publicodes dev
+/france-chaleur-urbaine-publicodes

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "db:sync": "pnpm cli db:sync",
     "db:verify": "pnpm db:introspect --verify",
     "postinstall": "node scripts/postinstall.mjs",
-    "scalingo-postbuild": "./scripts/migrate.sh && pnpm build && next-sitemap",
+    "scalingo-postbuild": "pnpm build && next-sitemap",
     "predev": "only-include-used-icons --silent",
     "prebuild": "only-include-used-icons",
     "talisman:add-exception": "node-talisman -i -g pre-commit",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "postinstall": "node scripts/postinstall.mjs",
     "scalingo-postbuild": "pnpm build && next-sitemap",
     "predev": "only-include-used-icons --silent",
-    "prebuild": "only-include-used-icons",
+    "prebuild": "only-include-used-icons && scripts/fetch-publicodes-dev.sh",
     "talisman:add-exception": "node-talisman -i -g pre-commit",
     "ts": "NODE_OPTIONS=\"--max-old-space-size=8192\" pnpm tsc --build --clean && pnpm tsc"
   },

--- a/scripts/fetch-publicodes-dev.sh
+++ b/scripts/fetch-publicodes-dev.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+rm -rf france-chaleur-urbaine-publicodes
+git clone --branch main --depth 1 https://github.com/betagouv/france-chaleur-urbaine-publicodes.git france-chaleur-urbaine-publicodes
+cd france-chaleur-urbaine-publicodes
+pnpm install
+pnpm build
+cd ..
+pnpm install @betagouv/france-chaleur-urbaine-publicodes@file:france-chaleur-urbaine-publicodes


### PR DESCRIPTION
Cette PR sert juste à voir les changements de la branche dev-publicodes, qui est liée à un environnement permanent côté scalingo et est utilisé par la CI du projet [france-chaleur-urbaine-publicodes](https://github.com/betagouv/france-chaleur-urbaine-publicodes) pour déployer automatiquement à chaque commit sur dev.

Concrètement, elle contient : 
- désactivation des migrations de BDD (car lié à la BDD de dev)
- récupération automatique de la dernière version des règles publicodes avant build