### PR TITLE
Fix affectation demandes

### DIFF
--- a/.ai/context/conventions.md
+++ b/.ai/context/conventions.md
@@ -70,6 +70,7 @@
 - Guard clauses for early returns instead of nested `if/else`.
 - Explicit names over abbreviations (`networkIdentifier` not `netId`).
 - **Never use single-letter or shortened variable names** (`r`, `n`, `el`, `ev`, `idx`, `tmp`, `acc`). Always spell the role: `reminder`, `network`, `element`, `event`, `index`, `temp`, `accumulator`. Applies to parameters, callbacks (`map`/`filter`/`reduce`), and local variables — no exceptions for short scopes.
+- **Don't destructure to read just a few properties** — access them directly (`lastEligibility.distance`, `lastEligibility.type`), not `const { distance, type } = lastEligibility`. Destructuring is reserved for React components in general (props).
 - **Any `for` loop is a smell** — first try a functional pipeline (`map`/`filter`/`reduce`/`flatMap`/`Set`/`Object.fromEntries`). Each step names one operation, intent reads top-to-bottom. Keep the loop only when the pipeline would force multiple passes on a hot path, or when early-exit (`break`) is the natural shape.
 
 ## TypeScript patterns

--- a/src/modules/demands/client/AffectedNetworkCell.tsx
+++ b/src/modules/demands/client/AffectedNetworkCell.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import AsyncButton from '@/components/ui/AsyncButton';
+import FCUBadge from '@/components/ui/Badge';
 import Button from '@/components/ui/Button';
 import CallOut from '@/components/ui/CallOut';
 import Tooltip from '@/components/ui/Tooltip';
@@ -18,6 +19,7 @@ type BaseDemand = {
   network_type: NetworkType | null;
   network_name: string | null;
   network_sncu_id: string | null;
+  ville_differente?: boolean;
   'Distance au réseau'?: number | null;
   pending_assignment_change: PendingAssignmentChange | null;
   pending_assignment_name: string | null;
@@ -108,6 +110,7 @@ export default function AffectedNetworkCell<T extends BaseDemand>(props: Affecte
     })();
   };
 
+  const villeDifferente = !!props.isAdmin && !!demand.ville_differente;
   const pending = demand.pending_assignment_change;
   const pendingIsUnassign = !!pending && pending.network_id === null;
   const pendingNotFound = !!pending && !pendingIsUnassign && !demand.pending_assignment_name;
