### PR TITLE
Maj cli bulk update

### DIFF
--- a/src/modules/reseaux/commands.ts
+++ b/src/modules/reseaux/commands.ts
@@ -2,6 +2,7 @@ import type { Command } from '@commander-js/extra-typings';
 import { z } from 'zod';
 
 import { readFileGeometry } from '@/modules/geo/server/helpers';
+import { identifyNetworkGeometries } from '@/modules/reseaux/server/geometry-identify';
 import { kdb, sql } from '@/server/db/kysely';
 import { logger } from '@/server/helpers/logger';
 
@@ -105,6 +106,28 @@ export function registerNetworkCommands(parentProgram: Command) {
     .option('--apply', 'Applique réellement les mises à jour (par défaut: dry-run)', false)
     .action(async (directory, { apply }) => {
       await applyNetworkGeometries(directory, { dryRun: !apply });
+    });
+
+  program
+    .command('identify')
+    .description(
+      "Identifie l'id SNCU de fichiers KML/GeoJSON (nommés par ville) par overlap géométrique avec les réseaux existants, et écrit un rapport CSV de scoring."
+    )
+    .argument('<directory>', 'Répertoire contenant les fichiers .kml / .geojson')
+    .argument('[output]', 'Chemin du fichier CSV de sortie', 'network-identify.csv')
+    .option(
+      '--write <dir>',
+      'Convertit et écrit tous les fichiers en GeoJSON : <id_sncu>.geojson si un réseau est identifié, <nom_original>.geojson sinon. Supprimer les fichiers indésirables puis lancer bulk-update.'
+    )
+    .option('--min-score <n>', 'Score minimal (0-100) pour considérer un match comme fort', '50')
+    .option('--max-distance <m>', 'Distance de recherche des réseaux candidats en mètres', '300')
+    .action(async (directory, output, { write, minScore, maxDistance }) => {
+      await identifyNetworkGeometries(directory, {
+        maxDistance: parseFloat(maxDistance),
+        minScore: parseFloat(minScore),
+        outputPath: output,
+        writeDir: write,
+      });
     });
 
   program

--- a/src/modules/reseaux/commands.ts
+++ b/src/modules/reseaux/commands.ts
@@ -99,7 +99,7 @@ export function registerNetworkCommands(parentProgram: Command) {
   program
     .command('bulk-update')
     .description(
-      "Met à jour les tracés des réseaux de chaleur/froid à partir d'un répertoire de <id_sncu>.geojson. Skip les fichiers vides et les ID absents de la BDD."
+      "Met à jour (ou crée) les tracés des réseaux de chaleur/froid à partir d'un répertoire de <id_sncu>.geojson. Les réseaux absents de la BDD sont créés en récupérant leur id_fcu depuis Airtable. Skip les fichiers vides."
     )
     .argument('<directory>', 'Répertoire contenant les fichiers <id_sncu>.geojson')
     .option('--apply', 'Applique réellement les mises à jour (par défaut: dry-run)', false)

--- a/src/modules/reseaux/constants.ts
+++ b/src/modules/reseaux/constants.ts
@@ -50,6 +50,16 @@ export const tableToNetworkEntity = {
   zones_et_reseaux_en_construction: 'reseau_en_construction',
 } as const satisfies Record<(typeof networkEntityToTable)[NetworkEntityType], NetworkEntityType>;
 
+/**
+ * Détermine la table réseau à partir du suffixe de l'identifiant SNCU.
+ * `…C` → réseau de chaleur, `…F` → réseau de froid, sinon `null`.
+ */
+export function networkTableForId(id_sncu: string): 'reseaux_de_chaleur' | 'reseaux_de_froid' | null {
+  if (id_sncu.endsWith('C')) return 'reseaux_de_chaleur';
+  if (id_sncu.endsWith('F')) return 'reseaux_de_froid';
+  return null;
+}
+
 const tableNames = [
   'reseaux_de_chaleur',
   'zones_et_reseaux_en_construction',

--- a/src/modules/reseaux/server/geometry-apply.ts
+++ b/src/modules/reseaux/server/geometry-apply.ts
@@ -2,20 +2,27 @@ import { readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { processGeometry } from '@/modules/geo/server/helpers';
+import { AirtableDB } from '@/server/db/airtable';
 import { kdb } from '@/server/db/kysely';
 import { logger } from '@/server/helpers/logger';
+import { Airtable } from '@/types/enum/Airtable';
 
-import { updateEntityGeometry } from './geometry-operations';
+import { networkTableForId } from '../constants';
+import { insertEntityWithGeometry, updateEntityGeometry } from './geometry-operations';
 
-type Statut = 'updated' | 'would_update' | 'missing' | 'empty' | 'error';
+// Action réalisée (ou qui le serait en dry-run) pour un fichier.
+type Action = 'created' | 'updated' | 'empty' | 'error';
 
-function networkTableForId(id_sncu: string): 'reseaux_de_chaleur' | 'reseaux_de_froid' | null {
-  if (id_sncu.endsWith('C')) return 'reseaux_de_chaleur';
-  if (id_sncu.endsWith('F')) return 'reseaux_de_froid';
-  return null;
-}
+// Tables réseau gérées par la commande (chaleur / froid).
+type ReseauTable = NonNullable<ReturnType<typeof networkTableForId>>;
+
+const airtableTableForReseau: Record<ReseauTable, Airtable> = {
+  reseaux_de_chaleur: Airtable.NETWORKS,
+  reseaux_de_froid: Airtable.COLD_NETWORKS,
+};
 
 export async function applyNetworkGeometries(directory: string, options: { dryRun: boolean }): Promise<void> {
+  const { dryRun } = options;
   const entries = await readdir(directory);
   const files = entries.filter((f) => f.toLowerCase().endsWith('.geojson')).sort();
 
@@ -24,43 +31,85 @@ export async function applyNetworkGeometries(directory: string, options: { dryRu
     return;
   }
 
-  const prefix = options.dryRun ? '[DRY-RUN] ' : '';
+  const prefix = dryRun ? '[DRY-RUN] ' : '';
   logger.info(`${prefix}Application des géométries depuis ${files.length} fichiers GeoJSON`);
 
-  // Sequential: each file does a SELECT + UPDATE + label refresh; keeping it serial avoids
+  const resolveAirtableIdFcu = createAirtableIdFcuResolver();
+
+  // Sequential: each file does a SELECT + INSERT/UPDATE + label refresh; keeping it serial avoids
   // lock contention on the labels and gives predictable log ordering.
-  const results: Statut[] = [];
+  const results: Action[] = [];
   for (const file of files) {
-    const id_sncu = path.basename(file, path.extname(file));
-    results.push(await applyOne(id_sncu, path.join(directory, file), options.dryRun));
+    const identifier = path.basename(file, path.extname(file));
+    results.push(await applyOne(identifier, path.join(directory, file), dryRun, resolveAirtableIdFcu));
   }
 
-  const counts = results.reduce<Record<Statut, number>>((acc, s) => ({ ...acc, [s]: acc[s] + 1 }), {
+  const counts = results.reduce<Record<Action, number>>((acc, s) => ({ ...acc, [s]: acc[s] + 1 }), {
+    created: 0,
     empty: 0,
     error: 0,
-    missing: 0,
     updated: 0,
-    would_update: 0,
   });
 
   logger.info(`${prefix}Résumé:`);
-  if (counts.updated > 0) logger.info(`  ${counts.updated} mis à jour`);
-  if (counts.would_update > 0) logger.info(`  ${counts.would_update} seraient mis à jour`);
+  if (counts.created > 0) logger.info(`  ${counts.created} ${dryRun ? 'seraient créés' : 'créés'}`);
+  if (counts.updated > 0) logger.info(`  ${counts.updated} ${dryRun ? 'seraient mis à jour' : 'mis à jour'}`);
   if (counts.empty > 0) logger.warn(`  ${counts.empty} fichiers vides ignorés`);
-  if (counts.missing > 0) logger.warn(`  ${counts.missing} ID absents en BDD ignorés`);
   if (counts.error > 0) logger.error(`  ${counts.error} erreurs`);
 
-  if (options.dryRun) {
+  if (dryRun) {
     logger.info(`Aucune modification effectuée. Relancer avec --apply pour exécuter.`);
   }
 }
 
-async function applyOne(id_sncu: string, filePath: string, dryRun: boolean): Promise<Statut> {
+async function applyOne(
+  identifier: string,
+  filePath: string,
+  dryRun: boolean,
+  resolveAirtableIdFcu: (table: ReseauTable, id_sncu: string) => Promise<number | null>
+): Promise<Action> {
   const prefix = dryRun ? '[DRY-RUN] ' : '';
+
+  // Numeric filename → id_fcu path: always reseaux_de_chaleur, update-only (no insert).
+  if (/^\d+$/.test(identifier)) {
+    const id_fcu = parseInt(identifier, 10);
+    try {
+      const parsed = JSON.parse(await readFile(filePath, 'utf8')) as
+        | GeoJSON.FeatureCollection
+        | GeoJSON.GeometryCollection
+        | GeoJSON.Geometry;
+      const isEmpty =
+        (parsed.type === 'FeatureCollection' && parsed.features.length === 0) ||
+        (parsed.type === 'GeometryCollection' && parsed.geometries.length === 0);
+      if (isEmpty) {
+        logger.warn(`${prefix}${id_fcu}: fichier vide, ignoré`);
+        return 'empty';
+      }
+      const geometryConfig = await processGeometry(parsed);
+      if (geometryConfig.geom.type !== 'MultiLineString' && geometryConfig.geom.type !== 'Point') {
+        logger.error(`${prefix}${id_fcu}: type de géométrie non autorisé (${geometryConfig.geom.type}), attendu MultiLineString ou Point`);
+        return 'error';
+      }
+      if (dryRun) {
+        logger.info(`${prefix}${id_fcu}: serait mis à jour dans reseaux_de_chaleur`);
+        return 'updated';
+      }
+      // updateEntityGeometry throws if id_fcu not found — no separate existence check needed.
+      await updateEntityGeometry('reseaux_de_chaleur', 'id_fcu', id_fcu, geometryConfig);
+      logger.info(`${prefix}${id_fcu}: mis à jour dans reseaux_de_chaleur`);
+      return 'updated';
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error(`${id_fcu}: ${message}`);
+      return 'error';
+    }
+  }
+
+  const id_sncu = identifier;
   try {
     const table = networkTableForId(id_sncu);
     if (!table) {
-      logger.warn(`${prefix}${id_sncu}: identifiant inattendu (ni C ni F), ignoré`);
+      logger.error(`${prefix}${id_sncu}: identifiant inattendu (ni C ni F), ignoré`);
       return 'error';
     }
 
@@ -77,18 +126,37 @@ async function applyOne(id_sncu: string, filePath: string, dryRun: boolean): Pro
       return 'empty';
     }
 
+    // Toujours parsé/validé, y compris en dry-run, pour que la prévisualisation soit fidèle.
+    const geometryConfig = await processGeometry(parsed);
+
+    // Pour un réseau de chaleur/froid, seuls un tracé (MultiLineString) ou une localisation (Point) sont valides.
+    if (geometryConfig.geom.type !== 'MultiLineString' && geometryConfig.geom.type !== 'Point') {
+      logger.error(`${prefix}${id_sncu}: type de géométrie non autorisé (${geometryConfig.geom.type}), attendu MultiLineString ou Point`);
+      return 'error';
+    }
+
     const existing = await kdb.selectFrom(table).select('id_fcu').where('Identifiant reseau', '=', id_sncu).executeTakeFirst();
+
     if (!existing) {
-      logger.warn(`${prefix}${id_sncu}: aucun réseau correspondant en BDD, ignoré`);
-      return 'missing';
+      // Réseau absent de Postgres : on ne crée PAS de ligne Airtable, on récupère au contraire
+      // son id_fcu depuis Airtable (source de vérité) pour créer la ligne Postgres correspondante.
+      const idFcu = await resolveAirtableIdFcu(table, id_sncu);
+      if (idFcu === null) {
+        logger.error(`${prefix}${id_sncu}: absent de la BDD et introuvable sur Airtable, id_fcu indéterminable, ignoré`);
+        return 'error';
+      }
+      if (dryRun) {
+        logger.info(`${prefix}${id_sncu}: serait créé dans ${table} (id_fcu ${idFcu} depuis Airtable)`);
+        return 'created';
+      }
+      await insertEntityWithGeometry(table, geometryConfig, { id_fcu: idFcu, id_sncu });
+      return 'created';
     }
 
     if (dryRun) {
       logger.info(`${prefix}${id_sncu}: serait mis à jour dans ${table}`);
-      return 'would_update';
+      return 'updated';
     }
-
-    const geometryConfig = await processGeometry(parsed);
     await updateEntityGeometry(table, 'Identifiant reseau', id_sncu, geometryConfig);
     return 'updated';
   } catch (err) {
@@ -96,4 +164,35 @@ async function applyOne(id_sncu: string, filePath: string, dryRun: boolean): Pro
     logger.error(`${id_sncu}: ${message}`);
     return 'error';
   }
+}
+
+/**
+ * Résout l'id_fcu d'un réseau depuis Airtable à partir de son identifiant SNCU.
+ * Tous les records d'une table sont chargés au premier besoin puis mis en cache (≤1 requête par table).
+ */
+function createAirtableIdFcuResolver() {
+  const cache = new Map<ReseauTable, Map<string, number>>();
+
+  async function indexFor(table: ReseauTable): Promise<Map<string, number>> {
+    const cached = cache.get(table);
+    if (cached) return cached;
+
+    const records = await AirtableDB(airtableTableForReseau[table])
+      .select({ fields: ['Identifiant reseau', 'id_fcu'] })
+      .all();
+    const index = new Map<string, number>();
+    for (const record of records) {
+      const idSncu = record.get('Identifiant reseau');
+      const idFcu = record.get('id_fcu');
+      if (typeof idSncu === 'string' && typeof idFcu === 'number') {
+        index.set(idSncu, idFcu);
+      }
+    }
+    cache.set(table, index);
+    return index;
+  }
+
+  return async (table: ReseauTable, id_sncu: string): Promise<number | null> => {
+    return (await indexFor(table)).get(id_sncu) ?? null;
+  };
 }

--- a/src/modules/reseaux/server/geometry-diff.ts
+++ b/src/modules/reseaux/server/geometry-diff.ts
@@ -5,6 +5,8 @@ import { createGeometryExpression, processGeometry } from '@/modules/geo/server/
 import { kdb, sql } from '@/server/db/kysely';
 import { logger } from '@/server/helpers/logger';
 
+import { networkTableForId } from '../constants';
+
 const BUFFER_SMALL_M = 5;
 const BUFFER_LARGE_M = 20;
 // Below this %, we consider the geometry unchanged (covers floating-point noise).
@@ -73,12 +75,6 @@ export async function diffNetworkGeometries(directory: string, outputPath: strin
   logger.info(`  ${counts.inchangé} inchangés`);
   logger.info(`  ${counts.vide} fichiers vides (potentiellement à supprimer)`);
   if (counts.erreur > 0) logger.warn(`  ${counts.erreur} erreurs`);
-}
-
-function networkTableForId(id_sncu: string): 'reseaux_de_chaleur' | 'reseaux_de_froid' | null {
-  if (id_sncu.endsWith('C')) return 'reseaux_de_chaleur';
-  if (id_sncu.endsWith('F')) return 'reseaux_de_froid';
-  return null;
 }
 
 async function diffSingle(id_sncu: string, filePath: string): Promise<DiffRow> {

--- a/src/modules/reseaux/server/geometry-identify.ts
+++ b/src/modules/reseaux/server/geometry-identify.ts
@@ -1,0 +1,352 @@
+import { copyFile, mkdir, mkdtemp, readdir, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { createGeometryExpression, processGeometry } from '@/modules/geo/server/helpers';
+import { kdb, sql } from '@/server/db/kysely';
+import { logger } from '@/server/helpers/logger';
+import { ogr2ogrConvertToGeoJSON } from '@/utils/ogr2ogr';
+
+// Buffer (m) used to decide whether two traces overlap. Same order of magnitude as geometry-diff.
+const BUFFER_M = 20;
+// 2 segments per quadrant is enough for length-coverage stats and ~4x faster.
+const BUFFER_QUAD_SEGS = 2;
+// ST_Subdivide chunk size — smaller = faster buffers on big networks (e.g. CPCU).
+const SUBDIVIDE_MAX_VERTICES = 256;
+// Candidate networks are pre-filtered with ST_DWithin (GIST index) at this distance.
+const DEFAULT_MAX_DISTANCE_M = 300;
+// Minimum F1 score (harmonic mean of both coverages) to call a match "fort".
+const DEFAULT_MIN_SCORE = 50;
+// A "fort" match also needs this margin over the second candidate, else it is "ambigu".
+const MIN_MARGIN = 15;
+// Number of candidates returned per file (best + alternatives for the report).
+const CANDIDATE_LIMIT = 5;
+
+type Statut = 'fort' | 'ambigu' | 'faible' | 'aucun' | 'vide' | 'erreur';
+type NetworkType = 'chaleur' | 'froid';
+
+type CandidateRow = {
+  id_sncu: string;
+  type: NetworkType;
+  communes: string[] | null;
+  len_net: string | number | null;
+  len_trace: string | number | null;
+  cov_reseau: string | number | null;
+  cov_trace: string | number | null;
+  score: string | number | null;
+};
+
+type IdentifyRow = {
+  fichier: string;
+  statut: Statut;
+  id_sncu: string | null;
+  type: NetworkType | null;
+  score: number | null;
+  cov_trace: number | null;
+  cov_reseau: number | null;
+  longueur_trace_m: number | null;
+  longueur_reseau_m: number | null;
+  commune_match: boolean | null;
+  id_sncu_2: string | null;
+  score_2: number | null;
+  ecrit: boolean;
+  erreur: string | null;
+};
+
+const csvHeaders = [
+  'fichier',
+  'statut',
+  'id_sncu',
+  'type',
+  'score',
+  'cov_trace',
+  'cov_reseau',
+  'longueur_trace_m',
+  'longueur_reseau_m',
+  'commune_match',
+  'id_sncu_2',
+  'score_2',
+  'ecrit',
+  'erreur',
+] as const satisfies ReadonlyArray<keyof IdentifyRow>;
+
+type IdentifyOptions = {
+  outputPath: string;
+  writeDir?: string;
+  minScore?: number;
+  maxDistance?: number;
+};
+
+export async function identifyNetworkGeometries(directory: string, options: IdentifyOptions): Promise<void> {
+  const minScore = options.minScore ?? DEFAULT_MIN_SCORE;
+  const maxDistance = options.maxDistance ?? DEFAULT_MAX_DISTANCE_M;
+
+  const entries = await readdir(directory);
+  const files = entries.filter((f) => /\.(kml|kmz|geojson|json)$/i.test(f)).sort();
+
+  if (files.length === 0) {
+    logger.warn(`Aucun fichier .kml / .geojson trouvé dans ${directory}`);
+    return;
+  }
+
+  logger.info(`Identification de ${files.length} fichiers (distance candidats: ${maxDistance} m, score fort: ${minScore})`);
+
+  if (options.writeDir) {
+    await mkdir(options.writeDir, { recursive: true });
+  }
+  const tempDir = await mkdtemp(path.join(tmpdir(), 'geom-identify-'));
+
+  // Sequential: each file runs a spatial query + optional ogr2ogr conversion. Keeps logs ordered
+  // and avoids saturating the DB connection pool / ogr2ogr processes.
+  const rows: IdentifyRow[] = [];
+  for (const [index, file] of files.entries()) {
+    rows.push(
+      await identifyOne(path.join(directory, file), tempDir, index, {
+        maxDistance,
+        minScore,
+        writeDir: options.writeDir,
+      })
+    );
+  }
+
+  await writeFile(options.outputPath, toCsv(rows), 'utf8');
+
+  const counts = rows.reduce<Record<Statut, number>>((acc, r) => ({ ...acc, [r.statut]: acc[r.statut] + 1 }), {
+    ambigu: 0,
+    aucun: 0,
+    erreur: 0,
+    faible: 0,
+    fort: 0,
+    vide: 0,
+  });
+  logger.info(`Rapport écrit dans ${options.outputPath}`);
+  logger.info(`  ${counts.fort} matchs forts`);
+  logger.info(`  ${counts.ambigu} ambigus (à arbitrer manuellement)`);
+  logger.info(`  ${counts.faible} faibles`);
+  logger.info(`  ${counts.aucun} sans candidat`);
+  if (counts.vide > 0) logger.warn(`  ${counts.vide} fichiers vides`);
+  if (counts.erreur > 0) logger.warn(`  ${counts.erreur} erreurs`);
+  if (options.writeDir) {
+    logger.info(
+      `Fichiers GeoJSON écrits dans ${options.writeDir} — supprimer ceux à ne pas importer, renommer les sans candidat en <id_sncu>.geojson, puis lancer bulk-update.`
+    );
+  } else {
+    logger.info(`Relancer avec --write <dir> pour convertir et écrire tous les fichiers en GeoJSON.`);
+  }
+}
+
+async function identifyOne(
+  filePath: string,
+  tempDir: string,
+  index: number,
+  options: { minScore: number; maxDistance: number; writeDir?: string }
+): Promise<IdentifyRow> {
+  const fichier = path.basename(filePath);
+  const empty = (): IdentifyRow => buildRow(fichier, 'vide');
+
+  try {
+    const isKml = /\.(kml|kmz)$/i.test(filePath);
+    let geojsonText: string;
+    if (isKml) {
+      // ogr2ogrConvertToGeoJSON builds an unquoted shell command: neither the input nor the output
+      // path may contain spaces. Stage the source under a space-free name in the temp dir first.
+      const stagedInput = path.join(tempDir, `input-${index}${path.extname(filePath)}`);
+      const outPath = path.join(tempDir, `input-${index}.geojson`);
+      await copyFile(filePath, stagedInput);
+      await ogr2ogrConvertToGeoJSON(stagedInput, outPath);
+      geojsonText = await readFile(outPath, 'utf8');
+    } else {
+      geojsonText = await readFile(filePath, 'utf8');
+    }
+
+    const parsed = JSON.parse(geojsonText) as GeoJSON.FeatureCollection | GeoJSON.GeometryCollection | GeoJSON.Geometry;
+    const isEmpty =
+      (parsed.type === 'FeatureCollection' && parsed.features.length === 0) ||
+      (parsed.type === 'GeometryCollection' && parsed.geometries.length === 0);
+    if (isEmpty) {
+      logger.warn(`${fichier}: fichier vide, ignoré`);
+      return empty();
+    }
+
+    const { geom, srid } = await processGeometry(parsed);
+    const candidates = await scoreCandidates(geom, srid, options.maxDistance);
+
+    if (candidates.length === 0) {
+      logger.info(`${fichier}: aucun réseau dans un rayon de ${options.maxDistance} m`);
+      if (options.writeDir) {
+        const outName = path.basename(fichier, path.extname(fichier));
+        await writeFile(path.join(options.writeDir, `${outName}.geojson`), geojsonText, 'utf8');
+      }
+      return buildRow(fichier, 'aucun');
+    }
+
+    const best = candidates[0];
+    const second = candidates[1];
+    const score = num(best.score) ?? 0;
+    const score2 = second ? num(second.score) : null;
+
+    let statut: Statut;
+    if (score < options.minScore) {
+      statut = 'faible';
+    } else if (score2 !== null && score - score2 < MIN_MARGIN) {
+      statut = 'ambigu';
+    } else {
+      statut = 'fort';
+    }
+
+    const communeMatch = matchesCommune(fichier, best.communes);
+
+    let ecrit = false;
+    if (options.writeDir) {
+      await writeFile(path.join(options.writeDir, `${best.id_sncu}.geojson`), geojsonText, 'utf8');
+      ecrit = true;
+    }
+
+    logger.info(
+      `${fichier}: ${statut} → ${best.id_sncu} (${best.type}, score ${score}, trace ${num(best.cov_trace)}%, réseau ${num(
+        best.cov_reseau
+      )}%${communeMatch ? ', commune ✓' : ''})`
+    );
+
+    return {
+      commune_match: communeMatch,
+      cov_reseau: num(best.cov_reseau),
+      cov_trace: num(best.cov_trace),
+      ecrit,
+      erreur: null,
+      fichier,
+      id_sncu: best.id_sncu,
+      id_sncu_2: second?.id_sncu ?? null,
+      longueur_reseau_m: num(best.len_net),
+      longueur_trace_m: num(best.len_trace),
+      score,
+      score_2: score2,
+      statut,
+      type: best.type,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error(`${fichier}: ${message}`);
+    return { ...buildRow(fichier, 'erreur'), erreur: message };
+  }
+}
+
+/**
+ * For a trace geometry, return the nearby networks (both heat and cold) ranked by overlap score.
+ * Score = harmonic mean of two length coverages computed with a {@link BUFFER_M} buffer:
+ *  - cov_trace: % of the imported trace lying on the existing network,
+ *  - cov_reseau: % of the existing network lying under the imported trace.
+ * Candidate networks are clipped to the trace neighbourhood before buffering to bound the cost
+ * on very large networks (e.g. CPCU), while the full network length is kept as the cov_reseau denominator.
+ */
+async function scoreCandidates(geom: GeoJSON.Geometry, srid: number, maxDistance: number): Promise<CandidateRow[]> {
+  const traceExpr = createGeometryExpression(geom, srid);
+  const maxDist = sql.lit(maxDistance);
+  const bufferM = sql.lit(BUFFER_M);
+  const bufferOpts = sql.lit(`quad_segs=${BUFFER_QUAD_SEGS}`);
+  const subdivideMax = sql.lit(SUBDIVIDE_MAX_VERTICES);
+
+  const { rows } = await sql<CandidateRow>`
+    WITH n AS (SELECT ${traceExpr} AS g),
+    nlen AS (SELECT g, ST_Length(g) AS len, ST_Expand(ST_Envelope(g), ${maxDist}) AS zone FROM n),
+    n_sub AS (SELECT ST_Subdivide(g, ${subdivideMax}) AS chunk FROM n),
+    nbuf AS (SELECT ST_UnaryUnion(ST_Collect(ST_Buffer(chunk, ${bufferM}, ${bufferOpts}))) AS gbuf FROM n_sub),
+    candidates AS (
+      SELECT r."Identifiant reseau" AS id_sncu, 'chaleur'::text AS type, r.communes,
+             r.geom AS g, ST_Intersection(r.geom, nlen.zone) AS g_local
+      FROM reseaux_de_chaleur r, nlen
+      WHERE r.geom IS NOT NULL AND r."Identifiant reseau" IS NOT NULL AND ST_DWithin(r.geom, nlen.g, ${maxDist})
+      UNION ALL
+      SELECT r."Identifiant reseau", 'froid'::text, r.communes,
+             r.geom, ST_Intersection(r.geom, nlen.zone)
+      FROM reseaux_de_froid r, nlen
+      WHERE r.geom IS NOT NULL AND r."Identifiant reseau" IS NOT NULL AND ST_DWithin(r.geom, nlen.g, ${maxDist})
+    ),
+    scored AS (
+      SELECT c.id_sncu, c.type, c.communes,
+        ST_Length(c.g) AS len_net,
+        nlen.len AS len_trace,
+        COALESCE(ST_Length(ST_Intersection(c.g_local, nbuf.gbuf)), 0) AS net_covered,
+        COALESCE(cb.trace_covered, 0) AS trace_covered
+      FROM candidates c, nlen, nbuf
+      CROSS JOIN LATERAL (
+        SELECT ST_Length(ST_Intersection(nlen.g, nb2.gbuf)) AS trace_covered
+        FROM (
+          SELECT ST_UnaryUnion(ST_Collect(ST_Buffer(sub.chunk, ${bufferM}, ${bufferOpts}))) AS gbuf
+          FROM ST_Subdivide(c.g_local, ${subdivideMax}) AS sub(chunk)
+        ) nb2
+      ) cb
+    ),
+    final AS (
+      SELECT id_sncu, type, communes, len_net, len_trace,
+        100.0 * net_covered / NULLIF(len_net, 0) AS cov_reseau,
+        100.0 * trace_covered / NULLIF(len_trace, 0) AS cov_trace
+      FROM scored
+    )
+    SELECT id_sncu, type, communes,
+      ROUND(len_net::numeric, 0) AS len_net,
+      ROUND(len_trace::numeric, 0) AS len_trace,
+      ROUND(cov_reseau::numeric, 1) AS cov_reseau,
+      ROUND(cov_trace::numeric, 1) AS cov_trace,
+      ROUND((2 * cov_reseau * cov_trace / NULLIF(cov_reseau + cov_trace, 0))::numeric, 1) AS score
+    FROM final
+    ORDER BY score DESC NULLS LAST
+    LIMIT ${sql.lit(CANDIDATE_LIMIT)}
+  `.execute(kdb);
+
+  return rows;
+}
+
+/** Loose match between the file name (city) and a candidate's communes — confirmation signal only. */
+function matchesCommune(fichier: string, communes: string[] | null): boolean | null {
+  if (!communes || communes.length === 0) return null;
+  const nf = normalize(path.basename(fichier, path.extname(fichier)));
+  if (nf.length === 0) return null;
+  return communes.some((c) => {
+    const nc = normalize(c);
+    return nc.length > 2 && (nf.includes(nc) || nc.includes(nf));
+  });
+}
+
+function normalize(s: string): string {
+  return s
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '');
+}
+
+function buildRow(fichier: string, statut: Statut): IdentifyRow {
+  return {
+    commune_match: null,
+    cov_reseau: null,
+    cov_trace: null,
+    ecrit: false,
+    erreur: null,
+    fichier,
+    id_sncu: null,
+    id_sncu_2: null,
+    longueur_reseau_m: null,
+    longueur_trace_m: null,
+    score: null,
+    score_2: null,
+    statut,
+    type: null,
+  };
+}
+
+function num(v: unknown): number | null {
+  if (v === null || v === undefined) return null;
+  const n = typeof v === 'number' ? v : Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function toCsv(rows: IdentifyRow[]): string {
+  const escape = (v: unknown): string => {
+    if (v === null || v === undefined) return '';
+    const s = String(v);
+    return /[",\n\r]/.test(s) ? `"${s.replaceAll('"', '""')}"` : s;
+  };
+  const dataLines = rows.map((row) => csvHeaders.map((header) => escape(row[header])).join(','));
+  return `${[csvHeaders.join(','), ...dataLines].join('\n')}\n`;
+}

--- a/src/utils/ogr2ogr.ts
+++ b/src/utils/ogr2ogr.ts
@@ -58,16 +58,62 @@ export async function ogr2ogrConvertToGeoJSON(
     inputFileName = `${randomPrefix}${inputFileName}`;
     await rename(inputFilePath, join(dockerVolumePath, inputFileName));
   }
-  await runOgr2ogr(
-    `-f GeoJSON ${serverConfig.USE_DOCKER_GEO_COMMANDS ? 'output.geojson' : outputFilePath} ${serverConfig.USE_DOCKER_GEO_COMMANDS ? inputFileName : inputFilePath} -t_srs EPSG:4326`,
-    options
-  );
+
+  const inputArg = serverConfig.USE_DOCKER_GEO_COMMANDS ? inputFileName : inputFilePath;
+  const outputArg = serverConfig.USE_DOCKER_GEO_COMMANDS ? 'output.geojson' : outputFilePath;
+
+  const layers = await listNonEmptyLayers(inputArg);
+  if (layers.length <= 1) {
+    await runOgr2ogr(`-f GeoJSON ${outputArg} ${inputArg} -t_srs EPSG:4326`, options);
+  } else {
+    // KML (and other multi-layer formats): GeoJSON only supports one layer per file.
+    // Convert the first layer normally, then append the rest under the same layer name.
+    const [first, ...rest] = layers;
+    await runOgr2ogr(`-f GeoJSON ${outputArg} ${inputArg} "${first}" -t_srs EPSG:4326 -nlt GEOMETRY`, options);
+    for (const layer of rest) {
+      await runOgr2ogr(
+        `-f GeoJSON -update -append ${outputArg} ${inputArg} "${layer}" -t_srs EPSG:4326 -nlt GEOMETRY -nln "${first}"`,
+        options
+      );
+    }
+  }
+
   if (serverConfig.USE_DOCKER_GEO_COMMANDS) {
     // input
     await rename(join(dockerVolumePath, inputFileName), inputFilePath);
     // output
     await rename(join(dockerVolumePath, 'output.geojson'), outputFilePath);
   }
+}
+
+/**
+ * Returns the names of layers that contain at least one feature.
+ * Skips empty layers (e.g. LIBKML metadata containers named after the source file).
+ */
+async function listNonEmptyLayers(filePath: string): Promise<string[]> {
+  const run = serverConfig.USE_DOCKER_GEO_COMMANDS
+    ? (cmd: string) => runDocker(`ghcr.io/osgeo/gdal:alpine-normal-latest-${dockerImageArch}`, cmd, { captureOutput: true })
+    : (cmd: string) => runBash(cmd, { captureOutput: true });
+
+  const { output } = await run(`ogrinfo -al -so "${filePath}"`);
+
+  const layers: string[] = [];
+  let currentLayer: string | null = null;
+  for (const line of output.split('\n')) {
+    const layerMatch = line.match(/^Layer name: (.+)$/);
+    if (layerMatch) {
+      currentLayer = layerMatch[1].trim();
+      continue;
+    }
+    const countMatch = line.match(/^Feature Count: (\d+)/);
+    if (countMatch && currentLayer) {
+      if (parseInt(countMatch[1], 10) > 0) {
+        layers.push(currentLayer);
+      }
+      currentLayer = null;
+    }
+  }
+  return layers;
 }
 
 export async function ogr2ogrExtractNDJSONFromDatabaseTable(


### PR DESCRIPTION
Complète une CLI déjà existante pour maj en masse des tracés.

A part les modifs de code, j'ai :
- récupéré le dossier contenant les geojson
- supprimé du dossier les fichiers à ne pas mettre à jour (en rouge ou orange sur le spreadsheet)
- puis :
- avec le tunnel configuré pour la BDD de prod
- avec AIRTABLE_BASE ET DATABASE_URL qui pointent vers la prod
- lancé la commande `pnpm cli geom bulk-update --apply <chemin_vers_dossier_tracés>`
- lancé la commande `pnpm cli geom extend rdc <chemin/vers/9410C.geojson> 9410C` (car contient une extension seulement, à ajouter à la géométrie actuelle)
- ~~lancé la commande `pnpm cli sync-postgres-to-airtable` pour synchro les métadonnées déduites des géométries~~ (inutile en fait)
- lancé une synchro depuis l'[espace admin](https://france-chaleur-urbaine.beta.gouv.fr/admin/reseaux) pour les réseaux de chaud et de froid


Pour Coriance, toujours branché en prod :

```sh
pnpm cli geom identify --write coriance ~/Downloads/fcu/MAJ\ CORIANCE\ 2026 coriance.csv
# Lire le fichier coriance.csv pour voir si l'affectation aux réseau est bonne. Dès que c'est < 95, ça peut être louche. Parfois un réseau n'a pas d'id SNCU donc il faut renommer le fichier avec l'id_fcu (on gère seulement les réseaux de chaleur).
pnpm cli geom diff coriance
# Lire le geometry-diff.csv pour voir s'il y a des cas louches (grosses suppressions principalement)
# Avec les 2 fichiers et avec des drag n drop sur la carte, vérifier chaque cas pour savoir si la maj est légitime. S'il y a des doutes, supprimer le fichier du répertoire pour ne laisser que les fichiers dont la mise à jour est certaine.
pnpm cli geom bulk-update --write coriance
```