### PR TITLE
Affiche la structure dans l'admin

### DIFF
--- a/src/components/Admin/UserForm.tsx
+++ b/src/components/Admin/UserForm.tsx
@@ -3,10 +3,11 @@ import useForm from '@/components/form/react-form/useForm';
 import Badge from '@/components/ui/Badge';
 import Tag from '@/components/ui/Tag';
 import Tooltip from '@/components/ui/Tooltip';
-import { createUserAdminSchema, structureTypes, updateUserAdminSchema } from '@/modules/users/constants';
+import { createUserAdminSchema, structureTypesFormLabels, updateUserAdminSchema } from '@/modules/users/constants';
 import type { UsersResponse } from '@/pages/api/admin/users/[[...slug]]';
 import { userRoles } from '@/types/enum/UserRole';
 import cx from '@/utils/cx';
+import { ObjectEntries } from '@/utils/typescript';
 
 export type OnCreate = (data: UsersResponse['createInput']) => Promise<void> | void;
 export type OnUpdate = (data: UsersResponse['updateInput']) => Promise<void> | void;
@@ -138,7 +139,7 @@ const UserForm = ({ user, onSubmit, loading }: UserFormProps) => {
             <Field.Select
               name="structure_type"
               label="Type de structure"
-              options={Object.entries(structureTypes).map(([key, label]) => ({ label, value: key }))}
+              options={ObjectEntries(structureTypesFormLabels).map(([key, label]) => ({ label, value: key }))}
             />
             {structureType === 'autre' && (
               <Field.Input

--- a/src/components/Map/layers/testsAdresses.tsx
+++ b/src/components/Map/layers/testsAdresses.tsx
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 
 import Tooltip from '@/components/ui/Tooltip';
 import type { ProEligibilityTestHistoryEntry } from '@/modules/pro-eligibility-tests/types';
-import { structureTypes } from '@/modules/users/constants';
+import { structureTypesLabels } from '@/modules/users/constants';
 import { upperCaseFirstChar } from '@/utils/strings';
 
 import type { MapSourceLayersSpecification, PopupStyleHelpers } from './common';
@@ -138,7 +138,7 @@ function Popup(
                   >
                     <span>
                       {structure_name || structure_type
-                        ? `${structure_name || ''} ${structure_type ? `(${structureTypes[structure_type as keyof typeof structureTypes]})` : ''}`
+                        ? `${structure_name || ''} ${structure_type ? `(${structureTypesLabels[structure_type as keyof typeof structureTypesLabels]})` : ''}`
                         : 'Structure non connue'}
                       {(gestionnaires || []).join(', ')}
                     </span>

--- a/src/components/connexion/ProfileForm.tsx
+++ b/src/components/connexion/ProfileForm.tsx
@@ -3,7 +3,8 @@ import Loader from '@/components/ui/Loader';
 import Notice from '@/components/ui/Notice';
 import { notify } from '@/modules/notification';
 import trpc from '@/modules/trpc/client';
-import { roles, structureTypes, updateProfileDefaultValues, zUpdateProfileSchema } from '@/modules/users/constants';
+import { roles, structureTypesFormLabels, updateProfileDefaultValues, zUpdateProfileSchema } from '@/modules/users/constants';
+import { ObjectEntries } from '@/utils/typescript';
 
 function ProfileForm() {
   const { data: profile, isLoading } = trpc.users.getProfile.useQuery();
@@ -60,7 +61,7 @@ function ProfileForm() {
             <Select
               name="structure_type"
               label="Type de structure"
-              options={Object.entries(structureTypes).map(([key, label]) => ({ label, value: key }))}
+              options={ObjectEntries(structureTypesFormLabels).map(([key, label]) => ({ label, value: key }))}
             />
             <Input name="structure_name" label="Nom de la structure" />
             {structureType === 'autre' && <Input name="structure_other" label="Renseignez le type de structure" />}

--- a/src/components/connexion/RegisterForm.tsx
+++ b/src/components/connexion/RegisterForm.tsx
@@ -11,13 +11,14 @@ import { toastErrors } from '@/modules/notification';
 import {
   type CredentialsSchema,
   type IdentitySchema,
-  structureTypes,
+  structureTypesFormLabels,
   zCredentialsSchema,
   zIdentitySchema,
 } from '@/modules/users/constants';
 import { userRolesInscription } from '@/types/enum/UserRole';
 import { postFetchJSON } from '@/utils/network';
 import { upperCaseFirstChar } from '@/utils/strings';
+import { ObjectEntries } from '@/utils/typescript';
 
 type FormStep = {
   label: string;
@@ -156,7 +157,7 @@ function RegisterForm() {
                   <Select
                     name="structure_type"
                     label="Type de structure"
-                    options={Object.entries(structureTypes).map(([key, label]) => ({ label, value: key }))}
+                    options={ObjectEntries(structureTypesFormLabels).map(([key, label]) => ({ label, value: key }))}
                   />
                   <Input
                     name="structure_name"

--- a/src/components/ui/table/TableFilter.tsx
+++ b/src/components/ui/table/TableFilter.tsx
@@ -171,10 +171,10 @@ const TableFilter = ({ value, type, onChange, filterProps, facetedUniqueValues, 
                 <Badge noIcon severity={facetKey === 'true' ? 'success' : 'error'} small>
                   {facetKey === 'true' ? 'Oui' : 'Non'}
                 </Badge>
+              ) : facetKey === 'undefined' || facetKey === 'null' || facetKey === '' ? (
+                'Aucun'
               ) : Component ? (
                 <Component value={facetKey} />
-              ) : facetKey === 'undefined' || facetKey === '' ? (
-                'Aucun'
               ) : (
                 facetKey
               )}{' '}

--- a/src/components/ui/table/TableSimple.tsx
+++ b/src/components/ui/table/TableSimple.tsx
@@ -93,7 +93,7 @@ export const customFilterFn = <T extends RowData>(): Record<string, FilterFn<T>>
 
     // Gérer undefined/null/"" explicitement
     if (!value) {
-      return filterValue.undefined === true || filterValue[''] === true;
+      return filterValue.undefined === true || filterValue['null'] === true || filterValue[''] === true;
     }
 
     return Object.entries(filterValue)

--- a/src/modules/users/AGENTS.md
+++ b/src/modules/users/AGENTS.md
@@ -14,7 +14,7 @@ Ce module est actuellement en cours de migration depuis l'architecture legacy ve
   - `registrationSchema` - Schéma complet d'inscription
   - `createUserAdminSchema` - Création admin
   - `updateUserAdminSchema` - Mise à jour admin
-  - `structureTypes` - Types de structures professionnelles
+  - `structureTypesLabels` - Types de structures professionnelles
 - **`server/service.ts`** : Services CRUD utilisateurs (migré depuis `/src/server/services/user.ts`)
 
 ### 🚧 Ce qui reste à migrer
@@ -69,10 +69,10 @@ users/
 
 ```typescript
 // Schémas Zod (déjà dans le module)
-import { 
+import {
   registrationSchema,
   createUserAdminSchema,
-  updateUserAdminSchema 
+  updateUserAdminSchema
 } from '@/modules/users/constants';
 
 // Services (migré dans les modules)
@@ -89,16 +89,16 @@ import * as authService from '@/modules/auth/server/service';
 
 ```typescript
 // Schémas Zod
-import { 
+import {
   registrationSchema,
-  createUserAdminSchema 
+  createUserAdminSchema
 } from '@/modules/users/constants';
 
 // Services backend
-import { 
+import {
   createUser,
   updateUser,
-  deleteUser 
+  deleteUser
 } from '@/modules/users/server/service';
 
 // TRPC (client)

--- a/src/modules/users/constants.ts
+++ b/src/modules/users/constants.ts
@@ -2,8 +2,9 @@ import { z } from 'zod';
 
 import { type UserRole, userRoles, userRolesInscription } from '@/types/enum/UserRole';
 
+/** Label des types de structure  */
 // biome-ignore assist/source/useSortedKeys: keep field order for clarity and maintainability
-export const structureTypes = {
+export const structureTypesLabels = {
   bailleur_social: 'Bailleur social',
   bureau_etudes: "Bureau d'études",
   collectivite: 'Collectivité',
@@ -11,6 +12,12 @@ export const structureTypes = {
   gestionnaire_reseaux: 'Gestionnaire de réseaux de chaleur',
   mandataire_cee: 'Mandataire / délégataire CEE',
   syndic_copropriete: 'Syndic de copropriété',
+  autre: 'Autre',
+};
+
+/** Labels utilisés sur le formulaire */
+export const structureTypesFormLabels = {
+  ...structureTypesLabels,
   autre: 'Autre (préciser)',
 };
 

--- a/src/pages/admin/users.tsx
+++ b/src/pages/admin/users.tsx
@@ -115,7 +115,7 @@ export default function ManageUsers() {
         header: 'Role',
       },
       {
-        accessorKey: 'structure_type',
+        accessorFn: (row) => row.structure_type || null,
         cell: (info) => info.getValue() && structureTypesLabels[info.getValue<keyof typeof structureTypesLabels>()],
         filterProps: {
           Component: ({ value }) => <>{structureTypesLabels[value as keyof typeof structureTypesLabels] ?? value}</>,
@@ -123,6 +123,7 @@ export default function ManageUsers() {
         filterType: 'Facets',
         flex: 1.4,
         header: 'Type de structure',
+        id: 'structure_type',
       },
       {
         accessorFn: (row) => row.gestionnaires?.map((u) => u.toLowerCase()).join(' ') ?? '',

--- a/src/pages/admin/users.tsx
+++ b/src/pages/admin/users.tsx
@@ -18,6 +18,7 @@ import TableSimple, { type ColumnDef } from '@/components/ui/table/TableSimple';
 import { useFetch } from '@/hooks/useApi';
 import useCrud from '@/hooks/useCrud';
 import { notify, toastErrors } from '@/modules/notification';
+import { structureTypesLabels } from '@/modules/users/constants';
 import type { UsersResponse } from '@/pages/api/admin/users/[[...slug]]';
 import { withAuthentication } from '@/server/authentication';
 import type { UserRole } from '@/types/enum/UserRole';
@@ -86,10 +87,6 @@ export default function ManageUsers() {
   const columns: ColumnDef<UsersResponse['listItem']>[] = useMemo(
     () => [
       {
-        accessorKey: 'id',
-        hidden: true,
-      },
-      {
         accessorKey: 'email',
         cell: (info) => (
           <div>
@@ -116,6 +113,16 @@ export default function ManageUsers() {
         filterType: 'Facets',
         flex: 1.5,
         header: 'Role',
+      },
+      {
+        accessorKey: 'structure_type',
+        cell: (info) => info.getValue() && structureTypesLabels[info.getValue<keyof typeof structureTypesLabels>()],
+        filterProps: {
+          Component: ({ value }) => <>{structureTypesLabels[value as keyof typeof structureTypesLabels] ?? value}</>,
+        },
+        filterType: 'Facets',
+        flex: 1.4,
+        header: 'Type de structure',
       },
       {
         accessorFn: (row) => row.gestionnaires?.map((u) => u.toLowerCase()).join(' ') ?? '',

--- a/src/server/services/airtable.ts
+++ b/src/server/services/airtable.ts
@@ -1,4 +1,4 @@
-import { structureTypes } from '@/modules/users/constants';
+import { structureTypesLabels } from '@/modules/users/constants';
 import base from '@/server/db/airtable';
 import { kdb, sql } from '@/server/db/kysely';
 import { parentLogger } from '@/server/helpers/logger';
@@ -68,7 +68,7 @@ export const syncComptesProFromUsers = async (interval?: string) => {
         Prénom: user.first_name,
         Role: user.role,
         Statut: user.status,
-        'Type de structure': user.structure_other || structureTypes[user.structure_type as keyof typeof structureTypes],
+        'Type de structure': user.structure_other || structureTypesLabels[user.structure_type as keyof typeof structureTypesLabels],
         Téléphone: user.phone
           ? user.phone
               .replace(/\s/g, '')


### PR DESCRIPTION
- Ajoute la colonne type de structure à l'admin,
- Supprime l'id qui est inutile maintenant (devait être là à l'origine pour du debug)
- Améliore un peu la gestion des labels affichés dans les filtres des tableaux (gère les valeurs vides pareil)