### PR TITLE
Evite la surcharge des limites de MapConfiguration

### DIFF
--- a/src/modules/map/client/config/map-configuration.ts
+++ b/src/modules/map/client/config/map-configuration.ts
@@ -1,4 +1,3 @@
-import { deepMergeObjects } from '@/utils/core';
 import type { Interval } from '@/utils/interval';
 import type { DeepPartial, FlattenKeys } from '@/utils/typescript';
 
@@ -306,6 +305,6 @@ export const iframeSimpleMapConfiguration = createMapConfiguration({
   },
 });
 
-export function createMapConfiguration(config: DeepPartial<MapConfiguration>): MapConfiguration {
-  return deepMergeObjects(emptyMapConfiguration, config);
+export function createMapConfiguration(config: DeepPartial<MapConfiguration>): DeepPartial<MapConfiguration> {
+  return config;
 }

--- a/src/modules/map/client/config/useMapConfiguration.ts
+++ b/src/modules/map/client/config/useMapConfiguration.ts
@@ -1,9 +1,10 @@
 import { useMemo } from 'react';
 
 import trpc from '@/modules/trpc/client';
+import { deepMergeObjects } from '@/utils/core';
 import type { DeepPartial } from '@/utils/typescript';
 
-import { createMapConfiguration, type MapConfiguration } from './map-configuration';
+import { emptyMapConfiguration, type MapConfiguration } from './map-configuration';
 
 /**
  * Resolves a full `MapConfiguration` by fetching the réseaux-de-chaleur limits
@@ -17,7 +18,7 @@ export function useMapConfiguration(partial: DeepPartial<MapConfiguration>): Map
     if (!limits) {
       return null;
     }
-    return createMapConfiguration({
+    return deepMergeObjects(emptyMapConfiguration, {
       ...partial,
       reseauxDeChaleur: {
         ...limits,


### PR DESCRIPTION
Avant ça, certaines réseaux n'était pas visibles dans /admin/reseaux... :facepalm: 
Maintenant c'est plus logique, on ne passe que les options à écraser en externe.