### PR TITLE
Fais des lowercase pour éviter les doublons par email

### DIFF
--- a/src/modules/auth/server/service.ts
+++ b/src/modules/auth/server/service.ts
@@ -38,7 +38,7 @@ export const register = async ({
   entreprise?: Entreprise | null;
 }) => {
   const lowerCaseEmail = email.trim().toLowerCase();
-  const existingUser = await kdb.selectFrom('users').select('id').where('email', 'ilike', lowerCaseEmail).executeTakeFirst();
+  const existingUser = await kdb.selectFrom('users').select('id').where('email', '=', lowerCaseEmail).executeTakeFirst();
   if (existingUser) {
     throw new BadRequestError(`L'utilisateur associé à l'email '${email}' existe déjà. Connectez-vous.`);
   }

--- a/src/modules/users/constants.ts
+++ b/src/modules/users/constants.ts
@@ -101,7 +101,7 @@ export type RegistrationSchema = z.infer<typeof registrationSchema>;
 
 export const createUserAdminSchema = z.object({
   active: z.boolean().optional(),
-  email: z.email(),
+  email: z.email().trim().toLowerCase(),
   entreprise: zEntreprise.nullable().optional(),
   first_name: z.string().optional().nullable(),
   last_name: z.string().optional().nullable(),
@@ -118,7 +118,7 @@ export const createUserAdminSchema = z.object({
 export const updateUserAdminSchema = z
   .object({
     active: z.boolean(),
-    email: z.email().optional(),
+    email: z.email().trim().toLowerCase().optional(),
     entreprise: zEntreprise.nullable().optional(),
     first_name: z.string().optional(),
     last_name: z.string().optional(),

--- a/src/modules/users/server/service.ts
+++ b/src/modules/users/server/service.ts
@@ -75,6 +75,12 @@ export type User = Awaited<ReturnType<typeof list>>['items'][number];
 
 export const create = async (data: CreateUserInput, context: Context): Promise<DB['users']> => {
   const { optin_at, entreprise, ...rest } = data;
+
+  const existingUser = await kdb.selectFrom('users').select('id').where('email', '=', data.email).executeTakeFirst();
+  if (existingUser) {
+    throw new TRPCError({ code: 'CONFLICT', message: `L'utilisateur associé à l'email '${data.email}' existe déjà.` });
+  }
+
   const salt = await bcrypt.genSalt(10);
   const password = await bcrypt.hash(Math.random().toString(36).slice(2, 10), salt);
 


### PR DESCRIPTION
- Vérif ajoutée côté admin.
- Changement côté inscription pour ilike => =, afin d'éviter le wildcard des underscores _ (en plus des %)