### PR TITLE
Ajoute le maitre d'ouvrage aux réseaux en construction

### DIFF
--- a/src/components/ContributionForm/ContributionForm.tsx
+++ b/src/components/ContributionForm/ContributionForm.tsx
@@ -227,6 +227,11 @@ const typeDemandeFields = {
       schema: stringSchema,
     },
     {
+      label: "Maître d'ouvrage :",
+      name: 'maitreOuvrage',
+      schema: stringSchema,
+    },
+    {
       label: 'Date de mise en service prévisionnelle :',
       name: 'dateMiseEnServicePrevisionnelle',
       schema: stringSchema,
@@ -272,6 +277,11 @@ const typeDemandeFields = {
     {
       label: 'Gestionnaire :',
       name: 'gestionnaire',
+      schema: stringSchema,
+    },
+    {
+      label: "Maître d'ouvrage :",
+      name: 'maitreOuvrage',
       schema: stringSchema,
     },
     {

--- a/src/components/NetworksList/NetworksList.tsx
+++ b/src/components/NetworksList/NetworksList.tsx
@@ -42,6 +42,7 @@ const NetworksListContainer = styled.div`
 export const GeneralFieldsList = [
   'communes',
   'Gestionnaire',
+  'MO',
   'Taux EnR&R',
   'contenu CO2 ACV',
   'contenu CO2',
@@ -83,6 +84,10 @@ const exportColumns = [
   {
     accessorKey: 'Gestionnaire',
     name: 'Gestionnaire',
+  },
+  {
+    accessorKey: 'MO',
+    name: "Maître d'ouvrage",
   },
   {
     accessorKey: 'Taux EnR&R',
@@ -258,6 +263,7 @@ const NetworksList = () => {
         (network: NetworkToCompare) =>
           network.nom_reseau?.toLocaleLowerCase().includes(searchValueLowerCase) ||
           network.Gestionnaire?.toLocaleLowerCase().includes(searchValueLowerCase) ||
+          network.MO?.toLocaleLowerCase().includes(searchValueLowerCase) ||
           network.region?.toLocaleLowerCase().includes(searchValueLowerCase) ||
           network.communes?.join(', ').toLocaleLowerCase().includes(searchValueLowerCase) ||
           network['Identifiant reseau']?.toLocaleLowerCase().includes(searchValueLowerCase)
@@ -328,6 +334,11 @@ const NetworksList = () => {
       {
         accessorKey: 'Gestionnaire',
         header: 'Gestionnaire',
+        width: '250px',
+      },
+      {
+        accessorKey: 'MO',
+        header: "Maître d'ouvrage",
         width: '250px',
       },
       {

--- a/src/modules/map/client/layers/filters.ts
+++ b/src/modules/map/client/layers/filters.ts
@@ -131,7 +131,10 @@ export function buildFiltreGestionnaire(filtreGestionnaire: MapConfiguration['fi
     : [];
 }
 
-/** Free-text substring match on the `MO` (maître d'ouvrage) field. Case-insensitive; multiple values are OR-ed. */
+/**
+ * Free-text substring match on the `MO` (maître d'ouvrage) field. Case-insensitive; multiple values are OR-ed.
+ * The union type param ensures `MO` exists on every filtered tile source (chaleur, froid, construction).
+ */
 export function buildFiltreMaitreOuvrage(filtreMaitreOuvrage: MapConfiguration['filtreMaitreOuvrage']): ExpressionSpecification[] {
   const values = (filtreMaitreOuvrage ?? []).map((value) => value.trim().toLowerCase()).filter(Boolean);
   return values.length > 0
@@ -140,7 +143,11 @@ export function buildFiltreMaitreOuvrage(filtreMaitreOuvrage: MapConfiguration['
           'any',
           ...values.map(
             (filtre) =>
-              ['in', filtre, ['downcase', ['coalesce', getProp<ReseauxDeChaleurTile>('MO'), '']]] satisfies ExpressionSpecification
+              [
+                'in',
+                filtre,
+                ['downcase', ['coalesce', getProp<ReseauxDeChaleurTile | ReseauxEnConstructionTile>('MO'), '']],
+              ] satisfies ExpressionSpecification
           ),
         ],
       ]

--- a/src/modules/map/client/layers/specs/reseauxEnConstruction.tsx
+++ b/src/modules/map/client/layers/specs/reseauxEnConstruction.tsx
@@ -2,7 +2,7 @@ import Accordion from '@/components/ui/Accordion';
 import Icon from '@/components/ui/Icon';
 import { DownloadNetworkGeometryButton } from '@/modules/map/client/components/DownloadNetworkGeometryButton';
 import { defineLayerPopup, ifHoverElse, type MapSourceLayersSpecification } from '@/modules/map/client/core/common';
-import { buildFiltreGestionnaire } from '@/modules/map/client/layers/filters';
+import { buildFiltreGestionnaire, buildFiltreMaitreOuvrage } from '@/modules/map/client/layers/filters';
 import type { ReseauxEnConstructionTile } from '@/modules/tiles/server/tiles.config';
 
 const Popup = defineLayerPopup<ReseauxEnConstructionTile>((reseauEnConstruction, { Property, Title, TwoColumns }) => {
@@ -11,6 +11,7 @@ const Popup = defineLayerPopup<ReseauxEnConstructionTile>((reseauEnConstruction,
       <Title title={`ID FCU: ${reseauEnConstruction.id_fcu}`}>{reseauEnConstruction.nom_reseau ?? 'Réseau en construction'}</Title>
       <TwoColumns>
         <Property label="Gestionnaire" value={reseauEnConstruction.gestionnaire} />
+        <Property label="Maître d'ouvrage" value={reseauEnConstruction.MO} />
         <Property label="Mise en service" value={reseauEnConstruction.mise_en_service} />
       </TwoColumns>
       {!reseauEnConstruction.ouvert_aux_raccordements && (
@@ -43,7 +44,12 @@ export const reseauxEnConstructionLayersSpec = [
   {
     layers: [
       {
-        filter: (config) => ['all', ['==', ['get', 'is_zone'], true], ...buildFiltreGestionnaire(config.filtreGestionnaire)],
+        filter: (config) => [
+          'all',
+          ['==', ['get', 'is_zone'], true],
+          ...buildFiltreGestionnaire(config.filtreGestionnaire),
+          ...buildFiltreMaitreOuvrage(config.filtreMaitreOuvrage),
+        ],
         id: 'reseauxEnConstruction-zone',
         isVisible: (config) => config.reseauxEnConstruction,
         paint: {
@@ -59,7 +65,12 @@ export const reseauxEnConstructionLayersSpec = [
         type: 'fill',
       },
       {
-        filter: (config) => ['all', ['==', ['get', 'is_zone'], false], ...buildFiltreGestionnaire(config.filtreGestionnaire)],
+        filter: (config) => [
+          'all',
+          ['==', ['get', 'is_zone'], false],
+          ...buildFiltreGestionnaire(config.filtreGestionnaire),
+          ...buildFiltreMaitreOuvrage(config.filtreMaitreOuvrage),
+        ],
         id: 'reseauxEnConstruction-trace',
         isVisible: (config) => config.reseauxEnConstruction,
         layout: {

--- a/src/modules/reseaux/client/admin/AdminReseauxPage.tsx
+++ b/src/modules/reseaux/client/admin/AdminReseauxPage.tsx
@@ -786,6 +786,15 @@ const GestionDesReseaux = () => {
         width: '180px',
       },
       {
+        accessorKey: 'MO',
+        filterProps: {
+          placeholder: "Filtrer par maître d'ouvrage",
+        },
+        filterType: 'Text',
+        header: "Maître d'ouvrage",
+        width: '150px',
+      },
+      {
         accessorFn: (row) => row.communes?.join(', '),
         filterProps: {
           placeholder: 'Filtrer par commune',

--- a/src/modules/reseaux/server/download-network.ts
+++ b/src/modules/reseaux/server/download-network.ts
@@ -141,6 +141,7 @@ const conversionConfigReseauxDeFroid = {
 
 const conversionConfigReseauxEnConstruction = {
   gestionnaire: TypeString,
+  MO: TypeString,
   mise_en_service: TypeString,
   nom_reseau: TypeString,
   ouvert_aux_raccordements: TypeBool,

--- a/src/modules/reseaux/server/service.integration.spec.ts
+++ b/src/modules/reseaux/server/service.integration.spec.ts
@@ -97,7 +97,7 @@ describe('searchNetworkOperators()', () => {
   beforeAll(async () => {
     await cleanDatabase();
 
-    // Dalkia appears in chaleur + froid (distinct test); IDEX only in construction (gestionnaire-only table).
+    // Dalkia appears in chaleur + froid (distinct test); IDEX only in construction.
     await Promise.all([
       seedReseauDeChaleur({
         Gestionnaire: 'Dalkia',
@@ -118,6 +118,7 @@ describe('searchNetworkOperators()', () => {
         gestionnaire: 'IDEX',
         id_fcu: 3004,
         is_zone: false,
+        MO: 'Commune de Nantes',
         nom_reseau: 'ZC',
         ouvert_aux_raccordements: false,
       }),
@@ -136,6 +137,7 @@ describe('searchNetworkOperators()', () => {
     { expected: [], field: 'gestionnaire', label: 'gestionnaire : aucun match', search: 'zzz' },
     { expected: ['Métropole de Lyon'], field: 'maitreOuvrage', label: 'MO : match chaleur', search: 'métropole' },
     { expected: ['Région Sud'], field: 'maitreOuvrage', label: 'MO : inclut les réseaux de froid', search: 'région' },
+    { expected: ['Commune de Nantes'], field: 'maitreOuvrage', label: 'MO : inclut les réseaux en construction', search: 'nantes' },
     { expected: [], field: 'maitreOuvrage', label: 'MO : ne cherche pas dans le champ gestionnaire', search: 'idex' },
   ] as const;
 

--- a/src/modules/reseaux/server/service.ts
+++ b/src/modules/reseaux/server/service.ts
@@ -287,6 +287,7 @@ export const listReseauxEnConstruction = async () => {
       'nom_reseau',
       'communes',
       'gestionnaire',
+      'MO',
       eb
         .selectFrom('organizations')
         .select('name')
@@ -960,12 +961,13 @@ export const searchNetworksForMap = async (search: string): Promise<NetworkMapSe
 
 /**
  * Distinct operator names (gestionnaire / maître d'ouvrage) matching `search`, for the
- * iframe generator autocomplete. Gestionnaire spans chaleur + froid + construction; MO
- * spans chaleur + froid (construction has no MO column). Public, map-level data.
+ * iframe generator autocomplete. Both fields span chaleur + froid + construction.
+ * Public, map-level data.
  */
 export const searchNetworkOperators = async (field: 'gestionnaire' | 'maitreOuvrage', search: string): Promise<string[]> => {
   const pattern = `%${search}%`;
   const column = field === 'gestionnaire' ? ('Gestionnaire' as const) : ('MO' as const);
+  const constructionColumn = field === 'gestionnaire' ? ('gestionnaire' as const) : ('MO' as const);
 
   const chaleur = kdb
     .selectFrom('reseaux_de_chaleur')
@@ -975,16 +977,12 @@ export const searchNetworkOperators = async (field: 'gestionnaire' | 'maitreOuvr
     .selectFrom('reseaux_de_froid')
     .select((eb) => eb.ref(column).as('value'))
     .where(column, 'ilike', pattern);
+  const construction = kdb
+    .selectFrom('zones_et_reseaux_en_construction')
+    .select((eb) => eb.ref(constructionColumn).as('value'))
+    .where(constructionColumn, 'ilike', pattern);
 
-  const operators =
-    field === 'gestionnaire'
-      ? chaleur.union(froid).union(
-          kdb
-            .selectFrom('zones_et_reseaux_en_construction')
-            .select((eb) => eb.ref('gestionnaire').as('value'))
-            .where('gestionnaire', 'ilike', pattern)
-        )
-      : chaleur.union(froid);
+  const operators = chaleur.union(froid).union(construction);
 
   const rows = await kdb
     .selectFrom(operators.as('operators'))

--- a/src/modules/tiles/server/tiles.config.ts
+++ b/src/modules/tiles/server/tiles.config.ts
@@ -94,6 +94,7 @@ const reseauxEnConstructionFields = [
   'nom_reseau',
   'mise_en_service',
   'gestionnaire',
+  'MO',
   'is_zone',
   'ouvert_aux_raccordements',
 ] as const satisfies (keyof ZonesEtReseauxEnConstruction)[];

--- a/src/pages/api/contribution.ts
+++ b/src/pages/api/contribution.ts
@@ -137,6 +137,7 @@ export default handleRouteErrors(async (req, res) => {
       })
     ),
     Localisation: (formValues as any).localisation,
+    "Maître d'ouvrage": (formValues as any).maitreOuvrage,
     Nom: formValues.nom,
     'Nom gestionnaire': (formValues as any).gestionnaire,
     ouvert_aux_raccordements: (formValues as any).ouvertAuxRaccordements,

--- a/src/server/db/kysely/database.ts
+++ b/src/server/db/kysely/database.ts
@@ -958,6 +958,7 @@ export interface ZonesEtReseauxEnConstruction {
   id_fcu: number;
   is_zone: Generated<boolean>;
   mise_en_service: string | null;
+  MO: string | null;
   nom_reseau: string | null;
   notes: string | null;
   organization_id: string | null;

--- a/src/server/db/migrations/20260702000000_add_maitre_ouvrage_to_reseaux_en_construction.ts
+++ b/src/server/db/migrations/20260702000000_add_maitre_ouvrage_to_reseaux_en_construction.ts
@@ -1,0 +1,16 @@
+import type { Kysely } from 'kysely';
+import { sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`
+    ALTER TABLE zones_et_reseaux_en_construction
+    ADD COLUMN IF NOT EXISTS "MO" character varying(254);
+  `.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`
+    ALTER TABLE zones_et_reseaux_en_construction
+    DROP COLUMN IF EXISTS "MO";
+  `.execute(db);
+}


### PR DESCRIPTION
- Au formulaire de contribution
- En filtre des iframes et sur la carte
- Sur la liste des réseaux
- Dans les popups sur la carte

Fait sur airtable (dev et prod) :
- FCU - Futurs réseaux de chaleur : colonne MO créée
- FCU - Contribution : colonne Maitre d'ouvrage créé

A faire après déploiement : synchro des réseaux en construction pour télécharger les métadonnées MO et regénérer les tuiles