### PR TITLE
Intégration ademe connect

### DIFF
--- a/.ai/context/conventions.md
+++ b/.ai/context/conventions.md
@@ -98,6 +98,14 @@
 - No commented-out code — delete it.
 - No JSDoc except on complex public utility functions.
 
+## HTTP calls to external APIs
+
+Never use raw `fetch`. Use helpers from `@/utils/network`:
+- `postFetchJSON / putFetchJSON / patchFetchJSON / deleteFetchJSON(url, body?, headers?)` for mutation methods
+- `fetchJSON(url, init?)` for GET — pass `headers` inside `init`
+
+They handle `Content-Type: application/json`, JSON parsing, and throw `FetchError` on non-OK responses.
+
 ## Environment variables
 
 Never access `process.env` directly. Always use the typed config objects:

--- a/.ai/context/conventions.md
+++ b/.ai/context/conventions.md
@@ -98,6 +98,16 @@
 - No commented-out code — delete it.
 - No JSDoc except on complex public utility functions.
 
+## Environment variables
+
+Never access `process.env` directly. Always use the typed config objects:
+- **Server-side**: `serverConfig` from `@/server/config` — Zod-validated, typed.
+- **Client-side**: `clientConfig` from `@/client-config` — Zod-validated, typed.
+
+When adding a new env var:
+1. Add it to `serverConfigSchema` (or client schema) in `src/server/config.ts`.
+2. Add it with a placeholder value to `.env.example`.
+
 ## Pre-commit checklist
 
 Always run before committing:

--- a/.env.example
+++ b/.env.example
@@ -121,6 +121,14 @@ DATA_GOUV_FR_DATASET_ID=your-dataset-id
 PIPEDRIVE_API_KEY=your-pipedrive-api-key
 PIPEDRIVE_BASE_URL=https://api.pipedrive.com/v1
 
+# ADEME Connect (Mulesoft CRM)
+# Staging: https://ppd-x-ademe-interne-api.de-c1.eu1.cloudhub.io/api/v1
+# Production: https://prd-x-ademe-interne-api.de-c1.eu1.cloudhub.io/api/v1
+ADEME_CONNECT_BASE_URL=https://ppd-x-ademe-interne-api.de-c1.eu1.cloudhub.io/api/v1
+ADEME_CONNECT_CLIENT_ID=
+ADEME_CONNECT_CLIENT_SECRET=
+# ADEME_CONNECT_SOURCE=France Chaleur Urbaine
+
 # --------------------------------------------
 # MONITORING & ERREURS
 # --------------------------------------------

--- a/.gitignore
+++ b/.gitignore
@@ -91,14 +91,9 @@ scripts/simulateur/codes-insee.json
 .env.sentry-build-plugin
 
 # =============================================================================
-# claude - Auto-generated symlinks
-# ⚠️  Auto-generated - Do not edit manually
+# claude
 # =============================================================================
-.claude/commands
-.claude/agents
-.claude/output-styles
-.claude/settings.json
-.claude/context
+.claude/
 # CLAUDE.md
 
 # =============================================================================

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,4 @@ Think critically first, code second. One good question beats three iterations.
 
 ## Module-level docs
 
-Each module in `src/modules/` may have its own `AGENTS.md`. Read it when editing files in or importing from that module.
-
-25 modules: `analytics`, `app`, `auth`, `ban`, `bdnb`, `chaleur-renouvelable`, `config`, `data`, `demands`, `diagnostic`, `email`, `events`, `form`, `geo`, `jobs`, `notification`, `opendata`, `optimization`, `pro-eligibility-tests`, `reseaux`, `security`, `tags`, `tiles`, `trpc`, `users`.
+Each module in `src/modules/` may have its own `AGENTS.md`. Read it when editing files in or importing from that module. Use `glob src/modules/*/AGENTS.md` to discover which modules have one.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ For every user message:
   - **minor changes** (typo, rename, single-line fix): implement directly, no plan needed
   - **significant changes** (new feature, refactor, multi-file edit): create a plan → ask user to confirm → implement
   - **after implementation**: run `pnpm lint`, check IDE Tailwind CSS extension diagnostics on modified files (canonical classes, unknown utilities — not caught by Biome), run `pnpm ts`, and `pnpm test` if relevant — fix any errors before delivering
+  - **update module docs**: if the change affects a module's high-level behavior or integration points, update the relevant `AGENTS.md` (or `.ai/context/*.md`). Skip implementation details — only what matters for high-level understanding
   - print a summary: start with a high-level overview (4-5 sentences max: what was done and why), then list main files modified/created with a one-liner per file
 
 ## Developer profile

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-**MANDATORY: Read [AGENTS.md](./AGENTS.md) before every task.** It is the single source of truth for this project. All instructions there apply fully to Claude Code.
+@AGENTS.md

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -10,6 +10,7 @@ import prompts from 'prompts';
 import XLSX from 'xlsx';
 import { z } from 'zod';
 
+import { registerAdemeConnectCommands } from '@/modules/ademe-connect/commands';
 import { registerAppCommands } from '@/modules/app/commands';
 import { registerBdnbCommands } from '@/modules/bdnb/commands';
 import { registerDataCommands } from '@/modules/data/commands';
@@ -66,6 +67,7 @@ program
     await kdb.destroy();
   });
 
+registerAdemeConnectCommands(program);
 registerAppCommands(program);
 registerBdnbCommands(program);
 registerDataCommands(program);

--- a/src/components/Admin/UserForm.tsx
+++ b/src/components/Admin/UserForm.tsx
@@ -40,7 +40,7 @@ const UserForm = ({ user, onSubmit, loading }: UserFormProps) => {
       status: user?.status || 'pending_email_confirmation',
       structure_name: user?.structure_name ?? '',
       structure_other: user?.structure_other ?? '',
-      structure_type: user?.structure_type ?? '',
+      structure_type: user?.structure_type ?? null,
     },
     onSubmit: async ({ value }) => onSubmit(value as any),
     schema: isNew ? createUserAdminSchema : updateUserAdminSchema,