@@ -123,6 +126,7 @@ export default function AffectedNetworkCell<T extends BaseDemand>(props: Affecte
             networkSncuId={demand.network_sncu_id}
             distance={demand['Distance au réseau']}
           />
+          {villeDifferente && <FCUBadge type="warning_ville_differente" size="xs" className="mt-1" />}
         </div>
         <Tooltip title={props.isAdmin ? "Changer l'affectation du réseau" : 'Demander une réaffectation'}>
           <Button

--- a/src/modules/demands/server/admin-operations.ts
+++ b/src/modules/demands/server/admin-operations.ts
@@ -3,7 +3,7 @@ import { TRPCError } from '@trpc/server';
 import type { UpdateAdminDemandInput } from '@/modules/demands/constants';
 import { createEvent, createUserEvent } from '@/modules/events/server/service';
 import type { NetworkType } from '@/modules/reseaux/constants';
-import { kdb } from '@/server/db/kysely';
+import { kdb, sql } from '@/server/db/kysely';
 import { parentLogger } from '@/server/helpers/logger';
 
 import { computeNetworkDistance } from './eligibility';
@@ -45,7 +45,25 @@ export const removeDemand = async (demandId: string, userId?: string) => {
 export const listAdmin = async () => {
   const startTime = Date.now();
 
-  const records = await buildDemandQuery().execute();
+  // Flag admin (booléen, jamais renvoyé sous forme de liste de communes) : commune de la demande absente du réseau affecté.
+  const records = await buildDemandQuery()
+    .select((eb) => {
+      const communes = eb.fn.coalesce('rdc.communes_insee', 'zrc.communes_insee');
+      return eb
+        .case()
+        .when(
+          eb.and([
+            eb('demands.commune_code', 'is not', null),
+            eb(eb.fn<number>('array_length', [communes, eb.val(1)]), '>', 0),
+            eb.not(eb(communes, '&&', sql<string[]>`ARRAY[${eb.ref('demands.commune_code')}]`)),
+          ])
+        )
+        .then(true)
+        .else(false)
+        .end()
+        .as('ville_differente');
+    })
+    .execute();
 
   const { count } = await kdb
     .selectFrom('demands')

--- a/src/modules/demands/server/eligibility.integration.spec.ts
+++ b/src/modules/demands/server/eligibility.integration.spec.ts
@@ -1,7 +1,9 @@
 import { TRPCError } from '@trpc/server';
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import type { ProEligibilityTestHistoryEntry } from '@/modules/pro-eligibility-tests/types';
 import { kdb } from '@/server/db/kysely';
+import type { EligibilityType } from '@/server/services/addresseInformation';
 import {
   cleanDatabase,
   createLineGeometry,
@@ -11,7 +13,7 @@ import {
   seedZoneEtReseauEnConstruction,
 } from '@/tests/fixtures';
 
-import { computeNetworkDistance } from './eligibility';
+import { autoAssignNetworkFromEligibility, computeNetworkDistance } from './eligibility';
 
 const PARIS = { lat: 48.8566, lon: 2.3522 };
 
@@ -91,5 +93,103 @@ describe('computeNetworkDistance()', () => {
     await expect(computeNetworkDistance(demandId, 999, 'reseau_de_chaleur')).rejects.toThrow(
       new TRPCError({ code: 'NOT_FOUND', message: 'Réseau ou demande introuvable' })
     );
+  });
+});
+
+describe('autoAssignNetworkFromEligibility()', () => {
+  beforeEach(async () => {
+    await cleanDatabase();
+  });
+
+  const makeDemand = async (type: EligibilityType, distance: number | null, idFcu: number | null, eligible: boolean) => {
+    const [demand] = await kdb
+      .insertInto('demands')
+      .values({ legacy_values: JSON.stringify({}) })
+      .returningAll()
+      .execute();
+    const history: ProEligibilityTestHistoryEntry[] = [
+      {
+        calculated_at: new Date().toISOString(),
+        eligibility: { distance, eligible, id_fcu: idFcu, id_sncu: 'X', nom: 'N', type },
+        transition: 'initial',
+      },
+    ];
+    await seedProEligibilityTestsAddress({ demand_id: demand.id, eligibility_history: JSON.stringify(history), source_address: 'x' });
+    return demand.id;
+  };
+
+  const getNetwork = (id: string) =>
+    kdb.selectFrom('demands').select(['network_id', 'network_type']).where('id', '=', id).executeTakeFirstOrThrow();
+
+  const cases: {
+    label: string;
+    type: EligibilityType;
+    distance: number | null;
+    eligible: boolean;
+    idFcu: number;
+    expected: { network_id: number | null; network_type: string | null };
+  }[] = [
+    {
+      distance: 50,
+      eligible: true,
+      expected: { network_id: 16, network_type: 'reseau_de_chaleur' },
+      idFcu: 16,
+      label: 'réseau très proche → affecté',
+      type: 'reseau_existant_tres_proche',
+    },
+    {
+      distance: 400,
+      eligible: false,
+      expected: { network_id: 10, network_type: 'reseau_de_chaleur' },
+      idFcu: 10,
+      label: 'réseau loin < 500m → affecté',
+      type: 'reseau_existant_loin',
+    },
+    {
+      distance: 500,
+      eligible: false,
+      expected: { network_id: null, network_type: null },
+      idFcu: 11,
+      label: 'réseau loin = 500m → non affecté',
+      type: 'reseau_existant_loin',
+    },
+    {
+      distance: 700,
+      eligible: false,
+      expected: { network_id: null, network_type: null },
+      idFcu: 12,
+      label: 'réseau futur loin > 500m → non affecté',
+      type: 'reseau_futur_loin',
+    },
+    {
+      distance: null,
+      eligible: true,
+      expected: { network_id: 13, network_type: 'reseau_en_construction' },
+      idFcu: 13,
+      label: 'dans la zone (distance nulle) → affecté',
+      type: 'dans_zone_reseau_futur',
+    },
+    {
+      distance: 800,
+      eligible: true,
+      expected: { network_id: 14, network_type: 'reseau_de_chaleur' },
+      idFcu: 14,
+      label: 'PDP à 800m → affecté (pas de limite)',
+      type: 'dans_pdp_reseau_existant',
+    },
+    {
+      distance: null,
+      eligible: false,
+      expected: { network_id: null, network_type: null },
+      idFcu: 15,
+      label: 'réseau sans tracé → non affecté',
+      type: 'dans_ville_reseau_existant_sans_trace',
+    },
+  ];
+
+  it.each(cases)('$label', async ({ type, distance, idFcu, eligible, expected }) => {
+    const id = await makeDemand(type, distance, idFcu, eligible);
+    await autoAssignNetworkFromEligibility(id);
+    expect(await getNetwork(id)).toStrictEqual(expected);
   });
 });

--- a/src/modules/demands/server/eligibility.ts
+++ b/src/modules/demands/server/eligibility.ts
@@ -110,9 +110,14 @@ export const computeNetworkDistance = async (demandId: string, networkIdFcu: num
   return reseau.distance;
 };
 
+/** Max distance (m) to auto-assign a network for the non-eligible "réseau loin" cases. */
+const networkAssignmentDistanceThreshold = 500;
+
 /**
- * Auto-assigns network_id and network_type on a demand based on its eligibility test address.
- * Also populates legacy fields for backward compatibility.
+ * Auto-assigns network_id and network_type on a demand based on its eligibility case.
+ * Eligible cases (PDP, in-zone, within the eligible distance) are assigned by definition; the
+ * non-eligible "réseau loin" cases only within the 500m limit. Cases beyond that (no trace, too far)
+ * have a null distance and stay unassigned. Also populates legacy fields for backward compatibility.
  */
 export const autoAssignNetworkFromEligibility = async (demandId: string) => {
   const testAddress = await kdb
@@ -125,11 +130,11 @@ export const autoAssignNetworkFromEligibility = async (demandId: string) => {
 
   const history = testAddress.eligibility_history as ProEligibilityTestHistoryEntry[] | null;
   const lastEligibility = history?.[history.length - 1]?.eligibility;
+  if (!lastEligibility?.id_fcu) return;
 
-  if (!lastEligibility?.id_fcu || lastEligibility.type === 'trop_eloigne') return;
-
-  const networkType = getNetworkTypeFromEligibilityType(lastEligibility.type);
-  if (!networkType) return;
+  const isAssignable =
+    lastEligibility.eligible || (lastEligibility.distance !== null && lastEligibility.distance < networkAssignmentDistanceThreshold);
+  if (!isAssignable) return;
 
   await kdb
     .updateTable('demands')
@@ -140,7 +145,7 @@ export const autoAssignNetworkFromEligibility = async (demandId: string) => {
         'Nom réseau': lastEligibility.nom,
       }),
       network_id: lastEligibility.id_fcu,
-      network_type: networkType,
+      network_type: getNetworkTypeFromEligibilityType(lastEligibility.type),
     })
     .where('id', '=', demandId)
     .execute();

--- a/src/server/services/addresseInformation.ts
+++ b/src/server/services/addresseInformation.ts
@@ -378,7 +378,7 @@ export const getDetailedEligibilityStatus = async (lat: number, lon: number) => 
         distance: networkInfos?.distance ?? 0,
         gestionnaire: networkInfos?.gestionnaire ?? null,
         hasPDP: true,
-        id_fcu: pdp.id_fcu,
+        id_fcu: networkInfos?.id_fcu ?? null,
         id_sncu: pdp['Identifiant reseau'] ?? (networkInfos?.type === 'existant' ? networkInfos?.['Identifiant reseau'] : null) ?? '',
         isClasse: networkInfos?.type === 'existant' ? (networkInfos?.['reseaux classes'] ?? null) : null,
         nom: networkInfos?.nom_reseau ?? '',


### PR DESCRIPTION
- corrige une mauvaise affectation dans les cas PDP (on prend l'id_fcu du PDP, alors qu'il faut celui du réseau...)
- remet le badge ville différente, pour que l'admin ait + d'infos si une demande est affectée à un réseau d'une autre ville (cas rarement favorable au raccordement)
- corrige l'affectation du réseau seulement si < 500m (reprise de la logique des tags). C'était mal fait.