--- a/src/components/connexion/ProfileForm.tsx
+++ b/src/components/connexion/ProfileForm.tsx
@@ -28,7 +28,7 @@ function ProfileForm() {
       phone: profile?.phone ?? '',
       structure_name: profile?.structure_name ?? '',
       structure_other: profile?.structure_other ?? '',
-      structure_type: profile?.structure_type ?? '',
+      structure_type: profile?.structure_type ?? undefined,
     },
     onSubmit: async ({ value }) => {
       await updateProfile.mutateAsync(value);
@@ -39,7 +39,7 @@ function ProfileForm() {
   const structureType = useValue('structure_type');
   const showStructureFields = profile?.role !== 'particulier';
 
-  if (isLoading) {
+  if (!profile) {
     return <Loader variant="section" />;
   }
 
@@ -47,9 +47,9 @@ function ProfileForm() {
     <Form>
       <div className="flex flex-col gap-4">
         <Notice variant="info" className="mb-4">
-          <strong>Email :</strong> {profile?.email}
+          <strong>Email :</strong> {profile.email}
           <br />
-          <strong>Rôle :</strong> {roles[profile?.role as keyof typeof roles]}
+          <strong>Rôle :</strong> {roles[profile.role]}
         </Notice>
 
         <Input name="first_name" label="Prénom" />

--- a/src/components/connexion/ProfileNewsletterForm.tsx
+++ b/src/components/connexion/ProfileNewsletterForm.tsx
@@ -1,0 +1,51 @@
+import useForm from '@/components/form/react-form/useForm';
+import Loader from '@/components/ui/Loader';
+import { notify } from '@/modules/notification';
+import trpc from '@/modules/trpc/client';
+import { zUpdateNewsletterSchema } from '@/modules/users/constants';
+
+/**
+ * Form allowing the authenticated user to subscribe or unsubscribe from the FCU newsletter.
+ * Syncs the preference with ADEME Connect.
+ */
+function ProfileNewsletterForm() {
+  const { data: profile, isLoading } = trpc.users.getProfile.useQuery();
+  const utils = trpc.useUtils();
+
+  const updateNewsletter = trpc.users.updateNewsletterSubscription.useMutation({
+    onError: (error) => {
+      notify('error', error.message || 'Erreur lors de la mise à jour des préférences newsletter');
+    },
+    onSuccess: () => {
+      notify('success', 'Préférences newsletter mises à jour');
+      utils.users.getProfile.invalidate();
+    },
+  });
+
+  const { Checkbox, Submit, Form } = useForm({
+    defaultValues: {
+      optin_newsletter: profile?.optin_at !== null && profile?.optin_at !== undefined,
+    },
+    onSubmit: async ({ value }) => {
+      await updateNewsletter.mutateAsync(value);
+    },
+    schema: zUpdateNewsletterSchema,
+  });
+
+  if (isLoading) {
+    return <Loader variant="section" />;
+  }
+
+  return (
+    <Form>
+      <div className="flex flex-col gap-4">
+        <Checkbox name="optin_newsletter" label="Je souhaite recevoir la newsletter France Chaleur Urbaine" />
+        <div className="flex justify-end mt-4">
+          <Submit disabled={updateNewsletter.isPending}>{updateNewsletter.isPending ? 'Enregistrement...' : 'Enregistrer'}</Submit>
+        </div>
+      </div>
+    </Form>
+  );
+}
+
+export default ProfileNewsletterForm;

--- a/src/components/connexion/RegisterForm.tsx
+++ b/src/components/connexion/RegisterForm.tsx
@@ -46,7 +46,7 @@ const steps: FormStep[] = [
       role: 'professionnel',
       structure_name: '',
       structure_other: '',
-      structure_type: '',
+      structure_type: undefined,
     } satisfies IdentitySchema,
     label: 'Votre profil',
     schema: zIdentitySchema,

--- a/src/components/ui/table/TableSimple.tsx
+++ b/src/components/ui/table/TableSimple.tsx
@@ -93,7 +93,7 @@ export const customFilterFn = <T extends RowData>(): Record<string, FilterFn<T>>
 
     // Gérer undefined/null/"" explicitement
     if (!value) {
-      return filterValue.undefined === true || filterValue['null'] === true || filterValue[''] === true;
+      return filterValue.undefined === true || filterValue.null === true || filterValue[''] === true;
     }
 
     return Object.entries(filterValue)

--- a/src/modules/ademe-connect/AGENTS.md
+++ b/src/modules/ademe-connect/AGENTS.md
@@ -1,0 +1,72 @@
+# ademe-connect
+
+> HTTP client for ADEME's Mulesoft CRM API (CONNECT). Synchronizes FCU user accounts with ADEME's Salesforce CRM via a message queue.
+
+## Structure
+
+```
+src/modules/ademe-connect/
+  AGENTS.md
+  constants.ts    # Mapping UserRole → typeOrganisme (e.g. gestionnaire → "Entreprise")
+  commands.ts     # CLI commands (contact:get, contact:create, contacts:bulk-create)
+  server/
+    client.ts     # Mulesoft HTTP client (createContact, updateContact, getContact)
+```
+
+## Purpose and boundaries
+
+**Owns:** HTTP communication with Mulesoft API (`/api/v1/personnes`).
+
+**Must NOT:** contain business logic, know about FCU users or roles — callers handle that mapping.
+
+## API (tRPC routes)
+
+None — this module is a server-side client only. It is called by other modules.
+
+## Env vars
+
+| Var | Description | Default |
+|-----|-------------|---------|
+| `ADEME_CONNECT_BASE_URL` | Mulesoft base URL | staging URL |
+| `ADEME_CONNECT_CLIENT_ID` | Auth client ID | — |
+| `ADEME_CONNECT_CLIENT_SECRET` | Auth client secret | — |
+| `ADEME_CONNECT_SOURCE` | Source identifier (provided by ADEME CRM team) | — |
+
+## Key behaviors
+
+- Auth: `client_id` + `client_secret` headers on every request.
+- Empty/null/undefined fields are stripped before sending (API requirement).
+- Fields `ExternalID`, `federationId`, `ancienMail` are never sent.
+- Creation and update return a queue acknowledgment, not a direct CRM confirmation.
+- Errors are thrown — callers are responsible for fire-and-forget handling.
+
+## Integration points
+
+| Caller | Operation | Trigger |
+|--------|-----------|---------|
+| `modules/auth/server/service.ts` → `register` | `createContact` | User self-registration |
+| `modules/auth/server/service.ts` → `login` | `updateContact` | Login: update `dateConnexion` |
+| `modules/users/server/service.ts` → `invite` | `createContact` | Admin creates a user |
+| `modules/users/server/trpc-routes.ts` → `updateProfile` | `updateContact` | Profile update: first/last name, phone |
+| `modules/users/server/trpc-routes.ts` → `updateNewsletterSubscription` | `updateContact` | Newsletter opt-in/out |
+| `modules/users/server/service.ts` → `remove` | `updateContact` | User deletion: set `actif: false` |
+| `server/api/users/engie.ts` | `updateContact` | Engie user reactivation (`actif: true`) / deactivation (`actif: false`) |
+| `modules/ademe-connect/commands.ts` → CLI | `createContact`, `getContact` | Manual commands / bulk backfill |
+
+All calls are fire-and-forget: errors are logged but not propagated to the caller.
+
+## CLI
+
+Commands registered via `registerAdemeConnectCommands` in the main CLI:
+
+```
+pnpm cli ademe-connect contact:get <email>
+pnpm cli ademe-connect contact:create <email> [--nom] [--prenom] [--telephone] [--siret] [--type-organisme]
+pnpm cli ademe-connect contacts:bulk-create [--dry-run]
+```
+
+`contacts:bulk-create`: fetches all valid FCU users with role `particulier`, `professionnel`, or `gestionnaire` and creates them one by one in the ADEME Connect API. Intended for backfilling existing accounts.
+
+## Dependencies
+
+No imports from other FCU modules.

--- a/src/modules/ademe-connect/commands.ts
+++ b/src/modules/ademe-connect/commands.ts
@@ -1,0 +1,87 @@
+import type { Command } from '@commander-js/extra-typings';
+import dayjs from 'dayjs';
+import { z } from 'zod';
+
+import { ROLE_TYPE_ORGANISME } from '@/modules/ademe-connect/constants';
+import { createContact, getContact } from '@/modules/ademe-connect/server/client';
+import { kdb } from '@/server/db/kysely';
+import { logger } from '@/server/helpers/logger';
+
+export function registerAdemeConnectCommands(parentProgram: Command) {
+  const program = parentProgram.command('ademe-connect').description('Commandes pour le CRM ADEME Connect');
+
+  program
+    .command('contact:get')
+    .description("Récupère les informations d'un contact depuis l'API ADEME Connect")
+    .argument('<email>', 'Email du contact', (v) => z.email().parse(v))
+    .action(async (email) => {
+      const contact = await getContact(email);
+      logger.info(JSON.stringify(contact, null, 2));
+    });
+
+  program
+    .command('contact:create')
+    .description("Crée un contact dans l'API ADEME Connect")
+    .argument('<email>', 'Email du contact', (v) => z.email().parse(v))
+    .option('--nom <nom>', 'Nom du contact')
+    .option('--prenom <prenom>', 'Prénom du contact')
+    .option('--telephone <telephone>', 'Téléphone du contact')
+    .option('--type-organisme <typeOrganisme>', 'Type organisme (Particulier, Entreprise, Collectivité…)')
+    .action(async (email, options) => {
+      const result = await createContact({
+        email,
+        nom: options.nom,
+        prenom: options.prenom,
+        telephone: options.telephone,
+        typeOrganisme: options.typeOrganisme,
+      });
+      logger.info(JSON.stringify(result, null, 2));
+    });
+
+  program
+    .command('contacts:bulk-create')
+    .description("Crée en masse tous les utilisateurs FCU dans ADEME Connect (reprise de l'existant)")
+    .option('--dry-run', "Affiche les contacts qui seraient créés sans appeler l'API", false)
+    .action(async ({ dryRun }) => {
+      const users = await kdb
+        .selectFrom('users')
+        .select(['email', 'first_name', 'last_name', 'phone', 'role', 'optin_at', 'created_at'])
+        .where('role', 'in', ['particulier', 'professionnel', 'gestionnaire'])
+        .where('status', '=', 'valid')
+        .orderBy('created_at', 'asc')
+        .execute();
+
+      logger.info(`${users.length} utilisateurs à synchroniser${dryRun ? ' (dry-run)' : ''}`);
+
+      let success = 0;
+      let errors = 0;
+
+      for (const user of users) {
+        if (dryRun) {
+          logger.info(`[dry-run] ${user.email} (${user.role})`);
+          continue;
+        }
+
+        try {
+          await createContact({
+            abonnementNewsletter: !!user.optin_at,
+            dateCreation: user.created_at ? dayjs(user.created_at).format('YYYY-MM-DDTHH:mm:ss') : undefined,
+            email: user.email,
+            nom: user.last_name ?? undefined,
+            prenom: user.first_name ?? undefined,
+            telephone: user.phone ?? undefined,
+            typeOrganisme: ROLE_TYPE_ORGANISME[user.role],
+          });
+          logger.info(`✓ ${user.email}`);
+          success++;
+        } catch (error) {
+          logger.error(`✗ ${user.email}`, { error });
+          errors++;
+        }
+      }
+
+      if (!dryRun) {
+        logger.info(`Terminé : ${success} créés, ${errors} erreurs`);
+      }
+    });
+}

--- a/src/modules/ademe-connect/commands.ts
+++ b/src/modules/ademe-connect/commands.ts
@@ -4,7 +4,6 @@ import { z } from 'zod';
 
 import { buildRubriques, ROLE_TYPE_ORGANISME } from '@/modules/ademe-connect/constants';
 import { createContact, getContact } from '@/modules/ademe-connect/server/client';
-import { structureTypesLabels } from '@/modules/users/constants';
 import { kdb } from '@/server/db/kysely';
 import { logger } from '@/server/helpers/logger';
 import { isOneOf } from '@/utils/array';
@@ -74,7 +73,7 @@ export function registerAdemeConnectCommands(parentProgram: Command) {
             email: user.email,
             nom: user.last_name ?? undefined,
             prenom: user.first_name ?? undefined,
-            rubriques: buildRubriques(user.role, user.structure_type && structureTypesLabels[user.structure_type]),
+            rubriques: buildRubriques(user.role, user.structure_type),
             telephone: user.phone ?? undefined,
             typeOrganisme: ROLE_TYPE_ORGANISME[user.role],
           });

--- a/src/modules/ademe-connect/commands.ts
+++ b/src/modules/ademe-connect/commands.ts
@@ -2,10 +2,12 @@ import type { Command } from '@commander-js/extra-typings';
 import dayjs from 'dayjs';
 import { z } from 'zod';
 
-import { ROLE_TYPE_ORGANISME } from '@/modules/ademe-connect/constants';
+import { buildRubriques, ROLE_TYPE_ORGANISME } from '@/modules/ademe-connect/constants';
 import { createContact, getContact } from '@/modules/ademe-connect/server/client';
+import { structureTypesLabels } from '@/modules/users/constants';
 import { kdb } from '@/server/db/kysely';
 import { logger } from '@/server/helpers/logger';
+import { isOneOf } from '@/utils/array';
 
 export function registerAdemeConnectCommands(parentProgram: Command) {
   const program = parentProgram.command('ademe-connect').description('Commandes pour le CRM ADEME Connect');
@@ -45,7 +47,7 @@ export function registerAdemeConnectCommands(parentProgram: Command) {
     .action(async ({ dryRun }) => {
       const users = await kdb
         .selectFrom('users')
-        .select(['email', 'first_name', 'last_name', 'phone', 'role', 'optin_at', 'created_at'])
+        .select(['email', 'first_name', 'last_name', 'phone', 'role', 'structure_type', 'optin_at', 'created_at', 'last_connection'])
         .where('role', 'in', ['particulier', 'professionnel', 'gestionnaire'])
         .where('status', '=', 'valid')
         .orderBy('created_at', 'asc')
@@ -65,10 +67,14 @@ export function registerAdemeConnectCommands(parentProgram: Command) {
         try {
           await createContact({
             abonnementNewsletter: !!user.optin_at,
+            acceptationRGPD: isOneOf(user.role, ['particulier', 'professionnel']),
+            dateConnexion: user.last_connection ? dayjs(user.last_connection).format('YYYY-MM-DDTHH:mm:ss') : undefined,
             dateCreation: user.created_at ? dayjs(user.created_at).format('YYYY-MM-DDTHH:mm:ss') : undefined,
+            dateNewsletter: user.optin_at ? dayjs(user.optin_at).format('YYYY-MM-DD') : undefined,
             email: user.email,
             nom: user.last_name ?? undefined,
             prenom: user.first_name ?? undefined,
+            rubriques: buildRubriques(user.role, user.structure_type && structureTypesLabels[user.structure_type]),
             telephone: user.phone ?? undefined,
             typeOrganisme: ROLE_TYPE_ORGANISME[user.role],
           });

--- a/src/modules/ademe-connect/constants.ts
+++ b/src/modules/ademe-connect/constants.ts
@@ -5,3 +5,16 @@ export const ROLE_TYPE_ORGANISME: Partial<Record<UserRole, string>> = {
   particulier: 'Particulier',
   professionnel: 'Entreprise',
 };
+
+/**
+ * Builds the `rubriques` array for ADEME Connect from pre-resolved labels.
+ * - roleLabel: human-readable role name (e.g. "Particulier")
+ * - structureLabel: human-readable structure type label (e.g. "Bailleur social")
+ * Returns undefined if no rubrique can be built.
+ */
+export const buildRubriques = (roleLabel?: string | null, structureLabel?: string | null): string[] | undefined => {
+  const items = [roleLabel ? `FCU - compte ${roleLabel}` : null, structureLabel ? `FCU - type ${structureLabel}` : null].filter(
+    (v) => !!v
+  ) as string[];
+  return items.length > 0 ? items : undefined;
+};

--- a/src/modules/ademe-connect/constants.ts
+++ b/src/modules/ademe-connect/constants.ts
@@ -14,7 +14,7 @@ export const ROLE_TYPE_ORGANISME: Partial<Record<UserRole, string>> = {
  */
 export const buildRubriques = (roleLabel?: string | null, structureLabel?: string | null): string[] | undefined => {
   const items = [roleLabel ? `FCU - compte ${roleLabel}` : null, structureLabel ? `FCU - type ${structureLabel}` : null].filter(
-    (v) => !!v
-  ) as string[];
+    (v): v is string => !!v
+  );
   return items.length > 0 ? items : undefined;
 };

--- a/src/modules/ademe-connect/constants.ts
+++ b/src/modules/ademe-connect/constants.ts
@@ -1,0 +1,7 @@
+import type { UserRole } from '@/types/enum/UserRole';
+
+export const ROLE_TYPE_ORGANISME: Partial<Record<UserRole, string>> = {
+  gestionnaire: 'Entreprise',
+  particulier: 'Particulier',
+  professionnel: 'Entreprise',
+};

--- a/src/modules/ademe-connect/constants.ts
+++ b/src/modules/ademe-connect/constants.ts
@@ -29,6 +29,13 @@ const STRUCTURE_RUBRIQUES: Partial<Record<StructureType, string>> = {
 };
 
 /**
+ * All FCU rubriques managed by this app on ADEME Connect.
+ * Used as `rubriquesASupprimer` on update so the contact ends up with only the rubriques
+ * we send in `rubriques` (full sync of FCU rubriques, leaves non-FCU rubriques untouched).
+ */
+export const ALL_FCU_RUBRIQUES: string[] = [...Object.values(ROLE_RUBRIQUES), ...Object.values(STRUCTURE_RUBRIQUES)];
+
+/**
  * Builds the `rubriques` array for ADEME Connect from a user's role and structure type.
  * Returns undefined if no rubrique can be built.
  */

--- a/src/modules/ademe-connect/constants.ts
+++ b/src/modules/ademe-connect/constants.ts
@@ -1,3 +1,4 @@
+import type { StructureType } from '@/modules/users/constants';
 import type { UserRole } from '@/types/enum/UserRole';
 
 export const ROLE_TYPE_ORGANISME: Partial<Record<UserRole, string>> = {
@@ -6,15 +7,32 @@ export const ROLE_TYPE_ORGANISME: Partial<Record<UserRole, string>> = {
   professionnel: 'Entreprise',
 };
 
+// biome-ignore assist/source/useSortedKeys: keep order matching the rubriques list expected on ADEME Connect
+const ROLE_RUBRIQUES: Partial<Record<UserRole, string>> = {
+  particulier: 'FCU - rôle particulier',
+  professionnel: 'FCU - rôle professionnel',
+  gestionnaire: 'FCU - rôle gestionnaire',
+  // collectivite: 'FCU - rôle collectivité',
+  // alec: 'FCU - rôle ALEC',
+};
+
+const STRUCTURE_RUBRIQUES: Partial<Record<StructureType, string>> = {
+  autre: 'FCU - structure Autre',
+  bailleur_social: 'FCU - structure Bailleur social',
+  bureau_etudes: "FCU - structure Bureau d'études",
+  collectivite: 'FCU - structure Collectivité',
+  gestionnaire_parc_tertiaire: 'FCU - structure Gestionnaire de parc tertiaire',
+  gestionnaire_reseaux: 'FCU - structure Gestionnaire de réseau de chaleur',
+  mandataire_cee: 'FCU - structure Mandataire / délégataire CEE',
+  syndic_copropriete: 'FCU - structure Syndic de copropriété',
+  // alec: 'FCU - structure ALEC',
+};
+
 /**
- * Builds the `rubriques` array for ADEME Connect from pre-resolved labels.
- * - roleLabel: human-readable role name (e.g. "Particulier")
- * - structureLabel: human-readable structure type label (e.g. "Bailleur social")
+ * Builds the `rubriques` array for ADEME Connect from a user's role and structure type.
  * Returns undefined if no rubrique can be built.
  */
-export const buildRubriques = (roleLabel?: string | null, structureLabel?: string | null): string[] | undefined => {
-  const items = [roleLabel ? `FCU - compte ${roleLabel}` : null, structureLabel ? `FCU - type ${structureLabel}` : null].filter(
-    (v): v is string => !!v
-  );
+export const buildRubriques = (role?: UserRole | null, structureType?: StructureType | null): string[] | undefined => {
+  const items = [role && ROLE_RUBRIQUES[role], structureType && STRUCTURE_RUBRIQUES[structureType]].filter((v): v is string => !!v);
   return items.length > 0 ? items : undefined;
 };

--- a/src/modules/ademe-connect/server/client.ts
+++ b/src/modules/ademe-connect/server/client.ts
@@ -20,6 +20,7 @@ type ContactData = {
   region?: string;
   telephone?: string;
   telephonePortable?: string;
+  rubriques?: string[];
   fonction?: string;
   typeOrganisme?: string;
   acceptationRGPD?: boolean;

--- a/src/modules/ademe-connect/server/client.ts
+++ b/src/modules/ademe-connect/server/client.ts
@@ -46,6 +46,8 @@ function stripEmpty(obj: Record<string, unknown>): Record<string, unknown> {
   return Object.fromEntries(Object.entries(obj).filter(([, v]) => v !== undefined && v !== null && v !== ''));
 }
 
+const isConfigured = () => !!serverConfig.ADEME_CONNECT_CLIENT_ID && !!serverConfig.ADEME_CONNECT_CLIENT_SECRET;
+
 function getAuthHeaders(): Record<string, string> {
   return {
     client_id: serverConfig.ADEME_CONNECT_CLIENT_ID ?? '',
@@ -55,13 +57,19 @@ function getAuthHeaders(): Record<string, string> {
 
 const nowIso = () => dayjs().format('YYYY-MM-DDTHH:mm:ss');
 
-export const createContact = async (data: ContactData): Promise<ContactResponse> => {
+export const createContact = async (data: ContactData): Promise<ContactResponse | null> => {
+  if (!isConfigured()) {
+    return null;
+  }
   logger.info('ademe-connect createContact', { email: pseudonymizeEmail(data.email), type: data.typeOrganisme });
   const payload = stripEmpty({ dateCreation: nowIso(), ...data, source: serverConfig.ADEME_CONNECT_SOURCE ?? '' });
   return postFetchJSON<ContactResponse>(`${serverConfig.ADEME_CONNECT_BASE_URL}/personnes`, payload, getAuthHeaders());
 };
 
-export const updateContact = async (mail: string, data: Partial<Omit<ContactData, 'email'>>): Promise<ContactResponse> => {
+export const updateContact = async (mail: string, data: Partial<Omit<ContactData, 'email'>>): Promise<ContactResponse | null> => {
+  if (!isConfigured()) {
+    return null;
+  }
   logger.info('ademe-connect updateContact', { email: pseudonymizeEmail(mail) });
   const payload = stripEmpty({ dateModification: nowIso(), email: mail, source: serverConfig.ADEME_CONNECT_SOURCE ?? '', ...data });
   return putFetchJSON<ContactResponse>(
@@ -72,6 +80,9 @@ export const updateContact = async (mail: string, data: Partial<Omit<ContactData
 };
 
 export const getContact = async (mail: string): Promise<unknown> => {
+  if (!isConfigured()) {
+    throw new Error('ADEME Connect is not configured (missing ADEME_CONNECT_CLIENT_ID / ADEME_CONNECT_CLIENT_SECRET)');
+  }
   logger.info('ademe-connect getContact', { email: pseudonymizeEmail(mail) });
   return fetchJSON(`${serverConfig.ADEME_CONNECT_BASE_URL}/personnes/mail/${encodeURIComponent(mail)}`, {
     headers: getAuthHeaders(),

--- a/src/modules/ademe-connect/server/client.ts
+++ b/src/modules/ademe-connect/server/client.ts
@@ -21,6 +21,7 @@ type ContactData = {
   telephone?: string;
   telephonePortable?: string;
   rubriques?: string[];
+  rubriquesASupprimer?: string[];
   fonction?: string;
   typeOrganisme?: string;
   acceptationRGPD?: boolean;

--- a/src/modules/ademe-connect/server/client.ts
+++ b/src/modules/ademe-connect/server/client.ts
@@ -1,0 +1,78 @@
+import dayjs from 'dayjs';
+
+import { serverConfig } from '@/server/config';
+import { logger } from '@/server/helpers/logger';
+import { pseudonymizeEmail } from '@/utils/email';
+import { fetchJSON, postFetchJSON, putFetchJSON } from '@/utils/network';
+
+type ContactData = {
+  email: string;
+  // source: string; défini en dur
+  siret?: string;
+  titre?: string;
+  nom?: string;
+  prenom?: string;
+  adressePostale?: string;
+  complementAdresse?: string;
+  cedexBP?: string;
+  codePostal?: string;
+  ville?: string;
+  region?: string;
+  telephone?: string;
+  telephonePortable?: string;
+  fonction?: string;
+  typeOrganisme?: string;
+  acceptationRGPD?: boolean;
+  dateCreation?: string;
+  dateModification?: string;
+  dateConnexion?: string;
+  abonnementNewsletter?: boolean;
+  dateNewsletter?: string;
+  dateFinNewsletter?: string;
+  actif?: boolean;
+};
+
+type ContactResponse = {
+  correlationId: string;
+  success: boolean;
+  timestamp: string;
+  message: string;
+  mail: string;
+};
+
+// Strip undefined, null, and empty string values (API rule: no empty tags)
+function stripEmpty(obj: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(obj).filter(([, v]) => v !== undefined && v !== null && v !== ''));
+}
+
+function getAuthHeaders(): Record<string, string> {
+  return {
+    client_id: serverConfig.ADEME_CONNECT_CLIENT_ID ?? '',
+    client_secret: serverConfig.ADEME_CONNECT_CLIENT_SECRET ?? '',
+  };
+}
+
+const nowIso = () => dayjs().format('YYYY-MM-DDTHH:mm:ss');
+
+export const createContact = async (data: ContactData): Promise<ContactResponse> => {
+  logger.info('ademe-connect createContact', { email: pseudonymizeEmail(data.email), type: data.typeOrganisme });
+  const payload = stripEmpty({ dateCreation: nowIso(), ...data, source: serverConfig.ADEME_CONNECT_SOURCE ?? '' });
+  return postFetchJSON<ContactResponse>(`${serverConfig.ADEME_CONNECT_BASE_URL}/personnes`, payload, getAuthHeaders());
+};
+
+export const updateContact = async (mail: string, data: Partial<Omit<ContactData, 'email'>>): Promise<ContactResponse> => {
+  logger.info('ademe-connect updateContact', { email: pseudonymizeEmail(mail) });
+  const payload = stripEmpty({ dateModification: nowIso(), email: mail, source: serverConfig.ADEME_CONNECT_SOURCE ?? '', ...data });
+  return putFetchJSON<ContactResponse>(
+    `${serverConfig.ADEME_CONNECT_BASE_URL}/personnes/mail/${encodeURIComponent(mail)}`,
+    payload,
+    getAuthHeaders()
+  );
+};
+
+export const getContact = async (mail: string): Promise<unknown> => {
+  logger.info('ademe-connect getContact', { email: pseudonymizeEmail(mail) });
+  return fetchJSON(`${serverConfig.ADEME_CONNECT_BASE_URL}/personnes/mail/${encodeURIComponent(mail)}`, {
+    headers: getAuthHeaders(),
+  });
+};

--- a/src/modules/auth/server/service.ts
+++ b/src/modules/auth/server/service.ts
@@ -1,6 +1,9 @@
 import bcrypt, { genSalt, hash } from 'bcryptjs';
+import dayjs from 'dayjs';
 import jwt from 'jsonwebtoken';
 
+import { ROLE_TYPE_ORGANISME } from '@/modules/ademe-connect/constants';
+import { createContact, updateContact } from '@/modules/ademe-connect/server/client';
 import { linkDemandsByEmail } from '@/modules/demands/server/demands-service';
 import { sendEmailTemplate } from '@/modules/email';
 import { createUserEvent } from '@/modules/events/server/service';
@@ -64,6 +67,16 @@ export const register = async ({
     context_type: 'user',
     type: 'user_created',
   });
+
+  createContact({
+    abonnementNewsletter: optin_newsletter,
+    email: insertedUser.email,
+    nom: userData.last_name,
+    prenom: userData.first_name,
+    telephone: userData.phone ?? undefined,
+    typeOrganisme: ROLE_TYPE_ORGANISME[role],
+  }).catch((error) => logger.error('ademe-connect createContact failed on register', { error, user_id: insertedUser.id }));
+
   return insertedUser.id;
 };
 
@@ -95,6 +108,10 @@ export const login = async (email: string, password: string) => {
     context_type: 'user',
     type: 'user_login',
   });
+
+  updateContact(user.email, { dateConnexion: dayjs().format('YYYY-MM-DDTHH:mm:ss') }).catch((error) =>
+    logger.error('ademe-connect updateContact failed on login', { error, user_id: user.id })
+  );
 
   // Link demands by email on every login
   try {

--- a/src/modules/auth/server/service.ts
+++ b/src/modules/auth/server/service.ts
@@ -7,7 +7,7 @@ import { createContact, updateContact } from '@/modules/ademe-connect/server/cli
 import { linkDemandsByEmail } from '@/modules/demands/server/demands-service';
 import { sendEmailTemplate } from '@/modules/email';
 import { createUserEvent } from '@/modules/events/server/service';
-import { type StructureType, structureTypesLabels } from '@/modules/users/constants';
+import type { StructureType } from '@/modules/users/constants';
 import { AirtableDB } from '@/server/db/airtable';
 import { kdb } from '@/server/db/kysely';
 import { logger } from '@/server/helpers/logger';
@@ -75,7 +75,7 @@ export const register = async ({
     email: insertedUser.email,
     nom: userData.last_name,
     prenom: userData.first_name,
-    rubriques: buildRubriques(role, userData.structure_type && structureTypesLabels[userData.structure_type]),
+    rubriques: buildRubriques(role, userData.structure_type),
     telephone: userData.phone ?? undefined,
     typeOrganisme: ROLE_TYPE_ORGANISME[role],
   }).catch((error) => logger.error('ademe-connect createContact failed on register', { error, user_id: insertedUser.id }));

--- a/src/modules/auth/server/service.ts
+++ b/src/modules/auth/server/service.ts
@@ -2,11 +2,12 @@ import bcrypt, { genSalt, hash } from 'bcryptjs';
 import dayjs from 'dayjs';
 import jwt from 'jsonwebtoken';
 
-import { ROLE_TYPE_ORGANISME } from '@/modules/ademe-connect/constants';
+import { buildRubriques, ROLE_TYPE_ORGANISME } from '@/modules/ademe-connect/constants';
 import { createContact, updateContact } from '@/modules/ademe-connect/server/client';
 import { linkDemandsByEmail } from '@/modules/demands/server/demands-service';
 import { sendEmailTemplate } from '@/modules/email';
 import { createUserEvent } from '@/modules/events/server/service';
+import { type StructureType, structureTypesLabels } from '@/modules/users/constants';
 import { AirtableDB } from '@/server/db/airtable';
 import { kdb } from '@/server/db/kysely';
 import { logger } from '@/server/helpers/logger';
@@ -29,7 +30,7 @@ export const register = async ({
   first_name: string;
   last_name: string;
   structure?: string;
-  structure_type?: string;
+  structure_type?: StructureType;
   structure_other?: string;
   phone?: string | null;
   accept_cgu?: boolean;
@@ -70,9 +71,11 @@ export const register = async ({
 
   createContact({
     abonnementNewsletter: optin_newsletter,
+    acceptationRGPD: true,
     email: insertedUser.email,
     nom: userData.last_name,
     prenom: userData.first_name,
+    rubriques: buildRubriques(role, userData.structure_type && structureTypesLabels[userData.structure_type]),
     telephone: userData.phone ?? undefined,
     typeOrganisme: ROLE_TYPE_ORGANISME[role],
   }).catch((error) => logger.error('ademe-connect createContact failed on register', { error, user_id: insertedUser.id }));

--- a/src/modules/auth/server/service.ts
+++ b/src/modules/auth/server/service.ts
@@ -66,7 +66,7 @@ export const register = async ({
     author_id: insertedUser.id,
     context_id: insertedUser.id,
     context_type: 'user',
-    type: 'user_created',
+    type: 'user_registered',
   });
 
   createContact({

--- a/src/modules/events/client/EventRow.tsx
+++ b/src/modules/events/client/EventRow.tsx
@@ -136,6 +136,24 @@ export const eventLabelRenderers: { [T in EventType]: EventRenderer<T> } = {
       </FilterButton>
     </>
   ),
+  user_created_api: (event, updateFilters) => (
+    <>
+      <span>
+        API <strong>{event.data.api_name}</strong> a créé le compte{' '}
+      </span>
+      <FilterButton onClick={() => updateFilters({ contextId: event.context_id, contextType: 'user' })}>
+        {event.data.role && <UserRoleBadge role={event.data.role} />}&nbsp;{event.data.email}
+      </FilterButton>
+    </>
+  ),
+  user_deactivated_api: (event, updateFilters) => (
+    <>
+      <span>
+        API <strong>{event.data.api_name}</strong> a désactivé le compte{' '}
+      </span>
+      <FilterButton onClick={() => updateFilters({ contextId: event.context_id, contextType: 'user' })}>{event.data.email}</FilterButton>
+    </>
+  ),
   user_deleted: () => 'a supprimé un compte',
   user_login: () => "s'est connecté",
   user_newsletter_subscribed: () => "s'est abonné à la newsletter",
@@ -143,6 +161,14 @@ export const eventLabelRenderers: { [T in EventType]: EventRenderer<T> } = {
   user_password_reset_requested: () => 'a demandé une réinitialisation de mot de passe',
   user_registered: () => 'a créé un compte',
   user_updated: () => 'a mis à jour son profil',
+  user_updated_api: (event, updateFilters) => (
+    <>
+      <span>
+        API <strong>{event.data.api_name}</strong> a mis à jour les tags de{' '}
+      </span>
+      <FilterButton onClick={() => updateFilters({ contextId: event.context_id, contextType: 'user' })}>{event.data.email}</FilterButton>
+    </>
+  ),
 };
 
 type EventRowProps = {

--- a/src/modules/events/client/EventRow.tsx
+++ b/src/modules/events/client/EventRow.tsx
@@ -131,8 +131,10 @@ export const eventLabelRenderers: { [T in EventType]: EventRenderer<T> } = {
   user_created: () => 'a créé un compte',
   user_deleted: () => 'a supprimé un compte',
   user_login: () => "s'est connecté",
+  user_newsletter_subscribed: () => "s'est abonné à la newsletter",
+  user_newsletter_unsubscribed: () => "s'est désabonné de la newsletter",
   user_password_reset_requested: () => 'a demandé une réinitialisation de mot de passe',
-  user_updated: () => 'a mis à jour un compte',
+  user_updated: () => 'a mis à jour son profil',
 };
 
 type EventRowProps = {

--- a/src/modules/events/client/EventRow.tsx
+++ b/src/modules/events/client/EventRow.tsx
@@ -128,12 +128,20 @@ export const eventLabelRenderers: { [T in EventType]: EventRenderer<T> } = {
     </>
   ),
   user_activated: () => 'a activé son compte',
-  user_created: () => 'a créé un compte',
+  user_created: (event, updateFilters) => (
+    <>
+      <span>a créé le compte </span>
+      <FilterButton onClick={() => updateFilters({ contextId: event.context_id, contextType: 'user' })}>
+        {event.data.role && <UserRoleBadge role={event.data.role} />}&nbsp;{event.data.email}
+      </FilterButton>
+    </>
+  ),
   user_deleted: () => 'a supprimé un compte',
   user_login: () => "s'est connecté",
   user_newsletter_subscribed: () => "s'est abonné à la newsletter",
   user_newsletter_unsubscribed: () => "s'est désabonné de la newsletter",
   user_password_reset_requested: () => 'a demandé une réinitialisation de mot de passe',
+  user_registered: () => 'a créé un compte',
   user_updated: () => 'a mis à jour son profil',
 };
 

--- a/src/modules/events/constants.ts
+++ b/src/modules/events/constants.ts
@@ -5,7 +5,10 @@ export const eventTypes = [
   'user_activated',
   'user_registered',
   'user_created',
+  'user_created_api',
+  'user_deactivated_api',
   'user_updated',
+  'user_updated_api',
   'user_newsletter_subscribed',
   'user_newsletter_unsubscribed',
   'user_deleted',
@@ -51,6 +54,8 @@ export const eventTypeLabels: Record<EventType, string> = {
   tag_reminder_deleted: 'Suppression rappel tag',
   user_activated: 'Activation utilisateur',
   user_created: 'Création utilisateur (admin)',
+  user_created_api: 'Création utilisateur (API)',
+  user_deactivated_api: 'Désactivation utilisateur (API)',
   user_deleted: 'Suppression utilisateur',
   user_login: 'Connexion utilisateur',
   user_newsletter_subscribed: 'Abonnement newsletter',
@@ -58,6 +63,7 @@ export const eventTypeLabels: Record<EventType, string> = {
   user_password_reset_requested: 'Demande réinitialisation mot de passe',
   user_registered: 'Inscription utilisateur',
   user_updated: 'Mise à jour profil utilisateur',
+  user_updated_api: 'Mise à jour utilisateur (API)',
 };
 
 export type EventDataMap = {
@@ -80,6 +86,8 @@ export type EventDataMap = {
   tag_reminder_deleted: { tag_name: string };
   user_activated: null;
   user_created: { email: string; role: UserRole };
+  user_created_api: { api_name: string; email: string; role: UserRole };
+  user_deactivated_api: { api_name: string; email: string };
   user_registered: null;
   user_deleted: null;
   user_login: null;
@@ -87,6 +95,7 @@ export type EventDataMap = {
   user_newsletter_subscribed: null;
   user_newsletter_unsubscribed: null;
   user_updated: null;
+  user_updated_api: { api_name: string; email: string; gestionnaires_before: string[]; gestionnaires_after: string[] };
 };
 
 export const eventGranularities = ['minute', 'hour', 'day', 'week', 'month', 'year'] as const;

--- a/src/modules/events/constants.ts
+++ b/src/modules/events/constants.ts
@@ -1,6 +1,9 @@
+import type { UserRole } from '@/types/enum/UserRole';
+
 export const eventTypes = [
   'user_login',
   'user_activated',
+  'user_registered',
   'user_created',
   'user_updated',
   'user_newsletter_subscribed',
@@ -47,12 +50,13 @@ export const eventTypeLabels: Record<EventType, string> = {
   tag_reminder_created: 'Création rappel tag',
   tag_reminder_deleted: 'Suppression rappel tag',
   user_activated: 'Activation utilisateur',
-  user_created: 'Création utilisateur',
+  user_created: 'Création utilisateur (admin)',
   user_deleted: 'Suppression utilisateur',
   user_login: 'Connexion utilisateur',
   user_newsletter_subscribed: 'Abonnement newsletter',
   user_newsletter_unsubscribed: 'Désabonnement newsletter',
   user_password_reset_requested: 'Demande réinitialisation mot de passe',
+  user_registered: 'Inscription utilisateur',
   user_updated: 'Mise à jour profil utilisateur',
 };
 
@@ -75,7 +79,8 @@ export type EventDataMap = {
   tag_reminder_created: { tag_name: string };
   tag_reminder_deleted: { tag_name: string };
   user_activated: null;
-  user_created: null;
+  user_created: { email: string; role: UserRole };
+  user_registered: null;
   user_deleted: null;
   user_login: null;
   user_password_reset_requested: null;

--- a/src/modules/events/constants.ts
+++ b/src/modules/events/constants.ts
@@ -3,6 +3,8 @@ export const eventTypes = [
   'user_activated',
   'user_created',
   'user_updated',
+  'user_newsletter_subscribed',
+  'user_newsletter_unsubscribed',
   'user_deleted',
   'user_password_reset_requested',
   'demand_created',
@@ -48,8 +50,10 @@ export const eventTypeLabels: Record<EventType, string> = {
   user_created: 'Création utilisateur',
   user_deleted: 'Suppression utilisateur',
   user_login: 'Connexion utilisateur',
+  user_newsletter_subscribed: 'Abonnement newsletter',
+  user_newsletter_unsubscribed: 'Désabonnement newsletter',
   user_password_reset_requested: 'Demande réinitialisation mot de passe',
-  user_updated: 'Mise à jour utilisateur',
+  user_updated: 'Mise à jour profil utilisateur',
 };
 
 export type EventDataMap = {
@@ -75,6 +79,8 @@ export type EventDataMap = {
   user_deleted: null;
   user_login: null;
   user_password_reset_requested: null;
+  user_newsletter_subscribed: null;
+  user_newsletter_unsubscribed: null;
   user_updated: null;
 };
 

--- a/src/modules/events/server/service.ts
+++ b/src/modules/events/server/service.ts
@@ -34,7 +34,9 @@ export async function listEvents(options: ListEventsOptions) {
   let baseQuery = kdb.selectFrom('events');
 
   if (authorIds && authorIds.length > 0) {
-    baseQuery = baseQuery.where('author_id', 'in', authorIds);
+    baseQuery = baseQuery.where((eb) =>
+      eb.or([eb('author_id', 'in', authorIds), eb.and([eb('context_type', '=', 'user'), eb('context_id', 'in', authorIds)])])
+    );
   }
   if (context) {
     baseQuery = baseQuery.where('context_type', '=', context.type).where('context_id', '=', context.id);
@@ -102,7 +104,9 @@ export async function getEventStats(options: EventStatsOptions): Promise<EventSt
       q = q.where('type', 'in', types);
     }
     if (authorIds && authorIds.length > 0) {
-      q = q.where('author_id', 'in', authorIds);
+      q = q.where((eb) =>
+        eb.or([eb('author_id', 'in', authorIds), eb.and([eb('context_type', '=', 'user'), eb('context_id', 'in', authorIds)])])
+      );
     }
     if (context) {
       q = q.where('context_type', '=', context.type).where('context_id', '=', context.id);

--- a/src/modules/users/constants.ts
+++ b/src/modules/users/constants.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { type UserRole, userRoles, userRolesInscription } from '@/types/enum/UserRole';
+import { ObjectKeys } from '@/utils/typescript';
 
 /** Label des types de structure  */
 // biome-ignore assist/source/useSortedKeys: keep field order for clarity and maintainability
@@ -14,6 +15,8 @@ export const structureTypesLabels = {
   syndic_copropriete: 'Syndic de copropriété',
   autre: 'Autre',
 };
+
+export type StructureType = keyof typeof structureTypesLabels;
 
 /** Labels utilisés sur le formulaire */
 export const structureTypesFormLabels = {
@@ -58,7 +61,7 @@ export const zIdentitySchema = z
     role: z.enum(userRolesInscription),
     structure_name: z.string().min(0, 'La structure est obligatoire').optional(),
     structure_other: z.string().optional(),
-    structure_type: z.string().optional(),
+    structure_type: z.enum(ObjectKeys(structureTypesLabels)).optional(),
   })
   .refine((data) => !(data.structure_type === 'autre' && !data.structure_other), {
     message: "Le type de structure 'Autre' doit être précisé",
@@ -91,7 +94,7 @@ export const createUserAdminSchema = z.object({
   role: z.enum(userRoles),
   structure_name: z.string().optional().nullable(),
   structure_other: z.string().optional().nullable(),
-  structure_type: z.string().optional().nullable(),
+  structure_type: z.enum(ObjectKeys(structureTypesLabels)).optional().nullable(),
 });
 
 export const updateUserAdminSchema = z
@@ -109,7 +112,7 @@ export const updateUserAdminSchema = z
     status: z.enum(['pending_email_confirmation', 'valid']),
     structure_name: z.string().optional(),
     structure_other: z.string().optional(),
-    structure_type: z.string().optional(),
+    structure_type: z.enum(ObjectKeys(structureTypesLabels)).optional(),
   })
   .partial();
 
@@ -126,7 +129,7 @@ export const zUpdateProfileSchema = z
       }),
     structure_name: z.string().optional(),
     structure_other: z.string().optional(),
-    structure_type: z.string().optional(),
+    structure_type: z.enum(ObjectKeys(structureTypesLabels)).optional(),
   })
   .refine((data) => !(data.structure_type === 'autre' && !data.structure_other), {
     message: "Le type de structure 'Autre' doit être précisé",
@@ -139,11 +142,17 @@ export const zUpdateProfileSchema = z
 
 export type UpdateProfileSchema = z.infer<typeof zUpdateProfileSchema>;
 
+export const zUpdateNewsletterSchema = z.object({
+  optin_newsletter: z.boolean(),
+});
+
+export type UpdateNewsletterSchema = z.infer<typeof zUpdateNewsletterSchema>;
+
 export const updateProfileDefaultValues: UpdateProfileSchema = {
   first_name: '',
   last_name: '',
   phone: '',
   structure_name: '',
   structure_other: '',
-  structure_type: '',
+  structure_type: undefined,
 };

--- a/src/modules/users/server/service.ts
+++ b/src/modules/users/server/service.ts
@@ -62,13 +62,15 @@ export const create: typeof baseModel.create = async ({ optin_at, ...data }, _co
 
   const record = await baseModel.create({ ...data, optin_at: optin_at ? new Date() : null, password, status: 'valid' }, _context);
 
-  await createUserEvent({
-    author_id: _context.userId!,
-    context_id: (record as any).id,
-    context_type: 'user',
-    data: { email: data.email as string, role: data.role as UserRole },
-    type: 'user_created',
-  });
+  if (_context.userId) {
+    await createUserEvent({
+      author_id: _context.userId,
+      context_id: (record as any).id,
+      context_type: 'user',
+      data: { email: data.email as string, role: data.role as UserRole },
+      type: 'user_created',
+    });
+  }
 
   if (data.active && data.role === 'gestionnaire') {
     await sendEmailTemplate('auth.inscription', { email: data.email as string, id: (record as any).id });
@@ -79,8 +81,8 @@ export const create: typeof baseModel.create = async ({ optin_at, ...data }, _co
       abonnementNewsletter: false,
       acceptationRGPD: false,
       email: data.email as string,
-      nom: (data.last_name as string) || '',
-      prenom: (data.first_name as string) || '',
+      nom: (data.last_name as string) || undefined,
+      prenom: (data.first_name as string) || undefined,
       rubriques: buildRubriques(data.role, data.structure_type && structureTypesLabels[data.structure_type as StructureType]),
       telephone: (data.phone as string) || undefined,
       typeOrganisme: ROLE_TYPE_ORGANISME[data.role],

--- a/src/modules/users/server/service.ts
+++ b/src/modules/users/server/service.ts
@@ -105,7 +105,7 @@ export const validation = {
 export const getProfile = async (userId: string) => {
   return kdb
     .selectFrom('users')
-    .select(['id', 'email', 'role', 'first_name', 'last_name', 'phone', 'structure_name', 'structure_type', 'structure_other'])
+    .select(['id', 'email', 'role', 'first_name', 'last_name', 'phone', 'structure_name', 'structure_type', 'structure_other', 'optin_at'])
     .where('id', '=', userId)
     .executeTakeFirst();
 };
@@ -114,4 +114,12 @@ export const updateProfile = async (userId: string, data: UpdateProfileSchema) =
   const result = await kdb.updateTable('users').set(data).where('id', '=', userId).executeTakeFirst();
 
   return result.numUpdatedRows > 0;
+};
+
+export const updateNewsletterSubscription = async (userId: string, optin: boolean) => {
+  await kdb
+    .updateTable('users')
+    .set({ optin_at: optin ? new Date() : null })
+    .where('id', '=', userId)
+    .executeTakeFirstOrThrow();
 };

--- a/src/modules/users/server/service.ts
+++ b/src/modules/users/server/service.ts
@@ -2,11 +2,11 @@ import bcrypt from 'bcryptjs';
 import type { UpdateObject } from 'kysely';
 
 import { buildRubriques, ROLE_TYPE_ORGANISME } from '@/modules/ademe-connect/constants';
-import { createContact, updateContact } from '@/modules/ademe-connect/server/client';
+import { createContact } from '@/modules/ademe-connect/server/client';
 import { sendEmailTemplate } from '@/modules/email';
 import { createUserEvent } from '@/modules/events/server/service';
 import { createUserAdminSchema, type StructureType, type UpdateProfileSchema, updateUserAdminSchema } from '@/modules/users/constants';
-import { type DB, kdb, sql, type Users } from '@/server/db/kysely';
+import { type DB, kdb, sql } from '@/server/db/kysely';
 import { createBaseModel } from '@/server/db/kysely/base-model';
 import { logger } from '@/server/helpers/logger';
 import type { UserRole } from '@/types/enum/UserRole';
@@ -97,9 +97,10 @@ export const update: typeof baseModel.update = async (id, data, config, _context
  */
 export const remove: typeof baseModel.remove = async (id, config, context) => {
   const record = await baseModel.remove(id, config, context);
-  updateContact((record as Users).email, { actif: false }).catch((error) =>
-    logger.error('ademe-connect updateContact failed on user delete', { error, user_id: id })
-  );
+  // FIXME vérifier que doit être désactivé suite à réunion ademe connect
+  // updateContact((record as Users).email, { actif: false }).catch((error) =>
+  //   logger.error('ademe-connect updateContact failed on user delete', { error, user_id: id })
+  // );
   return record;
 };
 

--- a/src/modules/users/server/service.ts
+++ b/src/modules/users/server/service.ts
@@ -5,13 +5,7 @@ import { buildRubriques, ROLE_TYPE_ORGANISME } from '@/modules/ademe-connect/con
 import { createContact, updateContact } from '@/modules/ademe-connect/server/client';
 import { sendEmailTemplate } from '@/modules/email';
 import { createUserEvent } from '@/modules/events/server/service';
-import {
-  createUserAdminSchema,
-  type StructureType,
-  structureTypesLabels,
-  type UpdateProfileSchema,
-  updateUserAdminSchema,
-} from '@/modules/users/constants';
+import { createUserAdminSchema, type StructureType, type UpdateProfileSchema, updateUserAdminSchema } from '@/modules/users/constants';
 import { type DB, kdb, sql, type Users } from '@/server/db/kysely';
 import { createBaseModel } from '@/server/db/kysely/base-model';
 import { logger } from '@/server/helpers/logger';
@@ -83,7 +77,7 @@ export const create: typeof baseModel.create = async ({ optin_at, ...data }, _co
       email: data.email as string,
       nom: (data.last_name as string) || undefined,
       prenom: (data.first_name as string) || undefined,
-      rubriques: buildRubriques(data.role, data.structure_type && structureTypesLabels[data.structure_type as StructureType]),
+      rubriques: buildRubriques(data.role, data.structure_type as StructureType | null | undefined),
       telephone: (data.phone as string) || undefined,
       typeOrganisme: ROLE_TYPE_ORGANISME[data.role],
     }).catch((error) => logger.error('ademe-connect createContact failed on user.invite', { error, user_id: record.id }));

--- a/src/modules/users/server/service.ts
+++ b/src/modules/users/server/service.ts
@@ -4,6 +4,7 @@ import type { UpdateObject } from 'kysely';
 import { buildRubriques, ROLE_TYPE_ORGANISME } from '@/modules/ademe-connect/constants';
 import { createContact, updateContact } from '@/modules/ademe-connect/server/client';
 import { sendEmailTemplate } from '@/modules/email';
+import { createUserEvent } from '@/modules/events/server/service';
 import {
   createUserAdminSchema,
   type StructureType,
@@ -14,6 +15,7 @@ import {
 import { type DB, kdb, sql, type Users } from '@/server/db/kysely';
 import { createBaseModel } from '@/server/db/kysely/base-model';
 import { logger } from '@/server/helpers/logger';
+import type { UserRole } from '@/types/enum/UserRole';
 import { isOneOf } from '@/utils/array';
 
 export const tableName = 'users';
@@ -59,6 +61,14 @@ export const create: typeof baseModel.create = async ({ optin_at, ...data }, _co
   const password = await bcrypt.hash(Math.random().toString(36).slice(2, 10), salt);
 
   const record = await baseModel.create({ ...data, optin_at: optin_at ? new Date() : null, password, status: 'valid' }, _context);
+
+  await createUserEvent({
+    author_id: _context.userId!,
+    context_id: (record as any).id,
+    context_type: 'user',
+    data: { email: data.email as string, role: data.role as UserRole },
+    type: 'user_created',
+  });
 
   if (data.active && data.role === 'gestionnaire') {
     await sendEmailTemplate('auth.inscription', { email: data.email as string, id: (record as any).id });

--- a/src/modules/users/server/service.ts
+++ b/src/modules/users/server/service.ts
@@ -1,10 +1,20 @@
 import bcrypt from 'bcryptjs';
 import type { UpdateObject } from 'kysely';
 
+import { buildRubriques, ROLE_TYPE_ORGANISME } from '@/modules/ademe-connect/constants';
+import { createContact, updateContact } from '@/modules/ademe-connect/server/client';
 import { sendEmailTemplate } from '@/modules/email';
-import { createUserAdminSchema, type UpdateProfileSchema, updateUserAdminSchema } from '@/modules/users/constants';
-import { type DB, kdb, sql } from '@/server/db/kysely';
+import {
+  createUserAdminSchema,
+  type StructureType,
+  structureTypesLabels,
+  type UpdateProfileSchema,
+  updateUserAdminSchema,
+} from '@/modules/users/constants';
+import { type DB, kdb, sql, type Users } from '@/server/db/kysely';
 import { createBaseModel } from '@/server/db/kysely/base-model';
+import { logger } from '@/server/helpers/logger';
+import { isOneOf } from '@/utils/array';
 
 export const tableName = 'users';
 
@@ -54,6 +64,19 @@ export const create: typeof baseModel.create = async ({ optin_at, ...data }, _co
     await sendEmailTemplate('auth.inscription', { email: data.email as string, id: (record as any).id });
   }
 
+  if (isOneOf(data.role, ['gestionnaire', 'particulier', 'professionnel'] as const)) {
+    createContact({
+      abonnementNewsletter: false,
+      acceptationRGPD: false,
+      email: data.email as string,
+      nom: (data.last_name as string) || '',
+      prenom: (data.first_name as string) || '',
+      rubriques: buildRubriques(data.role, data.structure_type && structureTypesLabels[data.structure_type as StructureType]),
+      telephone: (data.phone as string) || undefined,
+      typeOrganisme: ROLE_TYPE_ORGANISME[data.role],
+    }).catch((error) => logger.error('ademe-connect createContact failed on user.invite', { error, user_id: record.id }));
+  }
+
   return record;
 };
 export const update: typeof baseModel.update = async (id, data, config, _context) => {
@@ -64,8 +87,15 @@ export const update: typeof baseModel.update = async (id, data, config, _context
 
 /**
  * Supprime un utilisateur et toutes ses données associées en cascade.
+ * Marque le contact comme inactif dans ADEME Connect.
  */
-export const remove = baseModel.remove;
+export const remove: typeof baseModel.remove = async (id, config, context) => {
+  const record = await baseModel.remove(id, config, context);
+  updateContact((record as Users).email, { actif: false }).catch((error) =>
+    logger.error('ademe-connect updateContact failed on user delete', { error, user_id: id })
+  );
+  return record;
+};
 
 export const validation = {
   create: createUserAdminSchema,

--- a/src/modules/users/server/trpc-routes.integration.spec.ts
+++ b/src/modules/users/server/trpc-routes.integration.spec.ts
@@ -50,7 +50,6 @@ describe('usersRouter', () => {
           phone: null,
           structure_name: '',
           structure_other: '',
-          structure_type: '',
         });
 
       if (allowed) {

--- a/src/modules/users/server/trpc-routes.ts
+++ b/src/modules/users/server/trpc-routes.ts
@@ -1,7 +1,7 @@
 import { TRPCError } from '@trpc/server';
 import dayjs from 'dayjs';
 
-import { buildRubriques } from '@/modules/ademe-connect/constants';
+import { ALL_FCU_RUBRIQUES, buildRubriques } from '@/modules/ademe-connect/constants';
 import { updateContact } from '@/modules/ademe-connect/server/client';
 import { createUserEvent } from '@/modules/events/server/service';
 import { routeAuthenticated, router } from '@/modules/trpc/server/connection';
@@ -57,6 +57,7 @@ export const usersRouter = router({
       nom: input.last_name,
       prenom: input.first_name,
       rubriques: buildRubriques(ctx.user.role, input.structure_type),
+      rubriquesASupprimer: ALL_FCU_RUBRIQUES,
       telephone: input.phone ?? undefined,
     }).catch((error) => logger.error('ademe-connect updateContact failed on updateProfile', { error, user_id: ctx.user.id }));
   }),

--- a/src/modules/users/server/trpc-routes.ts
+++ b/src/modules/users/server/trpc-routes.ts
@@ -1,8 +1,11 @@
 import { TRPCError } from '@trpc/server';
+import dayjs from 'dayjs';
 
+import { buildRubriques } from '@/modules/ademe-connect/constants';
 import { updateContact } from '@/modules/ademe-connect/server/client';
+import { createUserEvent } from '@/modules/events/server/service';
 import { routeAuthenticated, router } from '@/modules/trpc/server/connection';
-import { zUpdateProfileSchema } from '@/modules/users/constants';
+import { structureTypesLabels, zUpdateNewsletterSchema, zUpdateProfileSchema } from '@/modules/users/constants';
 import * as usersService from '@/modules/users/server/service';
 import { logger } from '@/server/helpers/logger';
 
@@ -17,6 +20,25 @@ export const usersRouter = router({
     return user;
   }),
 
+  updateNewsletterSubscription: routeAuthenticated.input(zUpdateNewsletterSchema).mutation(async ({ ctx, input }) => {
+    await usersService.updateNewsletterSubscription(ctx.user.id, input.optin_newsletter);
+
+    await createUserEvent({
+      author_id: ctx.user.id,
+      context_id: ctx.user.id,
+      context_type: 'user',
+      type: input.optin_newsletter ? 'user_newsletter_subscribed' : 'user_newsletter_unsubscribed',
+    });
+
+    const now = dayjs().format('YYYY-MM-DD');
+    updateContact(ctx.user.email, {
+      abonnementNewsletter: input.optin_newsletter,
+      ...(input.optin_newsletter ? { dateNewsletter: now } : { dateFinNewsletter: now }),
+    }).catch((error) =>
+      logger.error('ademe-connect updateContact failed on updateNewsletterSubscription', { error, user_id: ctx.user.id })
+    );
+  }),
+
   updateProfile: routeAuthenticated.input(zUpdateProfileSchema).mutation(async ({ ctx, input }) => {
     const success = await usersService.updateProfile(ctx.user.id, input);
 
@@ -24,9 +46,17 @@ export const usersRouter = router({
       throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Erreur lors de la mise à jour du profil' });
     }
 
+    await createUserEvent({
+      author_id: ctx.user.id,
+      context_id: ctx.user.id,
+      context_type: 'user',
+      type: 'user_updated',
+    });
+
     updateContact(ctx.user.email, {
       nom: input.last_name,
       prenom: input.first_name,
+      rubriques: buildRubriques(ctx.user.role, input.structure_type && structureTypesLabels[input.structure_type]),
       telephone: input.phone ?? undefined,
     }).catch((error) => logger.error('ademe-connect updateContact failed on updateProfile', { error, user_id: ctx.user.id }));
   }),

--- a/src/modules/users/server/trpc-routes.ts
+++ b/src/modules/users/server/trpc-routes.ts
@@ -1,8 +1,10 @@
 import { TRPCError } from '@trpc/server';
 
+import { updateContact } from '@/modules/ademe-connect/server/client';
 import { routeAuthenticated, router } from '@/modules/trpc/server/connection';
 import { zUpdateProfileSchema } from '@/modules/users/constants';
 import * as usersService from '@/modules/users/server/service';
+import { logger } from '@/server/helpers/logger';
 
 export const usersRouter = router({
   getProfile: routeAuthenticated.query(async ({ ctx }) => {
@@ -21,5 +23,11 @@ export const usersRouter = router({
     if (!success) {
       throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Erreur lors de la mise à jour du profil' });
     }
+
+    updateContact(ctx.user.email, {
+      nom: input.last_name,
+      prenom: input.first_name,
+      telephone: input.phone ?? undefined,
+    }).catch((error) => logger.error('ademe-connect updateContact failed on updateProfile', { error, user_id: ctx.user.id }));
   }),
 });

--- a/src/modules/users/server/trpc-routes.ts
+++ b/src/modules/users/server/trpc-routes.ts
@@ -5,7 +5,7 @@ import { buildRubriques } from '@/modules/ademe-connect/constants';
 import { updateContact } from '@/modules/ademe-connect/server/client';
 import { createUserEvent } from '@/modules/events/server/service';
 import { routeAuthenticated, router } from '@/modules/trpc/server/connection';
-import { structureTypesLabels, zUpdateNewsletterSchema, zUpdateProfileSchema } from '@/modules/users/constants';
+import { zUpdateNewsletterSchema, zUpdateProfileSchema } from '@/modules/users/constants';
 import * as usersService from '@/modules/users/server/service';
 import { logger } from '@/server/helpers/logger';
 
@@ -56,7 +56,7 @@ export const usersRouter = router({
     updateContact(ctx.user.email, {
       nom: input.last_name,
       prenom: input.first_name,
-      rubriques: buildRubriques(ctx.user.role, input.structure_type && structureTypesLabels[input.structure_type]),
+      rubriques: buildRubriques(ctx.user.role, input.structure_type),
       telephone: input.phone ?? undefined,
     }).catch((error) => logger.error('ademe-connect updateContact failed on updateProfile', { error, user_id: ctx.user.id }));
   }),

--- a/src/pages/pro/mon-compte.tsx
+++ b/src/pages/pro/mon-compte.tsx
@@ -1,4 +1,5 @@
 import ProfileForm from '@/components/connexion/ProfileForm';
+import ProfileNewsletterForm from '@/components/connexion/ProfileNewsletterForm';
 import SimplePage from '@/components/shared/page/SimplePage';
 import Heading from '@/components/ui/Heading';
 import { withAuthentication } from '@/server/authentication';
@@ -9,8 +10,19 @@ export default function MonComptePage() {
       <Heading as="h1" color="blue-france">
         Mon compte
       </Heading>
-      <div className="max-w-xl">
-        <ProfileForm />
+      <div className="max-w-xl flex flex-col gap-10">
+        <section>
+          <Heading as="h2" size="h5">
+            Informations personnelles
+          </Heading>
+          <ProfileForm />
+        </section>
+        <section>
+          <Heading as="h2" size="h5">
+            Newsletter
+          </Heading>
+          <ProfileNewsletterForm />
+        </section>
       </div>
     </SimplePage>
   );

--- a/src/server/api/users/engie.ts
+++ b/src/server/api/users/engie.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 
 import cliConfig from '@/cli-config';
-import { updateContact } from '@/modules/ademe-connect/server/client';
 import { createEvent } from '@/modules/events/server/service';
 import { create } from '@/modules/users/server/service';
 import { type ApiAccounts, kdb } from '@/server/db/kysely';
@@ -130,11 +129,12 @@ export const handleData = async (account: ApiAccounts, networks: EngieApiNetwork
           type: 'user_updated_api',
         });
 
-        if (!user.active) {
-          updateContact(sanitizedEmail, { actif: true }).catch((error) =>
-            logger.error('ademe-connect updateContact failed on engie reactivation', { email: sanitizedEmail, error })
-          );
-        }
+        // FIXME vérifier que doit être désactivé suite à réunion ademe connect
+        // if (!user.active) {
+        //   updateContact(sanitizedEmail, { actif: true }).catch((error) =>
+        //     logger.error('ademe-connect updateContact failed on engie reactivation', { email: sanitizedEmail, error })
+        //   );
+        // }
       } else {
         logger.info(' ⏭️ Skipped');
       }
@@ -155,9 +155,10 @@ export const handleData = async (account: ApiAccounts, networks: EngieApiNetwork
           data: { api_name: account.name, email },
           type: 'user_deactivated_api',
         });
-        updateContact(email, { actif: false }).catch((error) =>
-          logger.error('ademe-connect updateContact failed on engie deactivation', { email, error })
-        );
+        // FIXME vérifier que doit être désactivé suite à réunion ademe connect
+        // updateContact(email, { actif: false }).catch((error) =>
+        //   logger.error('ademe-connect updateContact failed on engie deactivation', { email, error })
+        // );
       } else {
         logger.info(' ⏭️ Skipped');
       }

--- a/src/server/api/users/engie.ts
+++ b/src/server/api/users/engie.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 
 import cliConfig from '@/cli-config';
+import { updateContact } from '@/modules/ademe-connect/server/client';
+import { createEvent } from '@/modules/events/server/service';
 import { create } from '@/modules/users/server/service';
 import { type ApiAccounts, kdb } from '@/server/db/kysely';
 import { parentLogger } from '@/server/helpers/logger';
@@ -46,9 +48,8 @@ export const handleData = async (account: ApiAccounts, networks: EngieApiNetwork
   const existingUsersFromApi = await kdb
     .selectFrom('users')
     .innerJoin('api_accounts', 'users.from_api', 'api_accounts.key')
-    .select(['users.email', 'users.gestionnaires'])
+    .select(['users.id', 'users.email', 'users.active', 'users.gestionnaires'])
     .where('api_accounts.name', '=', account.name)
-    .where('users.active', '=', true)
     .execute();
 
   logger.info(`🔍 Found ${existingUsersFromApi.length} users in DB`);
@@ -71,7 +72,7 @@ export const handleData = async (account: ApiAccounts, networks: EngieApiNetwork
       if (!user) {
         logger.info(`🆕 Create user ${email}`);
         if (!cliConfig.dryRun) {
-          await create(
+          const record = await create(
             {
               active: true,
               email: sanitizedEmail,
@@ -85,6 +86,12 @@ export const handleData = async (account: ApiAccounts, networks: EngieApiNetwork
             },
             {} as any
           );
+          await createEvent({
+            context_id: (record as any).id,
+            context_type: 'user',
+            data: { api_name: account.name, email: sanitizedEmail, role: 'gestionnaire' },
+            type: 'user_created_api',
+          });
         } else {
           logger.info(' ⏭️ Skipped');
         }
@@ -110,19 +117,47 @@ export const handleData = async (account: ApiAccounts, networks: EngieApiNetwork
           })
           .where('id', '=', user.id)
           .execute();
+
+        await createEvent({
+          context_id: user.id,
+          context_type: 'user',
+          data: {
+            api_name: account.name,
+            email: sanitizedEmail,
+            gestionnaires_after: allTags,
+            gestionnaires_before: user.gestionnaires || [],
+          },
+          type: 'user_updated_api',
+        });
+
+        if (!user.active) {
+          updateContact(sanitizedEmail, { actif: true }).catch((error) =>
+            logger.error('ademe-connect updateContact failed on engie reactivation', { email: sanitizedEmail, error })
+          );
+        }
       } else {
         logger.info(' ⏭️ Skipped');
       }
     })
   );
 
-  logger.info(`🔍 Deactivate ${existingUsersFromApi.length} users not in the API`);
+  const usersToDeactivate = existingUsersFromApi.filter((u) => u.active);
+  logger.info(`🔍 Deactivate ${usersToDeactivate.length} users not in the API`);
 
   await Promise.all(
-    existingUsersFromApi.map(async ({ email }) => {
+    usersToDeactivate.map(async ({ id, email }) => {
       logger.info(`🚫 Deactivate user ${email}`);
       if (!cliConfig.dryRun) {
         await kdb.updateTable('users').set({ active: false }).where('email', '=', email).execute();
+        await createEvent({
+          context_id: id,
+          context_type: 'user',
+          data: { api_name: account.name, email },
+          type: 'user_deactivated_api',
+        });
+        updateContact(email, { actif: false }).catch((error) =>
+          logger.error('ademe-connect updateContact failed on engie deactivation', { email, error })
+        );
       } else {
         logger.info(' ⏭️ Skipped');
       }

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -5,6 +5,10 @@ import { parseEnv } from '@/utils/env';
 import type { ExcludeKeys } from '@/utils/typescript';
 
 const serverConfigSchema = {
+  ADEME_CONNECT_BASE_URL: z.string().default('https://ppd-x-ademe-interne-api.de-c1.eu1.cloudhub.io/api/v1'),
+  ADEME_CONNECT_CLIENT_ID: z.string().optional(),
+  ADEME_CONNECT_CLIENT_SECRET: z.string().optional(),
+  ADEME_CONNECT_SOURCE: z.string().default('France Chaleur Urbaine'),
   AIRTABLE_BASE: z.string(),
   AIRTABLE_KEY_API: z.string(),
   CLOCK_CRONS_ENABLE: z.boolean().default(true),

--- a/src/server/db/kysely/database.ts
+++ b/src/server/db/kysely/database.ts
@@ -7,6 +7,7 @@ import type { ColumnType, JSONColumnType } from 'kysely';
 
 import type { AirtableLegacyRecord } from '@/modules/demands/types';
 import type { EventType } from '@/modules/events/constants';
+import type { StructureType } from '@/modules/users/constants';
 import type { UserRole } from '@/types/enum/UserRole';
 
 export type Generated<T> =
@@ -718,7 +719,7 @@ export interface Users {
   status: 'pending_email_confirmation' | 'valid';
   structure_name: string | null;
   structure_other: string | null;
-  structure_type: string | null;
+  structure_type: StructureType | null;
 }
 
 export interface ZoneAPotentielChaud {

--- a/src/server/db/migrations/20260402000000_rename_user_created_to_user_registered.ts
+++ b/src/server/db/migrations/20260402000000_rename_user_created_to_user_registered.ts
@@ -1,0 +1,20 @@
+import type { Kysely } from 'kysely';
+import { sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`
+    UPDATE events
+    SET type = 'user_registered'
+    WHERE type = 'user_created'
+      AND context_type = 'user';
+  `.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`
+    UPDATE events
+    SET type = 'user_created'
+    WHERE type = 'user_registered'
+      AND context_type = 'user';
+  `.execute(db);
+}

--- a/src/utils/array.spec.ts
+++ b/src/utils/array.spec.ts
@@ -2,7 +2,21 @@ import { describe, expect, it } from 'vitest';
 
 import type { TestCase } from '@/tests/trpc-helpers';
 
-import { chunk } from './array';
+import { chunk, isOneOf } from './array';
+
+describe('isOneOf()', () => {
+  it('returns true when value is in the array', () => {
+    expect(isOneOf('b', ['a', 'b', 'c'] as const)).toBe(true);
+  });
+
+  it('returns false when value is not in the array', () => {
+    expect(isOneOf('d', ['a', 'b', 'c'] as const)).toBe(false);
+  });
+
+  it('returns false for empty array', () => {
+    expect(isOneOf('a', [] as const)).toBe(false);
+  });
+});
 
 describe('chunk()', () => {
   type ChunkTestCase = TestCase<{ array: any[]; size: number }, any[][]>;

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,3 +1,15 @@
+/**
+ * Type-safe array inclusion check that narrows the value type.
+ *
+ * @example
+ * if (isOneOf(user.role, ['particulier', 'professionnel'] as const)) {
+ *   // user.role is narrowed to 'particulier' | 'professionnel'
+ * }
+ */
+export function isOneOf<T extends U, U>(value: U, array: readonly T[]): value is T {
+  return array.includes(value as T);
+}
+
 export const shuffleArray = <T extends object>(array: T[]): T[] => {
   return array
     .map((item) => ({ ...item, sort: Math.random() }))

--- a/src/utils/email.spec.ts
+++ b/src/utils/email.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import type { TestCase } from '@/tests/trpc-helpers';
+
+import { pseudonymizeEmail } from './email';
+
+describe('pseudonymizeEmail', () => {
+  const cases: TestCase<string, string>[] = [
+    { expectedOutput: 'j...n@f...e.fr', input: 'john@france-chaleur-urbaine.fr', label: 'email standard' },
+    { expectedOutput: 'j...e@a...e.fr', input: 'jane.doe@alice.fr', label: 'local part avec point' },
+    { expectedOutput: 'a@t...t.com', input: 'a@test.com', label: 'local part à un caractère' },
+    { expectedOutput: 'a...b@t...t.com', input: 'ab@test.com', label: 'local part à deux caractères' },
+    {
+      expectedOutput: 't...s@s...b.e...e.c...o.uk',
+      input: 'test.aze-toto+bonus@sub.example.co.uk',
+      label: 'tous les labels sauf le TLD sont masqués',
+    },
+  ];
+
+  it.each(cases)('$label', ({ input, expectedOutput }) => {
+    expect(pseudonymizeEmail(input)).toStrictEqual(expectedOutput);
+  });
+
+  it('retourne *** pour une entrée sans @', () => {
+    expect(pseudonymizeEmail('invalid')).toStrictEqual('***');
+  });
+});

--- a/src/utils/email.ts
+++ b/src/utils/email.ts
@@ -1,0 +1,22 @@
+/**
+ * Pseudonymizes an email address for safe logging.
+ * Keeps the first and last character of the local part and of the first domain label,
+ * replacing the rest with "...".
+ *
+ * All domain labels are pseudonymized except the TLD (last label).
+ *
+ * @example
+ * pseudonymizeEmail('maxime@france-chaleur-urbaine.fr')      // 'm...e@f...e.fr'
+ * pseudonymizeEmail('jane.doe@alice.fr')                     // 'j...e@a...e.fr'
+ * pseudonymizeEmail('test@developpement-durable.gouv.fr')    // 't...t@d...e.g...v.fr'
+ * pseudonymizeEmail('test@sub.example.co.uk')                // 't...t@s...b.e...e.c...o.uk'
+ */
+export function pseudonymizeEmail(email: string): string {
+  const [local, domain] = email.split('@');
+  if (!domain) return '***';
+  const mask = (s: string) => (s.length <= 1 ? s : `${s[0]}...${s[s.length - 1]}`);
+  const domainParts = domain.split('.');
+  const tld = domainParts[domainParts.length - 1];
+  const pseudoDomain = [...domainParts.slice(0, -1).map(mask), tld].join('.');
+  return `${mask(local)}@${pseudoDomain}`;
+}

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -1,14 +1,17 @@
 type FetchErrorOptions = {
   message: string;
   status: number;
+  responseBody?: unknown;
 };
 export class FetchError extends Error {
   status: number;
+  responseBody?: unknown;
 
   constructor(options: FetchErrorOptions) {
     super(options.message);
     this.name = 'FetchError';
     this.status = options.status;
+    this.responseBody = options.responseBody;
   }
 }
 export const fetchMethod =
@@ -99,8 +102,10 @@ export const postFormDataFetchJSON = async <Data = any>(url: string, formState: 
 
 export async function handleError(res: Response, url: string) {
   const isJson = res.headers.get('Content-Type')?.includes('application/json');
-  const errorData = isJson ? await res.json().catch(() => null) : null;
+  const responseBody = isJson ? await res.json().catch(() => null) : await res.text().catch(() => null);
   const errorMessage =
-    res.status === 400 && errorData?.message ? errorData.message : `Failed to load data for ${url} (status ${res.status})`;
-  throw new FetchError({ message: errorMessage, status: res.status });
+    responseBody && typeof responseBody === 'object' && 'message' in responseBody
+      ? String(responseBody.message)
+      : `Failed to load data for ${url} (status ${res.status})`;
+  throw new FetchError({ message: errorMessage, responseBody, status: res.status });
 }


### PR DESCRIPTION
### TODO vérifier s'il faut activer/désactiver les comptes dans ademe-connect avant de merge.


Plusieurs commits de mises à jour de la doc ai ou divers
\+ des commits d'intégration ademe connect
\+ des commits liés l'ajout d'événements autour de la manipulation d'utilisateurs

Ce qui a été implémenté :
- Nous utilisons les endpoints POST /api/v1/personnes (création) et PUT /api/v1/personnes/mail/{email} (mise à jour), authentifiés par les headers client_id et client_secret.
- Le champ "source" avec "France Chaleur Urbaine" est envoyé systématiquement.
- Les champs vides ou nuls sont retirés du payload avant envoi.

Les différents contextes où j'ai intégré ADEME Connect :
- Inscription d'un utilisateur => Création du contact : email, nom, prenom, telephone, typeOrganisme, rubriques, acceptationRGPD (true), abonnementNewsletter, dateCreation.
- Création d'un compte par un administrateur => Création du contact : email, nom, prenom, telephone, typeOrganisme, rubriques, acceptationRGPD (false), abonnementNewsletter (false), dateCreation.
- Création d'un compte (synchronisation via API Engie) =>  Création du contact : email, typeOrganisme, rubriques, acceptationRGPD (false), abonnementNewsletter (false), dateCreation. (pas de nom / prénom disponibles)
- Connexion => Mise à jour du contact : dateConnexion, dateModification.
- Mise à jour du profil utilisateur => Mise à jour du contact : nom, prenom, telephone, rubriques, dateModification.
- Abonnement à la newsletter => Mise à jour du contact : abonnementNewsletter (true), dateNewsletter, dateModification.
- Désabonnement de la newsletter => Mise à jour du contact : abonnementNewsletter (false), dateFinNewsletter, dateModification.
- Suppression d'un compte utilisateur => Mise à jour du contact : actif (false), dateModification.
- Réactivation d'un compte (synchronisation via API Engie) => Mise à jour du contact : actif (true), dateModification.
- Désactivation d'un compte (synchronisation via API Engie) => Mise à jour du contact : actif (false), dateModification.
- Reprise des comptes existants : commande pour migrer créer les contacts : email, nom, prenom, telephone, typeOrganisme, rubriques, acceptationRGPD, abonnementNewsletter, dateNewsletter, dateConnexion, dateCreation.

Rubriques utilisées selon le rôle :
- FCU - compte particulier
- FCU - compte professionnel
- FCU - compte gestionnaire

Rubriques utilisées selon la structure (si présente) :
- FCU - type Bailleur social
- FCU - type Bureau d'études
- FCU - type Collectivité
- FCU - type Gestionnaire de parc tertiaire
- FCU - type Gestionnaire de réseaux de chaleur
- FCU - type Mandataire / délégataire CEE
- FCU - type Syndic de copropriété
- FCU - type Autre


Une fois déployé en prod, créer les contacts dans ademe-connect pour les comptes existants :
- `pnpm db:pull:prod --data-only --no-constraints users`
- avec l'env de prod configuré en local : `pnpm cli ademe-connect contacts:bulk-create`