### PR TITLE
Gestion abus tracking

### DIFF
--- a/.ai/context/styling.md
+++ b/.ai/context/styling.md
@@ -7,6 +7,10 @@
 - **Never**: new CSS-in-JS, global CSS for component styles, the legacy `Box` and `Text` components (use `div`/`p` + Tailwind), emojis (use icons).
 - **Inline `style={}`**: allowed only for genuinely dynamic/computed values (a JS-derived color, width, transform), and only for that property — everything static stays in Tailwind.**
 
+## Dialogs & confirmations
+- **Never** `window.confirm` / `window.prompt` / `alert`. Use `ConfirmDialog` (`@/components/ui/ConfirmDialog`) driven by `useDialogState` (`@/hooks/useDialogState`). Put any input (e.g. a required reason) in its `children`, gate the confirm button with `confirmDisabled`; `danger` renders the destructive (red) confirm. The dialog closes only on success (errors keep it open and are notified globally). For a full form use `Dialog` directly.
+- Coloured buttons via the `Button` `variant` prop (`destructive` red, `success` green, `info`, `warning`) + `iconId`, never ad-hoc colour classes.
+
 ## Tailwind rules
 - `cx()` (`@/utils/cx`) **only** for conditional classes; write unconditional class lists as plain strings.
 - Don't wrap literal DSFR utility classes in `fr.cx(...)` — write them inline (`'fr-text--xs font-bold'`); keep `fr.cx()` only for variable/typed values.

--- a/src/components/Admin/adminPages.ts
+++ b/src/components/Admin/adminPages.ts
@@ -51,6 +51,12 @@ export const adminPages = [
     label: 'Conversion par source',
   },
   {
+    desc: 'Détecter et bannir les IP polluant les stats de conversion',
+    group: 'analytics',
+    href: '/admin/conversion/abus',
+    label: 'Conversion — contrôle des abus',
+  },
+  {
     desc: 'Consultez les statistiques des demandes par réseau',
     group: 'analytics',
     href: '/admin/reseaux/stats',

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -61,6 +61,12 @@ export const variantClassNames = {
     tertiary: 'text-info!',
     'tertiary no outline': '',
   },
+  success: {
+    primary: 'bg-success/90! text-white! hover:bg-success! active:bg-success/80!',
+    secondary: 'border-success! text-success! shadow-success',
+    tertiary: 'text-success!',
+    'tertiary no outline': '',
+  },
   warning: {
     primary: 'bg-warning/90! text-white! hover:bg-warning! active:bg-warning/80!',
     secondary: 'border-warning! text-warning! shadow-warning',

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
 
 import AsyncButton from '@/components/ui/AsyncButton';
 import Button from '@/components/ui/Button';
@@ -16,6 +16,8 @@ type ConfirmDialogProps<T> = {
   cancelLabel?: string;
   /** Style destructif (bouton rouge + icône corbeille). */
   danger?: boolean;
+  /** Icône du bouton Confirmer (défaut : corbeille quand `danger`). */
+  confirmIconId?: ComponentProps<typeof AsyncButton>['iconId'];
   /** Désactive « Confirmer » (ex. pendant un chargement de contexte). */
   confirmDisabled?: boolean;
   /** Action confirmée. Le dialog se ferme uniquement en cas de succès ; en cas d'erreur il reste ouvert. */
@@ -31,6 +33,7 @@ const ConfirmDialog = <T,>({
   confirmLabel = 'Confirmer',
   cancelLabel = 'Annuler',
   danger,
+  confirmIconId,
   confirmDisabled,
   onConfirm,
 }: ConfirmDialogProps<T>) => {
@@ -51,7 +54,7 @@ const ConfirmDialog = <T,>({
           <AsyncButton
             priority="primary"
             variant={danger ? 'destructive' : undefined}
-            iconId={danger ? 'fr-icon-delete-line' : undefined}
+            iconId={confirmIconId ?? (danger ? 'fr-icon-delete-line' : undefined)}
             disabled={confirmDisabled}
             onClick={handleConfirm}
           >

--- a/src/components/ui/table/TableCell.tsx
+++ b/src/components/ui/table/TableCell.tsx
@@ -141,6 +141,12 @@ const TableCell = <T,>({ value, children: defaultValue, data, type, cellProps = 
 };
 
 export default memo(TableCell, (prevProps, nextProps) => {
+  // Les cellules à rendu personnalisé (forceCellRender) rendent `children`, recalculé à chaque
+  // render de la ligne et pouvant capturer un état externe (ex. un toggle). Les mémoïser sur
+  // value/data seuls masquerait tout changement de rendu à data constante : on ne les mémoïse pas.
+  if (prevProps.forceCellRender || nextProps.forceCellRender) {
+    return false;
+  }
   // Éviter la sérialisation JSON qui peut causer des erreurs de structure circulaire
   // Comparer directement les types et les valeurs
   return prevProps.type === nextProps.type && isEqual(prevProps.value, nextProps.value) && isEqual(prevProps.data, nextProps.data);

--- a/src/components/ui/table/TableSimple.tsx
+++ b/src/components/ui/table/TableSimple.tsx
@@ -186,6 +186,12 @@ type TableRowProps<T> = {
   onRowDoubleClick?: (rowId: any) => void;
   measureElement?: (element: Element | null) => void;
   columnClassName: (columnDef: ColumnDef<T>) => string;
+  /**
+   * Column definitions, passed to invalidate the row's memoization when a cell renderer changes
+   * (e.g. a `cell` closing over external toggle state) without the row data itself changing.
+   * Not read directly: `row.getVisibleCells()` already resolves the current column defs.
+   */
+  columns: ColumnDef<T>[];
 };
 
 // Memoized: with stable, primitive props (no `rowSelection` object), a selection change only
@@ -1062,6 +1068,7 @@ const TableSimple = <T extends RowData>({
                       onRowDoubleClick={onRowDoubleClick}
                       measureElement={measureRow}
                       columnClassName={columnClassName}
+                      columns={tableColumns}
                     />
                   );
                 })

--- a/src/components/ui/table/TableSimple.tsx
+++ b/src/components/ui/table/TableSimple.tsx
@@ -148,6 +148,10 @@ export type ColumnDef<T, K = any> = ColumnDefOriginal<T, K> & {
   filtersDialogLabel?: React.ReactNode;
   filtersDialogDescription?: React.ReactNode;
   showInFiltersDialog?: boolean;
+  /** Libellé de la colonne dans le dialog de tri (`enableSortDialog`) ; défaut = `header` s'il est une string. */
+  sortDialogLabel?: string;
+  /** Exclut la colonne du dialog de tri. Par défaut toute colonne triable (`enableSorting !== false`) y figure. */
+  showInSortDialog?: boolean;
   visible?: boolean;
   exportHeader?: string;
   exportFn?: (row: T) => string | number | boolean;
@@ -474,6 +478,11 @@ export type TableSimpleProps<T> = {
    * Affiche le bouton Filtres pour ouvrir la dialog. Par défaut, non affiché.
    */
   enableFiltersDialog?: boolean;
+  /**
+   * Affiche un bouton « Trier » (dialog) listant les colonnes triables — y compris masquées (`visible: false`)
+   * ou sans en-tête cliquable (cellule custom). Tri géré en interne par la table (déclaratif, aucun state externe).
+   */
+  enableSortDialog?: boolean;
 };
 
 const TableSimple = <T extends RowData>({
@@ -508,8 +517,10 @@ const TableSimple = <T extends RowData>({
   export: exportConfig,
   urlSyncKey,
   enableFiltersDialog = false,
+  enableSortDialog = false,
 }: TableSimpleProps<T>) => {
   const [isFiltersDialogOpen, setFiltersDialogOpen] = React.useState(false);
+  const [isSortDialogOpen, setSortDialogOpen] = React.useState(false);
   const {
     columnFilters,
     globalFilter,
@@ -654,6 +665,21 @@ const TableSimple = <T extends RowData>({
   const filterableColumnIds = React.useMemo(() => new Set(filterableColumns.map((column) => column.id)), [filterableColumns]);
   const activeFiltersCount = table.getState().columnFilters.filter((filter) => filterableColumnIds.has(filter.id as string)).length;
   const hasFiltersDialog = enableFiltersDialog !== undefined ? enableFiltersDialog : filterableColumns.length > 0;
+
+  const sortableColumns = React.useMemo(
+    () =>
+      table
+        .getAllColumns()
+        .filter((column) => !!column.id && column.getCanSort() && (column.columnDef as ColumnDef<T>).showInSortDialog !== false),
+    [table]
+  );
+  const hasSortDialog = enableSortDialog && sortableColumns.length > 0;
+  const sorting = table.getState().sorting;
+  const activeSort = sorting[0];
+  const columnSortLabel = (column: (typeof sortableColumns)[number]): string => {
+    const def = column.columnDef as ColumnDef<T>;
+    return def.sortDialogLabel ?? (typeof def.header === 'string' ? def.header : (column.id ?? ''));
+  };
 
   React.useEffect(() => {
     if (onSelectionChange) {
@@ -852,6 +878,73 @@ const TableSimple = <T extends RowData>({
                       Réinitialiser tout
                     </Button>
                     <Button priority="primary" size="small" iconId="ri-check-line" onClick={() => setFiltersDialogOpen(false)}>
+                      Fermer
+                    </Button>
+                  </div>
+                </div>
+              </Dialog>
+            )}
+            {hasSortDialog && (
+              <Dialog
+                title="Trier"
+                size="md"
+                open={isSortDialogOpen}
+                onOpenChange={setSortDialogOpen}
+                trigger={
+                  <Button size="small" priority={activeSort ? 'secondary' : 'tertiary'} iconId="fr-icon-sort-desc">
+                    {sorting.length > 0 ? `Trier (${sorting.length})` : 'Trier'}
+                  </Button>
+                }
+              >
+                <div className="flex flex-col gap-2">
+                  <p className="fr-hint-text mb-1">
+                    Cliquez sur ↑ / ↓ pour trier. Ajoutez plusieurs colonnes pour un tri combiné : le numéro indique l'ordre de priorité.
+                    Astuce : Maj + clic sur un en-tête du tableau ajoute aussi un critère.
+                  </p>
+                  {sortableColumns.map((column) => {
+                    const sorted = column.getIsSorted();
+                    const priority = sorting.findIndex((entry) => entry.id === column.id);
+                    const label = columnSortLabel(column);
+                    // Multi-tri : on ajoute/met à jour ce critère (2e arg = multi), et un clic sur le sens déjà actif le retire.
+                    const applySort = (desc: boolean) =>
+                      (desc ? sorted === 'desc' : sorted === 'asc') ? column.clearSorting() : column.toggleSorting(desc, true);
+                    return (
+                      <section
+                        key={column.id}
+                        className="flex items-center justify-between gap-3 rounded-lg border border-gray-200 p-2 px-3"
+                      >
+                        <span className={cx('flex items-center gap-2 leading-tight', sorted && 'font-semibold')}>
+                          {priority >= 0 && (
+                            <span className="inline-flex size-5 items-center justify-center rounded-full bg-(--background-action-high-blue-france) text-xs text-white">
+                              {priority + 1}
+                            </span>
+                          )}
+                          {label}
+                        </span>
+                        <div className="flex items-center gap-1">
+                          <Button
+                            size="small"
+                            priority={sorted === 'asc' ? 'primary' : 'tertiary'}
+                            iconId="fr-icon-sort-asc"
+                            title={`${label} croissant`}
+                            onClick={() => applySort(false)}
+                          />
+                          <Button
+                            size="small"
+                            priority={sorted === 'desc' ? 'primary' : 'tertiary'}
+                            iconId="fr-icon-sort-desc"
+                            title={`${label} décroissant`}
+                            onClick={() => applySort(true)}
+                          />
+                        </div>
+                      </section>
+                    );
+                  })}
+                  <div className="flex flex-wrap justify-between gap-2 pt-2">
+                    <Button priority="tertiary" iconId="ri-refresh-line" size="small" onClick={() => table.resetSorting()}>
+                      Réinitialiser
+                    </Button>
+                    <Button priority="primary" iconId="ri-check-line" size="small" onClick={() => setSortDialogOpen(false)}>
                       Fermer
                     </Button>
                   </div>

--- a/src/modules/conversion-tracking/AGENTS.md
+++ b/src/modules/conversion-tracking/AGENTS.md
@@ -15,9 +15,10 @@ conversion-tracking/
 │   │                               # isTrackablePage() (guard /admin), getDemandOrigin() (demands.origin_*)
 │   ├── useRecordConversionEvent.ts # hook d'émission fire-and-forget — point d'entrée unique des call sites
 │   ├── useTrackPageView.ts         # beacon `display` au montage, bâti sur useRecordConversionEvent
-│   └── ConversionStatsPage.tsx     # écran admin « conversion par source » (/admin/conversion)
+│   ├── ConversionStatsPage.tsx     # écran admin « conversion par source » (/admin/conversion) + lien anti-abus
+│   └── ConversionAbusePage.tsx     # écran admin « Contrôle des abus » (/admin/conversion/abus)
 └── server/
-    ├── service.ts        # logique métier (insert event, CRUD sources, agrégat stats, purge IP)
+    ├── service.ts        # logique métier (insert event, CRUD sources, agrégat stats, purge IP, anti-abus IP)
     └── trpc-routes.ts    # routeur `conversionTracking`
 ```
 
@@ -50,23 +51,38 @@ conversion-tracking/
   `useContactFormFCU`, plus `ComparateurPublicodes` et `EligibilityTestBox` en direct. La preview admin est
   exclue par le guard `/admin` (`isTrackablePage`, dans le hook).
 - **Admin** : générateur persistant `/admin/iframes` (CRUD du registre + config, iframes carte **et** form,
-  `?source=` dans le code) et écran `/admin/conversion` (`getStats` ; filtre `?source=` en URL via nuqs —
-  la colonne Source de `/admin/demandes` pointe dessus). CRUD = procédures tRPC explicites.
+  `?source=` dans le code), écran `/admin/conversion` (`getStats` ; filtre `?source=` en URL via nuqs — la
+  colonne Source de `/admin/demandes` pointe dessus) et écran anti-abus `/admin/conversion/abus` (détection +
+  règles IP ; deep-link `?source=` depuis la page stats pour isoler les IP d'une source). CRUD = procédures
+  tRPC explicites.
 - **Lignes à zéro** (`period: null`) : intégrations actives du registre sans event sur la période, et routes
   internes vues sur les 12 derniers mois mais muettes (détection d'intégration non déployée / tracking cassé).
 - **`unregistered`** : symétrique des lignes à zéro — une `source` reçue mais **absente du registre**
   (id erroné, intégration non enregistrée). Posé par `getStats`, signalé par un badge dans `/admin/conversion`.
 - **Ne fait pas** : pas de tracking client tiers (PostHog/Matomo restent dans `analytics` ; le
   `ContactFormContext` de `useContactFormFCU` ne sert plus qu'à eux).
-- `ip` / `user_agent` = **anti-abus uniquement**, purgés (~90 j) par cron, jamais en UI. `host` = analytics
-  **retenu**. Base légale : intérêt légitime.
+- `ip` / `user_agent` = **anti-abus uniquement**, purgés (~90 j) par cron. `host` = analytics **retenu**. Base
+  légale : intérêt légitime. Les IP ne sont exposées **que** dans l'écran anti-abus admin (`/admin/conversion/abus`),
+  avec un lien d'investigation externe (ipinfo.io — le serveur n'appelle aucun tiers ; l'admin ouvre).
+- **Anti-abus IP** (spam d'`address_test` gonflant tests / taux) : règles `conversion_ip_rules` (IP ou plage
+  CIDR, IPv4/IPv6 ; `disposition` = `exclude` bannir | `keep` IP légitime connue, `reason` obligatoire) +
+  colonne matérialisée `conversion_events.excluded`. La règle la **plus spécifique** (`masklen` max) l'emporte
+  (un `keep` /32 gagne sur un `exclude` /24). Toute modif de règle **réconcilie** `excluded` sur la plage
+  (`reconcileExcludedForRange` : nettoie les stats **et** fige l'exclusion avant la purge des IP) ; `recordEvent`
+  repose le flag à l'insert (règle « collante »), `getStats` ne lit que `excluded = false`. Matching par `<<=`
+  (inclusion inet, cross-famille v4/v6 = `false`). Détection : `getSuspiciousIps` (ratio tests/affichages,
+  routes, jours ; filtrable `source`/`route`/`host` pour remonter les IP d'une source pourrie).
 
 ## Routes tRPC (`conversionTracking`)
 
 | Procédure | Type | Auth | Description |
 |---|---|---|---|
 | `recordEvent` | mutation | public (rate-limité 60/min) | Enregistre un event (`source?`, `route`, `page`, `host?`, `eligible?`). IP/UA ajoutés serveur ; **bots ignorés** (`isbot` sur l'UA, drop silencieux — fiabilise les affichages). |
-| `getStats` | query | admin | Funnel niveau 1 (`source ?? route`) × période (+ drills `groupByPage`/`groupByHost`, filtres `source`/`channel`). Lignes à zéro incluses. |
+| `getStats` | query | admin | Funnel niveau 1 (`source ?? route`) × période (+ drills `groupByPage`/`groupByHost`, filtres `source`/`channel`). Lignes à zéro incluses. **Exclut `excluded = true`.** |
+| `getSuspiciousIps` | query | admin | IP suspectes de la période (≥ `minTests` tests), triées par volume, avec signaux d'abus + règle courante. Filtres `source`/`route`/`host` (`minTests: 0` → toutes les IP du périmètre). |
+| `ipRules.list` | query | admin | Règles IP/CIDR (`exclude`/`keep`) + motif + e-mail de l'admin auteur. |
+| `ipRules.upsert` | mutation | admin | Crée/met à jour une règle (`ip`, `disposition`, `reason`) puis réconcilie `excluded` sur la plage. |
+| `ipRules.remove` | mutation | admin | Supprime la règle d'une IP/CIDR puis réconcilie `excluded` (events non couverts par une autre règle). |
 | `sources.list` | query | admin | Registre des intégrations (option `includeArchived`). |
 | `sources.create` | mutation | admin | Crée une intégration (label, `config`) ; l'`id` uuid généré sert de `source=`. |
 | `sources.update` | mutation | admin | Met à jour label / config. |
@@ -80,9 +96,12 @@ Chaque mutation `sources.*` émet un event d'audit `conversion_source_created` /
 - `conversion_sources` : `id` uuid (= `source=`), `label`, `config` jsonb (snapshot params iframe),
   `archived_at`. Aucun seed.
 - `conversion_events` : `source` (nullable), `route` + `page` (NOT NULL), `host`, `type`
-  (`display`/`address_test`/`demand`), `eligible`, `ip`, `user_agent`, `created_at`.
+  (`display`/`address_test`/`demand`), `eligible`, `ip`, `user_agent`, `excluded` (anti-abus, NOT NULL
+  DEFAULT false), `created_at`.
   Index B-tree `(created_at)` (toutes les lectures filtrent par plage de dates ; pas de BRIN car la
   purge UPDATE chaque ligne à ~90 j) + partiel `(created_at) WHERE ip IS NOT NULL` pour la purge.
+- `conversion_ip_rules` : `ip` inet (PK, IPv4/IPv6, CIDR accepté), `disposition` (`exclude`/`keep`, CHECK),
+  `reason` (NOT NULL), `created_by` (→ `users`, `ON DELETE SET NULL`), `created_at`. Aucun seed.
 - `demands.origin_source` / `origin_page` / `origin_host` — colonnes **bonus** (hors module, écrites par
   `createDemand`). `origin_host` = page embarquante, décisive pour attribuer une demande iframe au partenaire.
 

--- a/src/modules/conversion-tracking/client/ConversionAbusePage.tsx
+++ b/src/modules/conversion-tracking/client/ConversionAbusePage.tsx
@@ -1,0 +1,438 @@
+import Badge from '@codegouvfr/react-dsfr/Badge';
+import { keepPreviousData } from '@tanstack/react-query';
+import { parseAsInteger, parseAsString, useQueryStates } from 'nuqs';
+import { useMemo, useState } from 'react';
+
+import Input from '@/components/form/dsfr/Input';
+import Select from '@/components/form/dsfr/Select';
+import SimplePage from '@/components/shared/page/SimplePage';
+import Button from '@/components/ui/Button';
+import ConfirmDialog from '@/components/ui/ConfirmDialog';
+import Heading from '@/components/ui/Heading';
+import Link from '@/components/ui/Link';
+import TableSimple, { type ColumnDef } from '@/components/ui/table/TableSimple';
+import { useDialogState } from '@/hooks/useDialogState';
+import { CONVERSION_IP_RETENTION_DAYS, type ConversionIpDisposition } from '@/modules/conversion-tracking/constants';
+import { notify } from '@/modules/notification';
+import trpc, { type RouterOutput } from '@/modules/trpc/client';
+import { formatAsISODate, formatFrenchDate } from '@/utils/date';
+
+type SuspiciousRow = RouterOutput['conversionTracking']['getSuspiciousIps'][number];
+type RuleRow = RouterOutput['conversionTracking']['ipRules']['list'][number];
+
+const today = new Date();
+const defaultTo = formatAsISODate(today);
+const defaultFrom = formatAsISODate(new Date(today.getTime() - CONVERSION_IP_RETENTION_DAYS * 24 * 3600 * 1000));
+
+const ratio = (value: number | null) => (value === null ? '—' : `${value.toFixed(1)}×`);
+/** Retire le préfixe hôte (`/32`, `/128`) pour les liens d'investigation d'un hôte unique. */
+const bareHost = (ip: string) => ip.replace(/\/(?:32|128)$/, '');
+
+const dispositionBadge: Record<ConversionIpDisposition, { label: string; severity: 'error' | 'info' }> = {
+  exclude: { label: 'exclue', severity: 'error' },
+  keep: { label: 'conservée', severity: 'info' },
+};
+
+/** Bouton-icône (globe) vers ipinfo.io (pays, ASN / hébergeur) — ouvre un onglet, à côté de l'IP. */
+const IpLink = ({ ip }: { ip: string }) => (
+  <Button
+    priority="tertiary no outline"
+    size="small"
+    iconId="fr-icon-earth-line"
+    title={`Voir ${ip} sur ipinfo.io`}
+    href={`https://ipinfo.io/${bareHost(ip)}`}
+  />
+);
+
+const filtersParsers = {
+  dateFrom: parseAsString.withDefault(defaultFrom),
+  dateTo: parseAsString.withDefault(defaultTo),
+  host: parseAsString,
+  minTests: parseAsInteger.withDefault(50),
+  route: parseAsString,
+  source: parseAsString,
+};
+
+const ConversionAbusePage = () => {
+  const utils = trpc.useUtils();
+  const [{ dateFrom, dateTo, host, minTests, route, source }, setFilters] = useQueryStates(filtersParsers);
+
+  const ruleDialog = useDialogState<{ ip: string; disposition: ConversionIpDisposition }>();
+  const removeDialog = useDialogState<{ ip: string }>();
+  const [reason, setReason] = useState('');
+
+  const scopeActive = Boolean(source || route || host);
+  const { data: rows = [], isLoading } = trpc.conversionTracking.getSuspiciousIps.useQuery(
+    {
+      dateFrom: new Date(dateFrom),
+      dateTo: new Date(`${dateTo}T23:59:59`),
+      host: host || undefined,
+      limit: 200,
+      // Source/route/host ciblés → toutes les IP (même faible volume) pour identifier l'origine.
+      minTests: scopeActive ? 0 : minTests,
+      route: route || undefined,
+      source: source || undefined,
+    },
+    { placeholderData: keepPreviousData }
+  );
+  const { data: rules = [], isLoading: loadingRules } = trpc.conversionTracking.ipRules.list.useQuery();
+  const { data: integrations = [] } = trpc.conversionTracking.sources.list.useQuery({ includeArchived: true });
+
+  const sourceOptions = useMemo(() => {
+    const options = [
+      { label: 'Toutes les sources', value: '' },
+      ...integrations.map((integration) => ({
+        label: integration.archived_at ? `${integration.label} (archivée)` : integration.label,
+        value: integration.id,
+      })),
+    ];
+    if (source && !integrations.some((integration) => integration.id === source)) {
+      options.push({ label: `${source} (hors registre)`, value: source });
+    }
+    return options;
+  }, [integrations, source]);
+
+  const invalidate = () => {
+    void utils.conversionTracking.getSuspiciousIps.invalidate();
+    void utils.conversionTracking.ipRules.list.invalidate();
+    void utils.conversionTracking.getStats.invalidate();
+  };
+  const upsertMutation = trpc.conversionTracking.ipRules.upsert.useMutation({ onSuccess: invalidate });
+  const removeMutation = trpc.conversionTracking.ipRules.remove.useMutation({ onSuccess: invalidate });
+
+  const openRule = (ip: string, disposition: ConversionIpDisposition) => {
+    setReason('');
+    ruleDialog.open({ disposition, ip });
+  };
+  // ConfirmDialog ne ferme que sur succès ; les erreurs tRPC sont notifiées globalement (errorHandlerLink).
+  const confirmRule = async () => {
+    const data = ruleDialog.data;
+    if (!data) return;
+    const result = await upsertMutation.mutateAsync({ ...data, reason: reason.trim() });
+    notify('success', `Règle « ${result.disposition} » enregistrée pour ${result.ip} — ${result.changedEvents} événement(s) recomptés.`);
+  };
+  const confirmRemove = async () => {
+    const target = removeDialog.data;
+    if (!target) return;
+    const result = await removeMutation.mutateAsync({ ip: target.ip });
+    notify('success', `Règle retirée pour ${result.ip} — ${result.changedEvents} événement(s) recomptés.`);
+  };
+
+  const suspiciousColumns: ColumnDef<SuspiciousRow>[] = useMemo(
+    () => [
+      {
+        accessorFn: (row) => row.ip,
+        cell: ({ row }) => (
+          <span className="flex items-center gap-1">
+            <span className="font-mono whitespace-nowrap">{row.original.ip}</span>
+            <IpLink ip={row.original.ip} />
+          </span>
+        ),
+        flex: 2,
+        header: 'IP',
+        id: 'ip',
+      },
+      {
+        accessorFn: (row) => row.tests,
+        align: 'right',
+        cell: ({ row }) => <span className="font-bold">{row.original.tests}</span>,
+        header: 'Tests',
+        id: 'tests',
+        width: '80px',
+      },
+      {
+        accessorFn: (row) => row.testPerDisplay ?? undefined,
+        align: 'right',
+        cell: ({ row }) => ratio(row.original.testPerDisplay),
+        header: 'Test/Aff.',
+        id: 'ratio',
+        sortUndefined: 'last',
+        width: '86px',
+      },
+      { accessorFn: (row) => row.distinctRoutes, align: 'right', header: 'Routes', id: 'routes', width: '68px' },
+      { accessorFn: (row) => row.distinctDays, align: 'right', header: 'Jours', id: 'days', width: '58px' },
+      { accessorFn: (row) => row.demands, align: 'right', header: 'Demandes', id: 'demands', width: '92px' },
+      {
+        accessorFn: (row) => row.lastSeen,
+        cell: ({ row }) => {
+          const first = formatFrenchDate(new Date(row.original.firstSeen));
+          const last = formatFrenchDate(new Date(row.original.lastSeen));
+          return <span className="whitespace-nowrap text-(--text-mention-grey)">{first === last ? first : `${first} → ${last}`}</span>;
+        },
+        header: 'Vue',
+        id: 'seen',
+        width: '200px',
+      },
+      {
+        accessorFn: (row) => row.ruleDisposition ?? '',
+        cell: ({ row }) => {
+          const { ruleDisposition, ruleReason } = row.original;
+          if (!ruleDisposition) return <span className="text-(--text-mention-grey)">—</span>;
+          const badge = dispositionBadge[ruleDisposition];
+          return (
+            <span title={ruleReason ?? undefined}>
+              <Badge severity={badge.severity} small noIcon>
+                {badge.label}
+              </Badge>
+            </span>
+          );
+        },
+        header: 'Statut',
+        id: 'status',
+        width: '92px',
+      },
+      {
+        cell: ({ row }) => {
+          const { ip, ruleDisposition } = row.original;
+          return (
+            <div className="flex flex-wrap gap-1">
+              {ruleDisposition !== 'exclude' && (
+                <Button
+                  size="small"
+                  priority="secondary"
+                  variant="destructive"
+                  iconId="fr-icon-close-circle-line"
+                  onClick={() => openRule(ip, 'exclude')}
+                >
+                  Bannir
+                </Button>
+              )}
+              {ruleDisposition !== 'keep' && (
+                <Button
+                  size="small"
+                  priority="secondary"
+                  variant="success"
+                  iconId="fr-icon-checkbox-circle-line"
+                  onClick={() => openRule(ip, 'keep')}
+                >
+                  Conserver
+                </Button>
+              )}
+              {ruleDisposition && (
+                <Button size="small" priority="tertiary" iconId="fr-icon-delete-line" onClick={() => removeDialog.open({ ip })}>
+                  Retirer
+                </Button>
+              )}
+            </div>
+          );
+        },
+        enableSorting: false,
+        header: 'Actions',
+        id: 'actions',
+        width: '230px',
+      },
+    ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
+  const ruleColumns: ColumnDef<RuleRow>[] = useMemo(
+    () => [
+      {
+        accessorFn: (row) => row.ip,
+        cell: ({ row }) => (
+          <span className="flex items-center gap-1">
+            <span className="font-mono whitespace-nowrap">{row.original.ip}</span>
+            <IpLink ip={row.original.ip} />
+          </span>
+        ),
+        flex: 1,
+        header: 'IP / plage',
+        id: 'ip',
+      },
+      {
+        accessorFn: (row) => row.disposition,
+        cell: ({ row }) => {
+          const badge = dispositionBadge[row.original.disposition];
+          return (
+            <Badge severity={badge.severity} small noIcon>
+              {badge.label}
+            </Badge>
+          );
+        },
+        header: 'Disposition',
+        id: 'disposition',
+        width: '120px',
+      },
+      {
+        accessorFn: (row) => row.reason,
+        cell: ({ row }) => <span className="break-all">{row.original.reason}</span>,
+        flex: 2,
+        header: 'Motif',
+        id: 'reason',
+      },
+      {
+        accessorFn: (row) => row.created_at,
+        cell: ({ row }) => (
+          <span className="whitespace-nowrap text-(--text-mention-grey)">{formatFrenchDate(new Date(row.original.created_at))}</span>
+        ),
+        header: 'Ajoutée le',
+        id: 'created_at',
+        width: '130px',
+      },
+      {
+        accessorFn: (row) => row.createdByEmail ?? undefined,
+        cell: ({ row }) => <span className="break-all text-(--text-mention-grey)">{row.original.createdByEmail ?? '—'}</span>,
+        flex: 1,
+        header: 'Par',
+        id: 'createdByEmail',
+        sortUndefined: 'last',
+      },
+      {
+        cell: ({ row }) => (
+          <Button size="small" priority="tertiary" iconId="fr-icon-delete-line" onClick={() => removeDialog.open({ ip: row.original.ip })}>
+            Retirer
+          </Button>
+        ),
+        enableSorting: false,
+        header: 'Actions',
+        id: 'actions',
+        width: '110px',
+      },
+    ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
+  const dialogData = ruleDialog.data;
+  const isExclude = dialogData?.disposition === 'exclude';
+
+  return (
+    <SimplePage
+      title="Contrôle des abus"
+      description="Détection et bannissement des IP polluant les stats de conversion"
+      mode="authenticated"
+      layout="center"
+      className="flex flex-col gap-8"
+    >
+      <div className="flex flex-col gap-1">
+        <Heading as="h1" color="blue-france" className="mb-0">
+          Contrôle des abus
+        </Heading>
+        <Link href="/admin/conversion" className="fr-link self-start">
+          ← Conversion par source
+        </Link>
+      </div>
+
+      <p className="fr-hint-text mb-0">
+        Les IP sont conservées {CONVERSION_IP_RETENTION_DAYS} jours (purge RGPD) : la détection et le bannissement ne portent que sur cette
+        fenêtre ; au-delà, les statistiques sont figées et ne peuvent plus être corrigées.
+      </p>
+
+      <div className="flex flex-wrap items-end gap-4">
+        <Input
+          label="Du"
+          className="mb-0"
+          nativeInputProps={{ onChange: (event) => setFilters({ dateFrom: event.target.value }), type: 'date', value: dateFrom }}
+        />
+        <Input
+          label="Au"
+          className="mb-0"
+          nativeInputProps={{ onChange: (event) => setFilters({ dateTo: event.target.value }), type: 'date', value: dateTo }}
+        />
+        <Select
+          label="Source"
+          className="mb-0"
+          nativeSelectProps={{ onChange: (event) => setFilters({ source: event.target.value || null }), value: source ?? '' }}
+          options={sourceOptions}
+        />
+        <Input
+          label="Route"
+          className="mb-0"
+          nativeInputProps={{
+            onChange: (event) => setFilters({ route: event.target.value || null }),
+            placeholder: '/villes/[ville]',
+            value: route ?? '',
+          }}
+        />
+        <Input
+          label="Site hôte"
+          className="mb-0"
+          nativeInputProps={{
+            onChange: (event) => setFilters({ host: event.target.value || null }),
+            placeholder: 'exemple.fr',
+            value: host ?? '',
+          }}
+        />
+        <Input
+          label="Tests min."
+          className="mb-0"
+          disabled={scopeActive}
+          hintText={scopeActive ? 'Toutes les IP (source ciblée)' : undefined}
+          nativeInputProps={{
+            min: 0,
+            onChange: (event) => setFilters({ minTests: Number(event.target.value) || 0 }),
+            type: 'number',
+            value: scopeActive ? 0 : minTests,
+          }}
+        />
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <Heading as="h2" color="blue-france" className="mb-0">
+          IP suspectes
+        </Heading>
+        <p className="fr-hint-text mb-0">
+          Un ratio Test/Affichage élevé, une seule route et 0 demande signalent un robot. « Bannir » retire des statistiques les événements
+          de l'IP des {CONVERSION_IP_RETENTION_DAYS} derniers jours ; « Conserver » marque une IP légitime connue (elle ne sera plus
+          proposée au bannissement). Le globe ouvre le détail de l'IP (pays, hébergeur/ASN) sur ipinfo.io.
+        </p>
+        <TableSimple
+          columns={suspiciousColumns}
+          data={rows}
+          rowIdKey="ip"
+          controlsLayout="block"
+          loading={isLoading}
+          loadingEmptyMessage="Aucune IP suspecte sur ces critères."
+          padding="sm"
+        />
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <Heading as="h2" className="mb-0">
+          Règles ({rules.length})
+        </Heading>
+        <TableSimple
+          columns={ruleColumns}
+          data={rules}
+          rowIdKey="ip"
+          controlsLayout="block"
+          loading={loadingRules}
+          loadingEmptyMessage="Aucune règle définie."
+          padding="sm"
+        />
+      </div>
+
+      <ConfirmDialog
+        control={ruleDialog}
+        size="md"
+        title={isExclude ? `Bannir ${dialogData?.ip}` : `Conserver ${dialogData?.ip}`}
+        confirmLabel={isExclude ? 'Bannir' : 'Conserver'}
+        confirmIconId={isExclude ? 'fr-icon-close-circle-line' : 'fr-icon-checkbox-circle-line'}
+        danger={isExclude}
+        confirmDisabled={!reason.trim()}
+        onConfirm={confirmRule}
+      >
+        <Input
+          label="Motif"
+          nativeInputProps={{ autoFocus: true, onChange: (event) => setReason(event.target.value), required: true, value: reason }}
+        />
+      </ConfirmDialog>
+
+      <ConfirmDialog
+        control={removeDialog}
+        size="md"
+        title={`Retirer la règle sur ${removeDialog.data?.ip}`}
+        confirmLabel="Retirer"
+        onConfirm={confirmRemove}
+      >
+        <p className="mb-0">
+          Les événements de cette IP redeviendront comptés dans les statistiques, sauf s'ils restent couverts par une autre règle « exclude
+          ».
+        </p>
+      </ConfirmDialog>
+    </SimplePage>
+  );
+};
+
+export default ConversionAbusePage;

--- a/src/modules/conversion-tracking/client/ConversionStatsPage.tsx
+++ b/src/modules/conversion-tracking/client/ConversionStatsPage.tsx
@@ -8,6 +8,7 @@ import Input from '@/components/form/dsfr/Input';
 import Select from '@/components/form/dsfr/Select';
 import SimplePage from '@/components/shared/page/SimplePage';
 import Heading from '@/components/ui/Heading';
+import Link from '@/components/ui/Link';
 import TableSimple, { type ColumnDef } from '@/components/ui/table/TableSimple';
 import {
   type ConversionChannel,
@@ -28,6 +29,15 @@ const pctExport = (value: number | null) => (value === null ? '' : `${Math.round
 const channelLabel: Record<ConversionChannel, string> = { iframe: 'Iframe', internal: 'Interne' };
 
 type StatRow = RouterOutput['conversionTracking']['getStats'][number];
+
+/** Lien vers l'écran anti-abus filtré sur le canal de la ligne (source d'intégration, sinon route interne). */
+const abusePageHref = (row: StatRow) => {
+  const params = new URLSearchParams();
+  if (row.source) params.set('source', row.source);
+  else if (row.route) params.set('route', row.route);
+  if (row.host) params.set('host', row.host);
+  return `/admin/conversion/abus?${params.toString()}`;
+};
 
 const filtersParsers = {
   channel: parseAsStringLiteral(conversionChannels),
@@ -168,7 +178,14 @@ const ConversionStatsPage = () => {
       {
         accessorFn: (row) => row.distinctIp,
         align: 'right',
-        cell: ({ row }) => <span className="text-(--text-mention-grey)">{row.original.distinctIp}</span>,
+        cell: ({ row }) =>
+          row.original.distinctIp > 0 ? (
+            <Link href={abusePageHref(row.original)} className="fr-link fr-link--sm" title="Voir les IP de ce canal (contrôle des abus)">
+              {row.original.distinctIp}
+            </Link>
+          ) : (
+            <span className="text-(--text-mention-grey)">0</span>
+          ),
         header: 'IP uniques',
         id: 'distinctIp',
         width: '100px',
@@ -198,91 +215,100 @@ const ConversionStatsPage = () => {
   );
 
   return (
-    <SimplePage title="Conversion par source" description="Funnel affichages → tests → demandes, toutes sources" mode="authenticated">
-      <div className="fr-container fr-py-4w flex flex-col gap-6">
+    <SimplePage
+      title="Conversion par source"
+      description="Funnel affichages → tests → demandes, toutes sources"
+      mode="authenticated"
+      layout="center"
+      className="flex flex-col gap-6"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <Heading as="h1" color="blue-france" className="mb-0">
           Conversion par source
         </Heading>
+        <Link href="/admin/conversion/abus" className="fr-link fr-link--icon-right fr-icon-arrow-right-line">
+          Contrôle des abus
+        </Link>
+      </div>
 
-        <div className="flex flex-wrap items-end gap-4">
-          <Input
-            label="Du"
-            className="mb-0"
-            nativeInputProps={{ onChange: (event) => setFilters({ dateFrom: event.target.value }), type: 'date', value: dateFrom }}
-          />
-          <Input
-            label="Au"
-            className="mb-0"
-            nativeInputProps={{ onChange: (event) => setFilters({ dateTo: event.target.value }), type: 'date', value: dateTo }}
-          />
-          <Select
-            label="Granularité"
-            className="mb-0"
-            nativeSelectProps={{
-              onChange: (event) => setFilters({ granularity: event.target.value as ConversionStatsGranularity }),
-              value: granularity,
-            }}
-            options={[
-              { label: 'Mensuel', value: 'month' },
-              { label: 'Journalier', value: 'day' },
-            ]}
-          />
-          <Select
-            label="Canal"
-            className="mb-0"
-            nativeSelectProps={{
-              onChange: (event) => setFilters({ channel: (event.target.value || null) as ConversionChannel | null }),
-              value: channel ?? '',
-            }}
-            options={[
-              { label: 'Toutes', value: '' },
-              { label: 'Pages internes', value: 'internal' },
-              { label: 'Iframes', value: 'iframe' },
-            ]}
-          />
-          <Select
-            label="Source"
-            className="mb-0"
-            nativeSelectProps={{ onChange: (event) => setFilters({ source: event.target.value || null }), value: source ?? '' }}
-            options={sourceOptions}
-          />
-          <Checkbox
-            label="Détailler par page FCU"
-            nativeInputProps={{
-              checked: groupByPage,
-              name: 'groupByPage',
-              onChange: (event) => setFilters({ groupByPage: event.target.checked }),
-            }}
-          />
-          <Checkbox
-            label="Détailler par site hôte"
-            nativeInputProps={{
-              checked: groupByHost,
-              name: 'groupByHost',
-              onChange: (event) => setFilters({ groupByHost: event.target.checked }),
-            }}
-          />
-          <Checkbox
-            label="Afficher la date de création"
-            nativeInputProps={{
-              checked: showCreatedAt,
-              name: 'showCreatedAt',
-              onChange: (event) => setFilters({ showCreatedAt: event.target.checked }),
-            }}
-          />
-        </div>
-
-        <TableSimple
-          columns={columns}
-          data={rows}
-          controlsLayout="block"
-          loading={isLoading}
-          loadingEmptyMessage="Aucune donnée sur cette période."
-          padding="sm"
-          export={{ fileName: `conversion_${dateFrom}_${dateTo}.xlsx`, sheetName: 'Conversion' }}
-          urlSyncKey="conversion"
+      <div className="flex flex-wrap items-end gap-4">
+        <Input
+          label="Du"
+          className="mb-0"
+          nativeInputProps={{ onChange: (event) => setFilters({ dateFrom: event.target.value }), type: 'date', value: dateFrom }}
+        />
+        <Input
+          label="Au"
+          className="mb-0"
+          nativeInputProps={{ onChange: (event) => setFilters({ dateTo: event.target.value }), type: 'date', value: dateTo }}
+        />
+        <Select
+          label="Granularité"
+          className="mb-0"
+          nativeSelectProps={{
+            onChange: (event) => setFilters({ granularity: event.target.value as ConversionStatsGranularity }),
+            value: granularity,
+          }}
+          options={[
+            { label: 'Mensuel', value: 'month' },
+            { label: 'Journalier', value: 'day' },
+          ]}
+        />
+        <Select
+          label="Canal"
+          className="mb-0"
+          nativeSelectProps={{
+            onChange: (event) => setFilters({ channel: (event.target.value || null) as ConversionChannel | null }),
+            value: channel ?? '',
+          }}
+          options={[
+            { label: 'Toutes', value: '' },
+            { label: 'Pages internes', value: 'internal' },
+            { label: 'Iframes', value: 'iframe' },
+          ]}
+        />
+        <Select
+          label="Source"
+          className="mb-0"
+          nativeSelectProps={{ onChange: (event) => setFilters({ source: event.target.value || null }), value: source ?? '' }}
+          options={sourceOptions}
+        />
+        <Checkbox
+          label="Détailler par page FCU"
+          nativeInputProps={{
+            checked: groupByPage,
+            name: 'groupByPage',
+            onChange: (event) => setFilters({ groupByPage: event.target.checked }),
+          }}
+        />
+        <Checkbox
+          label="Détailler par site hôte"
+          nativeInputProps={{
+            checked: groupByHost,
+            name: 'groupByHost',
+            onChange: (event) => setFilters({ groupByHost: event.target.checked }),
+          }}
+        />
+        <Checkbox
+          label="Afficher la date de création"
+          nativeInputProps={{
+            checked: showCreatedAt,
+            name: 'showCreatedAt',
+            onChange: (event) => setFilters({ showCreatedAt: event.target.checked }),
+          }}
         />
       </div>
+
+      <TableSimple
+        columns={columns}
+        data={rows}
+        controlsLayout="block"
+        loading={isLoading}
+        loadingEmptyMessage="Aucune donnée sur cette période."
+        padding="sm"
+        export={{ fileName: `conversion_${dateFrom}_${dateTo}.xlsx`, sheetName: 'Conversion' }}
+        urlSyncKey="conversion"
+      />
     </SimplePage>
   );
 };

--- a/src/modules/conversion-tracking/client/ConversionStatsPage.tsx
+++ b/src/modules/conversion-tracking/client/ConversionStatsPage.tsx
@@ -17,15 +17,17 @@ import {
   conversionStatsGranularities,
 } from '@/modules/conversion-tracking/constants';
 import trpc, { type RouterOutput } from '@/modules/trpc/client';
-import { formatFrenchDate } from '@/utils/date';
+import cx from '@/utils/cx';
+import { formatAsISODate, formatFrenchDate } from '@/utils/date';
 
-const isoDay = (date: Date) => date.toISOString().slice(0, 10);
 const today = new Date();
-const defaultTo = isoDay(today);
-const defaultFrom = isoDay(new Date(today.getFullYear(), today.getMonth() - 11, 1));
+const defaultTo = formatAsISODate(today);
+const defaultFrom = formatAsISODate(new Date(today.getFullYear(), today.getMonth() - 11, 1));
 
-const pct = (value: number | null) => (value === null ? '—' : `${Math.round(value * 100)}%`);
-const pctExport = (value: number | null) => (value === null ? '' : `${Math.round(value * 100)}%`);
+/** Formate un taux de conversion (0–1) en pourcentage pour l'affichage ; `—` si non calculable. */
+const formatRate = (rate: number | null) => (rate === null ? '—' : `${Math.round(rate * 100)}%`);
+/** Idem `formatRate` mais vide (au lieu de `—`) pour l'export CSV. */
+const formatRateForExport = (rate: number | null) => (rate === null ? '' : `${Math.round(rate * 100)}%`);
 const channelLabel: Record<ConversionChannel, string> = { iframe: 'Iframe', internal: 'Interne' };
 
 type StatRow = RouterOutput['conversionTracking']['getStats'][number];
@@ -38,6 +40,40 @@ const abusePageHref = (row: StatRow) => {
   if (row.host) params.set('host', row.host);
   return `/admin/conversion/abus?${params.toString()}`;
 };
+
+/** Segment de flèche du funnel : barre horizontale avec le taux à l'intérieur `──{taux}──▶`. */
+const funnelArrow = (rate: number | null) => (
+  <span className="flex flex-col items-center px-1.5 leading-tight text-(--text-mention-grey)">
+    <span className="text-xs">
+      ──<span className="mx-0.5 inline-block w-[4.5ch] text-center tabular-nums">{formatRate(rate)}</span>──▶
+    </span>
+    {/* espaceur invisible : réserve la hauteur de la ligne « ✓ » pour aligner tous les segments */}
+    <span className="invisible text-xs">✓</span>
+  </span>
+);
+
+/** Étape du funnel : compteur + `(✓ nb éligibles)` en dessous (espaceur invisible si pas d'éligibles). */
+const funnelStage = (value: number, eligible: number | null) => (
+  <span className="flex w-14 flex-col items-center tabular-nums leading-tight">
+    <span>{value}</span>
+    <span className={cx('text-xs text-(--text-mention-grey)', (eligible === null || value === 0) && 'invisible')}>(✓ {eligible ?? 0})</span>
+  </span>
+);
+
+/** Cellule funnel : Affichages ─%▶ Tests (✓ élig.) ─%▶ Demandes (✓ élig.), centrée verticalement. */
+const funnelCell = (row: StatRow) => (
+  <div className="flex items-center whitespace-nowrap">
+    {funnelStage(row.displays, null)}
+    {funnelArrow(row.testRate)}
+    {funnelStage(row.tests, row.testsEligible)}
+    {funnelArrow(row.demandRate)}
+    {funnelStage(row.demands, row.demandsEligible)}
+  </div>
+);
+
+/** Représentation texte du funnel pour l'export. */
+const funnelExport = (row: StatRow) =>
+  `${row.displays} →${formatRateForExport(row.testRate)}→ ${row.tests} (${row.testsEligible} élig.) →${formatRateForExport(row.demandRate)}→ ${row.demands} (${row.demandsEligible} élig.)`;
 
 const filtersParsers = {
   channel: parseAsStringLiteral(conversionChannels),
@@ -94,52 +130,32 @@ const ConversionStatsPage = () => {
       },
       {
         accessorFn: (row) => row.label,
-        cell: ({ row }) => (
-          <span className="break-all">
-            {row.original.label}
-            {row.original.unregistered && (
-              <span title="Intégration reçue mais absente du registre des intégrations">
-                <Badge severity="warning" small noIcon className="fr-ml-1w">
-                  hors registre
-                </Badge>
+        // Contexte : label + drills (page / hôte / créée) fusionnés en sous-lignes plutôt qu'en colonnes séparées.
+        cell: ({ row }) => {
+          const r = row.original;
+          return (
+            <div className="flex flex-col gap-0.5 break-all">
+              <span>
+                {r.label}
+                {r.unregistered && (
+                  <span title="Intégration reçue mais absente du registre des intégrations">
+                    <Badge severity="warning" small noIcon className="fr-ml-1w">
+                      hors registre
+                    </Badge>
+                  </span>
+                )}
               </span>
-            )}
-          </span>
-        ),
+              {groupByPage && r.page && <span className="text-xs text-(--text-mention-grey)">Page : {r.page}</span>}
+              {groupByHost && r.host && <span className="text-xs text-(--text-mention-grey)">Hôte : {r.host}</span>}
+              {showCreatedAt && r.sourceCreatedAt && (
+                <span className="text-xs text-(--text-mention-grey)">Créée le {formatFrenchDate(new Date(r.sourceCreatedAt))}</span>
+              )}
+            </div>
+          );
+        },
         flex: 2,
         header: 'Intégration / route',
         id: 'label',
-      },
-      {
-        accessorFn: (row) => (row.sourceCreatedAt ? formatFrenchDate(new Date(row.sourceCreatedAt)) : undefined),
-        cell: ({ row }) => (
-          <span className="whitespace-nowrap text-(--text-mention-grey)">
-            {row.original.sourceCreatedAt ? formatFrenchDate(new Date(row.original.sourceCreatedAt)) : '—'}
-          </span>
-        ),
-        header: 'Créée le',
-        id: 'sourceCreatedAt',
-        sortUndefined: 'last',
-        visible: showCreatedAt,
-        width: '110px',
-      },
-      {
-        accessorFn: (row) => row.page ?? undefined,
-        cell: ({ row }) => <span className="break-all text-(--text-mention-grey)">{row.original.page ?? '—'}</span>,
-        flex: 2,
-        header: 'Page FCU',
-        id: 'page',
-        sortUndefined: 'last',
-        visible: groupByPage,
-      },
-      {
-        accessorFn: (row) => row.host ?? undefined,
-        cell: ({ row }) => <span className="break-all text-(--text-mention-grey)">{row.original.host ?? '—'}</span>,
-        flex: 2,
-        header: 'Site hôte',
-        id: 'host',
-        sortUndefined: 'last',
-        visible: groupByHost,
       },
       {
         accessorFn: (row) => row.period ?? undefined,
@@ -149,31 +165,14 @@ const ConversionStatsPage = () => {
         sortUndefined: 'last',
         width: '110px',
       },
-      { accessorFn: (row) => row.displays, align: 'right', header: 'Affichages', id: 'displays', width: '100px' },
-      { accessorFn: (row) => row.tests, align: 'right', header: 'Tests', id: 'tests', width: '80px' },
       {
-        accessorFn: (row) => row.testsEligible,
-        align: 'right',
-        exportHeader: 'Tests éligibles',
-        header: 'dont éligibles',
-        id: 'testsEligible',
-        width: '120px',
-      },
-      {
-        accessorFn: (row) => row.demands,
-        align: 'right',
-        cell: ({ row }) => <span className="font-bold">{row.original.demands}</span>,
-        header: 'Demandes',
-        id: 'demands',
-        width: '100px',
-      },
-      {
-        accessorFn: (row) => row.demandsEligible,
-        align: 'right',
-        exportHeader: 'Demandes éligibles',
-        header: 'dont éligibles',
-        id: 'demandsEligible',
-        width: '130px',
+        cell: ({ row }) => funnelCell(row.original),
+        enableSorting: false,
+        exportFn: (row) => funnelExport(row),
+        exportHeader: 'Funnel',
+        header: 'Affichages → Tests → Demandes',
+        id: 'funnel',
+        width: '380px',
       },
       {
         accessorFn: (row) => row.distinctIp,
@@ -190,25 +189,80 @@ const ConversionStatsPage = () => {
         id: 'distinctIp',
         width: '100px',
       },
+      // Colonnes masquées : compteurs/taux/drills du funnel, gardés comme colonnes pour rester triables
+      // génériquement (piste C : tri externe via le SortingState) et exportés à plat (exportOnly).
+      {
+        accessorFn: (row) => row.displays,
+        exportHeader: 'Affichages',
+        exportOnly: true,
+        header: 'Affichages',
+        id: 'displays',
+        visible: false,
+      },
+      { accessorFn: (row) => row.tests, exportHeader: 'Tests', exportOnly: true, header: 'Tests', id: 'tests', visible: false },
+      { accessorFn: (row) => row.demands, exportHeader: 'Demandes', exportOnly: true, header: 'Demandes', id: 'demands', visible: false },
+      {
+        accessorFn: (row) => row.testsEligible,
+        exportHeader: 'Tests éligibles',
+        exportOnly: true,
+        header: 'Tests éligibles',
+        id: 'testsEligible',
+        visible: false,
+      },
       {
         accessorFn: (row) => row.testRate ?? undefined,
-        align: 'right',
-        cell: ({ row }) => pct(row.original.testRate),
-        exportFn: (row) => pctExport(row.testRate),
+        exportFn: (row) => formatRateForExport(row.testRate),
+        exportHeader: 'Aff.→Test',
+        exportOnly: true,
         header: 'Aff.→Test',
         id: 'testRate',
         sortUndefined: 'last',
-        width: '100px',
+        visible: false,
+      },
+      {
+        accessorFn: (row) => row.demandsEligible,
+        exportHeader: 'Demandes éligibles',
+        exportOnly: true,
+        header: 'Demandes éligibles',
+        id: 'demandsEligible',
+        visible: false,
       },
       {
         accessorFn: (row) => row.demandRate ?? undefined,
-        align: 'right',
-        cell: ({ row }) => pct(row.original.demandRate),
-        exportFn: (row) => pctExport(row.demandRate),
+        exportFn: (row) => formatRateForExport(row.demandRate),
+        exportHeader: 'Test→Dem.',
+        exportOnly: true,
         header: 'Test→Dem.',
         id: 'demandRate',
         sortUndefined: 'last',
-        width: '100px',
+        visible: false,
+      },
+      {
+        accessorFn: (row) => row.page ?? undefined,
+        exportHeader: 'Page FCU',
+        exportOnly: groupByPage,
+        header: 'Page FCU',
+        id: 'page',
+        sortUndefined: 'last',
+        visible: false,
+      },
+      {
+        accessorFn: (row) => row.host ?? undefined,
+        exportHeader: 'Site hôte',
+        exportOnly: groupByHost,
+        header: 'Site hôte',
+        id: 'host',
+        sortUndefined: 'last',
+        visible: false,
+      },
+      {
+        accessorFn: (row) => (row.sourceCreatedAt ? formatFrenchDate(new Date(row.sourceCreatedAt)) : undefined),
+        exportHeader: 'Créée le',
+        exportOnly: showCreatedAt,
+        header: 'Créée le',
+        id: 'sourceCreatedAt',
+        sortUndefined: 'last',
+        visible: false,
       },
     ],
     [groupByPage, groupByHost, showCreatedAt]

--- a/src/modules/conversion-tracking/client/ConversionStatsPage.tsx
+++ b/src/modules/conversion-tracking/client/ConversionStatsPage.tsx
@@ -357,6 +357,7 @@ const ConversionStatsPage = () => {
         columns={columns}
         data={rows}
         controlsLayout="block"
+        enableSortDialog
         loading={isLoading}
         loadingEmptyMessage="Aucune donnée sur cette période."
         padding="sm"

--- a/src/modules/conversion-tracking/constants.ts
+++ b/src/modules/conversion-tracking/constants.ts
@@ -53,6 +53,41 @@ export const zListConversionSourcesInput = z
   })
   .default({ includeArchived: false });
 
+/** Rétention (jours) des données d'anti-abus (IP / user-agent) des `conversion_events` avant purge RGPD par cron. */
+export const CONVERSION_IP_RETENTION_DAYS = 90;
+
+/** Disposition d'une règle IP : retirée des stats (`exclude`) ou IP légitime connue à conserver (`keep`). */
+export const conversionIpDispositions = ['exclude', 'keep'] as const;
+export type ConversionIpDisposition = (typeof conversionIpDispositions)[number];
+
+/** Détection anti-abus : IP suspectes sur une période, filtrables par source / route / site hôte. */
+export const zGetSuspiciousIpsInput = z.object({
+  dateFrom: z.coerce.date(),
+  dateTo: z.coerce.date(),
+  /** Filtre : site embarquant (drill iframe). */
+  host: z.string().trim().min(1).max(2000).optional(),
+  /** Nombre max d'IP renvoyées (tri par tests décroissant). */
+  limit: z.number().int().min(1).max(500).default(50),
+  /** Seuil de tests (`address_test`) au-delà duquel une IP est listée. `0` (source ciblée) = toutes les IP. */
+  minTests: z.number().int().min(0).default(50),
+  /** Filtre : pattern de route Next (ex. `/villes/[ville]`). */
+  route: z.string().trim().min(1).max(2000).optional(),
+  /** Filtre : intégration iframe (`?source=`) — pour identifier les IP derrière une source pourrie. */
+  source: z.string().trim().min(1).max(100).optional(),
+});
+export type GetSuspiciousIpsInput = z.infer<typeof zGetSuspiciousIpsInput>;
+
+/** Crée / met à jour une règle sur une IP ou plage CIDR (IPv4/IPv6). Le format `inet` est validé côté serveur. */
+export const zUpsertIpRuleInput = z.object({
+  disposition: z.enum(conversionIpDispositions),
+  ip: z.string().trim().min(1).max(50),
+  reason: z.string().trim().min(1).max(500),
+});
+
+export const zRemoveIpRuleInput = z.object({
+  ip: z.string().trim().min(1).max(50),
+});
+
 export const zGetConversionStatsInput = z.object({
   /** Filtre iframe / pages internes (dérivé de l'event, pas du registre). */
   channel: z.enum(conversionChannels).optional(),

--- a/src/modules/conversion-tracking/server/service.ts
+++ b/src/modules/conversion-tracking/server/service.ts
@@ -1,6 +1,15 @@
-import { type ConversionEvents, type Insertable, kdb, sql } from '@/server/db/kysely';
+import { TRPCError } from '@trpc/server';
+import { type Expression, expressionBuilder, type SqlBool } from 'kysely';
 
-import type { ConversionChannel, ConversionSourceConfig, ConversionStatsGranularity } from '../constants';
+import { type ConversionEvents, type DB, type Insertable, kdb, sql } from '@/server/db/kysely';
+
+import {
+  CONVERSION_IP_RETENTION_DAYS,
+  type ConversionChannel,
+  type ConversionIpDisposition,
+  type ConversionSourceConfig,
+  type ConversionStatsGranularity,
+} from '../constants';
 
 /**
  * Service du module `conversion-tracking` — logique métier pure (aucune notion de HTTP/tRPC).
@@ -12,7 +21,15 @@ export type RecordConversionEventValues = Omit<Insertable<ConversionEvents>, 'id
 
 /** Enregistre un événement de conversion (affichage / test d'adresse / demande). */
 export async function recordConversionEvent(values: RecordConversionEventValues) {
-  await kdb.insertInto('conversion_events').values(values).execute();
+  await kdb
+    .insertInto('conversion_events')
+    .values({
+      ...values,
+      // Si une règle bannit déjà cette IP, l'event entre directement exclu des stats (pas besoin de rejouer
+      // le backfill). Détail de la résolution des règles : cf. `mostSpecificRuleExcludes`.
+      excluded: values.ip ? mostSpecificRuleExcludes(sql<string>`${values.ip}::inet`) : false,
+    })
+    .execute();
 }
 
 export async function listConversionSources({ includeArchived }: { includeArchived: boolean }) {
@@ -129,8 +146,9 @@ export async function getConversionStats(params: {
 }): Promise<ConversionStatRow[]> {
   const { dateFrom, dateTo, granularity, groupByPage = false, groupByHost = false, source, channel } = params;
   const periodFormat = granularity === 'month' ? 'YYYY-MM' : 'YYYY-MM-DD';
-  const period = sql<string>`to_char(date_trunc(${sql.lit(granularity)}, ${sql.ref('created_at')}), ${sql.lit(periodFormat)})`;
-  const periodGroup = sql`date_trunc(${sql.lit(granularity)}, ${sql.ref('created_at')})`;
+  const createdAt = expressionBuilder<DB, 'conversion_events'>().ref('created_at');
+  const period = sql<string>`to_char(date_trunc(${sql.lit(granularity)}, ${createdAt}), ${sql.lit(periodFormat)})`;
+  const periodGroup = sql`date_trunc(${sql.lit(granularity)}, ${createdAt})`;
 
   const [eventRows, sources, knownRoutes] = await Promise.all([
     kdb
@@ -139,25 +157,26 @@ export async function getConversionStats(params: {
         'source',
         'route',
         period.as('period'),
-        eb.fn.countAll<string>().filterWhere('type', '=', 'display').as('displays'),
-        eb.fn.countAll<string>().filterWhere('type', '=', 'address_test').as('tests'),
+        eb.fn.countAll<number>().filterWhere('type', '=', 'display').as('displays'),
+        eb.fn.countAll<number>().filterWhere('type', '=', 'address_test').as('tests'),
         eb.fn
-          .countAll<string>()
+          .countAll<number>()
           .filterWhere(eb.and([eb('type', '=', 'address_test'), eb('eligible', '=', true)]))
           .as('tests_eligible'),
         eb.fn
-          .countAll<string>()
+          .countAll<number>()
           .filterWhere(eb.and([eb('type', '=', 'address_test'), eb('eligible', '=', false)]))
           .as('tests_not_eligible'),
-        eb.fn.countAll<string>().filterWhere('type', '=', 'demand').as('demands'),
+        eb.fn.countAll<number>().filterWhere('type', '=', 'demand').as('demands'),
         eb.fn
-          .countAll<string>()
+          .countAll<number>()
           .filterWhere(eb.and([eb('type', '=', 'demand'), eb('eligible', '=', true)]))
           .as('demands_eligible'),
-        sql<string>`count(distinct ${sql.ref('ip')})`.as('distinct_ip'),
+        eb.fn.count<number>('ip').distinct().as('distinct_ip'),
       ])
       .where('created_at', '>=', dateFrom)
       .where('created_at', '<=', dateTo)
+      .where('excluded', '=', false)
       .$if(!!source, (qb) => qb.where('source', '=', source!))
       .groupBy(['source', 'route', periodGroup])
       .$if(groupByPage, (qb) => qb.select('page').groupBy('page'))
@@ -169,6 +188,7 @@ export async function getConversionStats(params: {
       .select('route')
       .distinct()
       .where('source', 'is', null)
+      .where('excluded', '=', false)
       .where('created_at', '>=', sql<Date>`now() - interval '12 months'`)
       .execute(),
   ]);
@@ -177,16 +197,14 @@ export async function getConversionStats(params: {
   const sourceCreatedAt = (id: string | null): string | null => (id ? (sourceById.get(id)?.created_at.toISOString() ?? null) : null);
 
   const rows = eventRows.map((r): ConversionStatRow => {
-    const displays = Number(r.displays);
-    const tests = Number(r.tests);
-    const demands = Number(r.demands);
+    const { demands, displays, tests } = r;
     return {
       channel: getChannel(r.source, r.route),
       demandRate: tests > 0 ? demands / tests : null,
       demands,
-      demandsEligible: Number(r.demands_eligible),
+      demandsEligible: r.demands_eligible,
       displays,
-      distinctIp: Number(r.distinct_ip),
+      distinctIp: r.distinct_ip,
       host: r.host ?? null,
       label: r.source ? (sourceById.get(r.source)?.label ?? r.source) : r.route,
       page: r.page ?? null,
@@ -196,8 +214,8 @@ export async function getConversionStats(params: {
       sourceCreatedAt: sourceCreatedAt(r.source),
       testRate: displays > 0 ? tests / displays : null,
       tests,
-      testsEligible: Number(r.tests_eligible),
-      testsNotEligible: Number(r.tests_not_eligible),
+      testsEligible: r.tests_eligible,
+      testsNotEligible: r.tests_not_eligible,
       unregistered: r.source ? !sourceById.has(r.source) : false,
     };
   });
@@ -232,10 +250,208 @@ export async function getConversionStats(params: {
 }
 
 /**
+ * Valide/normalise une IP ou plage CIDR via Postgres (`inet`, source de vérité IPv4/IPv6).
+ * Lève `BAD_REQUEST` sur une saisie invalide plutôt que d'exposer l'erreur SQL brute.
+ */
+async function normalizeInet(value: string): Promise<string> {
+  try {
+    // `::text` explicite → forme canonique avec masklen (`1.1.1.1/32`), cohérente avec les `ip::text`
+    // renvoyés ailleurs (upsert, getSuspiciousIps, listIpRules).
+    const { rows } = await sql<{ ip: string }>`select ${value}::inet::text as ip`.execute(kdb);
+    return rows[0].ip;
+  } catch {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: `IP ou plage CIDR invalide : ${value}` });
+  }
+}
+
+/**
+ * Vrai si la règle la plus spécifique (`masklen` max) couvrant `ip` est un `exclude`. `ip` = expression SQL
+ * `inet`. C'est la sémantique unique du flag `excluded` : un `keep` en /32 gagne sur un `exclude` en /24 ;
+ * aucune règle → non exclu. La sous-requête est buildée (colonnes/enum type-checkés) ; seuls `<<=`, `masklen`
+ * et `coalesce` (absents de Kysely) restent en SQL brut.
+ */
+const mostSpecificRuleExcludes = (ip: Expression<string | null>) => {
+  const rule = expressionBuilder<DB, never>()
+    .selectFrom('conversion_ip_rules as r')
+    .select((eb) => eb('r.disposition', '=', sql.lit<ConversionIpDisposition>('exclude')).as('is_exclude'))
+    .where((eb) => sql<SqlBool>`${ip} <<= ${eb.ref('r.ip')}`)
+    .orderBy((eb) => sql`masklen(${eb.ref('r.ip')}) desc`)
+    .limit(1);
+  return sql<boolean>`coalesce(${rule}, false)`;
+};
+
+/**
+ * Réconcilie `conversion_events.excluded` sur les events d'une plage après une modif de règle : recalcule le
+ * flag = « couvert par un `exclude` le plus spécifique ». Ne met à jour que les lignes qui basculent (renvoie
+ * leur nombre). Gère uniformément ban / keep / suppression. Les events purgés (IP nulle) restent figés.
+ */
+async function reconcileExcludedForRange(trx: typeof kdb, cidr: string): Promise<number> {
+  const shouldExclude = mostSpecificRuleExcludes(expressionBuilder<DB, 'conversion_events'>().ref('conversion_events.ip'));
+  const result = await trx
+    .updateTable('conversion_events')
+    .set({ excluded: shouldExclude })
+    .where((eb) => sql<SqlBool>`${eb.ref('ip')} <<= ${cidr}::inet`)
+    .where((eb) => sql<SqlBool>`${eb.ref('excluded')} is distinct from ${shouldExclude}`)
+    .executeTakeFirst();
+  return Number(result.numUpdatedRows ?? 0);
+}
+
+export type SuspiciousIpRow = {
+  ip: string;
+  events: number;
+  displays: number;
+  tests: number;
+  demands: number;
+  /** tests / affichages (null si aucun affichage). Un ratio élevé (≫ 1) signale du spam d'`address_test`. */
+  testPerDisplay: number | null;
+  distinctRoutes: number;
+  distinctDays: number;
+  firstSeen: string;
+  lastSeen: string;
+  /** Disposition de la règle la plus spécifique couvrant l'IP (`null` = non statuée). */
+  ruleDisposition: ConversionIpDisposition | null;
+  ruleReason: string | null;
+};
+
+/**
+ * IP suspectes sur une période : agrégat par IP trié par nb de tests, avec les signaux d'abus
+ * (ratio tests/affichages, nb de routes/jours, demandes) et la règle courante. Filtrable par
+ * `source` / `route` / `host` (identifier les IP derrière une source pourrie ; passer `minTests: 0`).
+ * Query builder (colonnes/enum type-checkés) ; seuls `<<=` et `masklen` (absents de Kysely) restent en SQL brut.
+ */
+export async function getSuspiciousIps(params: {
+  dateFrom: Date;
+  dateTo: Date;
+  minTests: number;
+  limit: number;
+  source?: string;
+  route?: string;
+  host?: string;
+}): Promise<SuspiciousIpRow[]> {
+  const { dateFrom, dateTo, minTests, limit, source, route, host } = params;
+
+  const rows = await kdb
+    .selectFrom('conversion_events as ce')
+    .where('ce.ip', 'is not', null)
+    .where('ce.created_at', '>=', dateFrom)
+    .where('ce.created_at', '<=', dateTo)
+    .$if(source !== undefined, (qb) => qb.where('ce.source', '=', source!))
+    .$if(route !== undefined, (qb) => qb.where('ce.route', '=', route!))
+    .$if(host !== undefined, (qb) => qb.where('ce.host', '=', host!))
+    .groupBy('ce.ip')
+    .having((eb) => eb.fn.countAll().filterWhere('ce.type', '=', 'address_test'), '>=', minTests)
+    .select((eb) => [
+      sql<string>`${eb.ref('ce.ip')}::text`.as('ip'),
+      eb.fn.countAll<number>().as('events'),
+      eb.fn.countAll<number>().filterWhere('ce.type', '=', 'display').as('displays'),
+      eb.fn.countAll<number>().filterWhere('ce.type', '=', 'address_test').as('tests'),
+      eb.fn.countAll<number>().filterWhere('ce.type', '=', 'demand').as('demands'),
+      eb.fn.count<number>('ce.route').distinct().as('distinct_routes'),
+      eb.fn
+        .count<number>(sql`date_trunc('day', ${eb.ref('ce.created_at')})`)
+        .distinct()
+        .as('distinct_days'),
+      eb.fn.min('ce.created_at').as('first_seen'),
+      eb.fn.max('ce.created_at').as('last_seen'),
+      eb
+        .selectFrom('conversion_ip_rules as r')
+        .select('r.disposition')
+        .where((sub) => sql<SqlBool>`${sub.ref('ce.ip')} <<= ${sub.ref('r.ip')}`)
+        .orderBy((eb) => sql`masklen(${eb.ref('r.ip')}) desc`)
+        .limit(1)
+        .as('rule_disposition'),
+      eb
+        .selectFrom('conversion_ip_rules as r')
+        .select('r.reason')
+        .where((sub) => sql<SqlBool>`${sub.ref('ce.ip')} <<= ${sub.ref('r.ip')}`)
+        .orderBy((eb) => sql`masklen(${eb.ref('r.ip')}) desc`)
+        .limit(1)
+        .as('rule_reason'),
+    ])
+    .orderBy((eb) => eb.fn.countAll().filterWhere('ce.type', '=', 'address_test'), 'desc')
+    .limit(limit)
+    .execute();
+
+  return rows.map((r) => ({
+    demands: r.demands,
+    displays: r.displays,
+    distinctDays: r.distinct_days,
+    distinctRoutes: r.distinct_routes,
+    events: r.events,
+    // min/max sur un groupe non vide (>= 1 event par IP) → jamais null.
+    firstSeen: new Date(r.first_seen ?? 0).toISOString(),
+    ip: r.ip,
+    lastSeen: new Date(r.last_seen ?? 0).toISOString(),
+    ruleDisposition: r.rule_disposition,
+    ruleReason: r.rule_reason,
+    testPerDisplay: r.displays > 0 ? r.tests / r.displays : null,
+    tests: r.tests,
+  }));
+}
+
+/** Règles IP/CIDR (bannir / conserver) avec l'e-mail de l'admin auteur, si encore présent. */
+export async function listIpRules() {
+  return await kdb
+    .selectFrom('conversion_ip_rules')
+    .leftJoin('users', 'users.id', 'conversion_ip_rules.created_by')
+    .select((eb) => [
+      sql<string>`${eb.ref('conversion_ip_rules.ip')}::text`.as('ip'),
+      'conversion_ip_rules.disposition',
+      'conversion_ip_rules.reason',
+      'conversion_ip_rules.created_at',
+      'users.email as createdByEmail',
+    ])
+    .orderBy('conversion_ip_rules.disposition', 'asc')
+    .orderBy('conversion_ip_rules.created_at', 'desc')
+    .execute();
+}
+
+/**
+ * Crée / met à jour une règle sur une IP/plage CIDR, puis réconcilie `excluded` sur la plage (nettoie les
+ * stats et fige l'exclusion avant purge). `changedEvents` = nb d'events dont l'exclusion a basculé.
+ */
+export async function upsertIpRule(params: { ip: string; disposition: ConversionIpDisposition; reason: string; createdBy: string }) {
+  const ip = await normalizeInet(params.ip);
+  return await kdb.transaction().execute(async (trx) => {
+    const rule = await trx
+      .insertInto('conversion_ip_rules')
+      .values({ created_by: params.createdBy, disposition: params.disposition, ip: sql<string>`${ip}::inet`, reason: params.reason })
+      .onConflict((oc) =>
+        oc.column('ip').doUpdateSet({
+          created_at: new Date(),
+          created_by: params.createdBy,
+          disposition: params.disposition,
+          reason: params.reason,
+        })
+      )
+      .returning((eb) => [sql<string>`${eb.ref('ip')}::text`.as('ip'), 'disposition', 'reason'])
+      .executeTakeFirstOrThrow();
+    const changedEvents = await reconcileExcludedForRange(trx, ip);
+    return { ...rule, changedEvents };
+  });
+}
+
+/**
+ * Supprime la règle d'une IP/plage, puis réconcilie `excluded` sur la plage (les events redeviennent comptés
+ * s'ils ne sont plus couverts par une autre règle `exclude`). Les events purgés (IP nulle) restent figés.
+ */
+export async function removeIpRule(rawIp: string) {
+  const ip = await normalizeInet(rawIp);
+  return await kdb.transaction().execute(async (trx) => {
+    await trx
+      .deleteFrom('conversion_ip_rules')
+      .where((eb) => sql<SqlBool>`${eb.ref('ip')} = ${ip}::inet`)
+      .execute();
+    const changedEvents = await reconcileExcludedForRange(trx, ip);
+    return { changedEvents, ip };
+  });
+}
+
+/**
  * Purge les données d'anti-abus (IP/UA) des événements plus vieux que `retentionDays`.
  * `host` est de l'analytics → conservé. Les compteurs restent intacts.
  */
-export async function purgeOldConversionEventIps(retentionDays = 90): Promise<number> {
+export async function purgeOldConversionEventIps(retentionDays = CONVERSION_IP_RETENTION_DAYS): Promise<number> {
   const result = await kdb
     .updateTable('conversion_events')
     .set({ ip: null, user_agent: null })

--- a/src/modules/conversion-tracking/server/trpc-routes.integration.spec.ts
+++ b/src/modules/conversion-tracking/server/trpc-routes.integration.spec.ts
@@ -2,12 +2,12 @@ import type { User } from 'next-auth';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import { appRouter } from '@/modules/trpc/trpc.config';
-import { type ConversionEvents, type Insertable, kdb } from '@/server/db/kysely';
+import { type ConversionEvents, type Insertable, kdb, sql } from '@/server/db/kysely';
 import { cleanDatabase, seedTableUser } from '@/tests/fixtures';
 import type { TestCaseBoolean } from '@/tests/trpc-helpers';
 import { createMockContext, createTestCaller, forbiddenError, testUsers } from '@/tests/trpc-helpers';
 
-import type { ConversionStatRow } from './service';
+import type { ConversionStatRow, SuspiciousIpRow } from './service';
 
 const adminOnlyPermissions: TestCaseBoolean<Partial<User> | null>[] = [
   { expectedOutput: false, input: null },
@@ -66,6 +66,32 @@ const statRow = (row: Partial<ConversionStatRow> & Pick<ConversionStatRow, 'chan
   ...row,
 });
 
+/** Ligne de suspect attendue, complète (défauts) — `firstSeen`/`lastSeen` = échos du seed, non asservis. */
+const suspiciousRow = (row: Partial<SuspiciousIpRow> & Pick<SuspiciousIpRow, 'ip'>): SuspiciousIpRow => ({
+  demands: 0,
+  displays: 0,
+  distinctDays: 1,
+  distinctRoutes: 1,
+  events: 0,
+  firstSeen: expect.any(String),
+  lastSeen: expect.any(String),
+  ruleDisposition: null,
+  ruleReason: null,
+  testPerDisplay: null,
+  tests: 0,
+  ...row,
+});
+
+/** Les `ip::text` des events actuellement exclus (triées), pour vérifier la réconciliation du flag. */
+const excludedEventIps = () =>
+  kdb
+    .selectFrom('conversion_events')
+    .select((eb) => sql<string>`${eb.ref('ip')}::text`.as('ip'))
+    .where('excluded', '=', true)
+    .orderBy('ip')
+    .execute()
+    .then((rows) => rows.map((r) => r.ip));
+
 describe('conversionTrackingRouter', () => {
   beforeAll(async () => {
     await cleanDatabase();
@@ -75,6 +101,7 @@ describe('conversionTrackingRouter', () => {
   beforeEach(async () => {
     await Promise.all([
       kdb.deleteFrom('conversion_events').execute(),
+      kdb.deleteFrom('conversion_ip_rules').execute(),
       kdb.deleteFrom('conversion_sources').execute(),
       kdb.deleteFrom('demands').execute(),
       kdb.deleteFrom('events').execute(),
@@ -382,6 +409,127 @@ describe('conversionTrackingRouter', () => {
         statRow({ channel: 'iframe', label: 'Iframe muette', source: muette.id, sourceCreatedAt: expect.any(String) }),
         statRow({ channel: 'internal', label: '/villes/[ville]', route: '/villes/[ville]' }),
       ]);
+    });
+  });
+
+  describe('contrôle des abus / IP (admin)', () => {
+    const statsInput = { dateFrom: daysAgo(30), dateTo: now, granularity: 'day' as const };
+    const suspiciousInput = { dateFrom: daysAgo(30), dateTo: now, minTests: 2 };
+
+    describe('permissions', () => {
+      testPermissions(adminOnlyPermissions, (user) => () => createTestCaller(user).conversionTracking.getSuspiciousIps(suspiciousInput));
+      testPermissions(adminOnlyPermissions, (user) => () => createTestCaller(user).conversionTracking.ipRules.list());
+      testPermissions(
+        adminOnlyPermissions,
+        (user) => () => createTestCaller(user).conversionTracking.ipRules.upsert({ disposition: 'exclude', ip: '1.1.1.1', reason: 'x' })
+      );
+      testPermissions(adminOnlyPermissions, (user) => () => createTestCaller(user).conversionTracking.ipRules.remove({ ip: '1.1.1.1' }));
+    });
+
+    it('liste les IP suspectes au-dessus du seuil, triées par nb de tests, avec les signaux et sans règle', async () => {
+      await seedEvents([
+        { created_at: daysAgo(2), ip: '1.1.1.1', type: 'display' },
+        { created_at: daysAgo(2), ip: '1.1.1.1', type: 'address_test' },
+        { created_at: daysAgo(2), ip: '1.1.1.1', type: 'address_test' },
+        { created_at: daysAgo(2), ip: '1.1.1.1', type: 'address_test' },
+        { created_at: daysAgo(2), ip: '9.9.9.9', type: 'address_test' }, // 1 test < seuil (2)
+      ]);
+
+      const result = await createTestCaller(testUsers.admin).conversionTracking.getSuspiciousIps(suspiciousInput);
+
+      expect(result).toStrictEqual([suspiciousRow({ displays: 1, events: 4, ip: '1.1.1.1/32', testPerDisplay: 3, tests: 3 })]);
+    });
+
+    it('bannir (exclude) retire les events de l’IP des stats et renvoie le nombre recompté', async () => {
+      const caller = createTestCaller(testUsers.admin);
+      await seedEvents([
+        { created_at: daysAgo(2), ip: '1.1.1.1', type: 'address_test' },
+        { created_at: daysAgo(2), ip: '1.1.1.1', type: 'address_test' },
+        { created_at: daysAgo(2), ip: '2.2.2.2', type: 'address_test' },
+      ]);
+
+      const rule = await caller.conversionTracking.ipRules.upsert({ disposition: 'exclude', ip: '1.1.1.1', reason: 'bot' });
+      expect(rule).toStrictEqual({ changedEvents: 2, disposition: 'exclude', ip: '1.1.1.1/32', reason: 'bot' });
+
+      const [stats, suspects] = await Promise.all([
+        caller.conversionTracking.getStats(statsInput),
+        caller.conversionTracking.getSuspiciousIps({ ...suspiciousInput, minTests: 1 }),
+      ]);
+      // Seul le test de 2.2.2.2 reste compté dans les stats…
+      expect(stats).toStrictEqual([
+        statRow({
+          channel: 'internal',
+          demandRate: 0,
+          distinctIp: 1,
+          label: '/page',
+          period: isoDay(daysAgo(2)),
+          route: '/page',
+          tests: 1,
+        }),
+      ]);
+      // …mais la détection montre toujours 1.1.1.1 avec sa disposition.
+      expect(suspects).toStrictEqual([
+        suspiciousRow({ events: 2, ip: '1.1.1.1/32', ruleDisposition: 'exclude', ruleReason: 'bot', tests: 2 }),
+        suspiciousRow({ events: 1, ip: '2.2.2.2/32', tests: 1 }),
+      ]);
+    });
+
+    it('bannit une plage CIDR, et un keep plus spécifique l’emporte sur l’exclude', async () => {
+      const caller = createTestCaller(testUsers.admin);
+      await seedEvents([
+        { created_at: daysAgo(2), ip: '10.0.0.5', type: 'address_test' },
+        { created_at: daysAgo(2), ip: '10.0.0.99', type: 'address_test' },
+      ]);
+
+      await caller.conversionTracking.ipRules.upsert({ disposition: 'exclude', ip: '10.0.0.0/24', reason: 'plage' });
+      expect(await excludedEventIps()).toStrictEqual(['10.0.0.5/32', '10.0.0.99/32']);
+
+      await caller.conversionTracking.ipRules.upsert({ disposition: 'keep', ip: '10.0.0.5', reason: 'interne' });
+      expect(await excludedEventIps()).toStrictEqual(['10.0.0.99/32']);
+    });
+
+    it('réintégrer (remove) recompte les events et vide le registre', async () => {
+      const caller = createTestCaller(testUsers.admin);
+      await seedEvents([{ created_at: daysAgo(2), ip: '1.1.1.1', type: 'address_test' }]);
+      await caller.conversionTracking.ipRules.upsert({ disposition: 'exclude', ip: '1.1.1.1', reason: 'bot' });
+
+      const removed = await caller.conversionTracking.ipRules.remove({ ip: '1.1.1.1' });
+      expect(removed).toStrictEqual({ changedEvents: 1, ip: '1.1.1.1/32' });
+
+      const [rules, excluded] = await Promise.all([caller.conversionTracking.ipRules.list(), excludedEventIps()]);
+      expect(rules).toStrictEqual([]);
+      expect(excluded).toStrictEqual([]);
+    });
+
+    it('conserver (keep) enregistre la règle sans exclure les events', async () => {
+      const caller = createTestCaller(testUsers.admin);
+      await seedEvents([{ created_at: daysAgo(2), ip: '1.1.1.1', type: 'address_test' }]);
+
+      const rule = await caller.conversionTracking.ipRules.upsert({ disposition: 'keep', ip: '1.1.1.1', reason: 'partenaire' });
+      expect(rule).toStrictEqual({ changedEvents: 0, disposition: 'keep', ip: '1.1.1.1/32', reason: 'partenaire' });
+      expect(await excludedEventIps()).toStrictEqual([]);
+    });
+
+    it('règle collante : un nouvel event d’une IP déjà bannie entre exclu (hors stats)', async () => {
+      const admin = createTestCaller(testUsers.admin);
+      // L’IP du contexte de test vaut 127.0.0.1 → on la bannit avant l’event.
+      await admin.conversionTracking.ipRules.upsert({ disposition: 'exclude', ip: '127.0.0.1', reason: 'bot' });
+
+      await createTestCaller(null).conversionTracking.recordEvent({
+        page: '/villes/paris',
+        route: '/villes/[ville]',
+        type: 'address_test',
+      });
+
+      const event = await kdb.selectFrom('conversion_events').select('excluded').executeTakeFirstOrThrow();
+      expect(event.excluded).toStrictEqual(true);
+      expect(await admin.conversionTracking.getStats(statsInput)).toStrictEqual([]);
+    });
+
+    it('rejette une IP invalide (BAD_REQUEST)', async () => {
+      await expect(
+        createTestCaller(testUsers.admin).conversionTracking.ipRules.upsert({ disposition: 'exclude', ip: 'pas-une-ip', reason: 'x' })
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
     });
   });
 });

--- a/src/modules/conversion-tracking/server/trpc-routes.integration.spec.ts
+++ b/src/modules/conversion-tracking/server/trpc-routes.integration.spec.ts
@@ -6,6 +6,7 @@ import { type ConversionEvents, type Insertable, kdb, sql } from '@/server/db/ky
 import { cleanDatabase, seedTableUser } from '@/tests/fixtures';
 import type { TestCaseBoolean } from '@/tests/trpc-helpers';
 import { createMockContext, createTestCaller, forbiddenError, testUsers } from '@/tests/trpc-helpers';
+import { formatAsISODate } from '@/utils/date';
 
 import type { ConversionStatRow, SuspiciousIpRow } from './service';
 
@@ -42,8 +43,6 @@ const seedEvents = (events: ConversionEventSeed[]) =>
     .insertInto('conversion_events')
     .values(events.map((event) => ({ page: '/page', route: '/page', ...event })))
     .execute();
-
-const isoDay = (date: Date) => date.toISOString().slice(0, 10);
 
 /** Ligne de stats attendue, complète (défauts à zéro) — à utiliser avec `toStrictEqual`. */
 const statRow = (row: Partial<ConversionStatRow> & Pick<ConversionStatRow, 'channel' | 'label'>): ConversionStatRow => ({
@@ -254,7 +253,7 @@ describe('conversionTrackingRouter', () => {
           displays: 3,
           distinctIp: 2,
           label: 'Iframe A',
-          period: isoDay(daysAgo(2)),
+          period: formatAsISODate(daysAgo(2)),
           route: '/page',
           source: source.id,
           sourceCreatedAt: new Date(source.created_at).toISOString(),
@@ -282,7 +281,7 @@ describe('conversionTrackingRouter', () => {
           demandRate: 0,
           displays: 2,
           label: '/villes/[ville]',
-          period: isoDay(daysAgo(2)),
+          period: formatAsISODate(daysAgo(2)),
           route: '/villes/[ville]',
           testRate: 1 / 2,
           tests: 1,
@@ -297,7 +296,7 @@ describe('conversionTrackingRouter', () => {
           displays: 1,
           label: '/villes/[ville]',
           page: '/villes/charleville',
-          period: isoDay(daysAgo(2)),
+          period: formatAsISODate(daysAgo(2)),
           route: '/villes/[ville]',
           testRate: 1,
           tests: 1,
@@ -307,7 +306,7 @@ describe('conversionTrackingRouter', () => {
           displays: 1,
           label: '/villes/[ville]',
           page: '/villes/reims',
-          period: isoDay(daysAgo(2)),
+          period: formatAsISODate(daysAgo(2)),
           route: '/villes/[ville]',
           testRate: 0,
         }),
@@ -330,7 +329,7 @@ describe('conversionTrackingRouter', () => {
           displays: 1,
           host: 'engie.fr/a',
           label: '/iframe/carte',
-          period: isoDay(daysAgo(2)),
+          period: formatAsISODate(daysAgo(2)),
           route: '/iframe/carte',
           testRate: 1,
           tests: 1,
@@ -340,7 +339,7 @@ describe('conversionTrackingRouter', () => {
           displays: 1,
           host: 'engie.fr/b',
           label: '/iframe/carte',
-          period: isoDay(daysAgo(2)),
+          period: formatAsISODate(daysAgo(2)),
           route: '/iframe/carte',
           testRate: 0,
         }),
@@ -370,7 +369,7 @@ describe('conversionTrackingRouter', () => {
           channel: 'internal',
           demandRate: 0,
           label: '/villes/[ville]',
-          period: isoDay(daysAgo(2)),
+          period: formatAsISODate(daysAgo(2)),
           route: '/villes/[ville]',
           tests: 1,
         }),
@@ -462,7 +461,7 @@ describe('conversionTrackingRouter', () => {
           demandRate: 0,
           distinctIp: 1,
           label: '/page',
-          period: isoDay(daysAgo(2)),
+          period: formatAsISODate(daysAgo(2)),
           route: '/page',
           tests: 1,
         }),

--- a/src/modules/conversion-tracking/server/trpc-routes.ts
+++ b/src/modules/conversion-tracking/server/trpc-routes.ts
@@ -10,22 +10,38 @@ import {
   zArchiveConversionSourceInput,
   zCreateConversionSourceInput,
   zGetConversionStatsInput,
+  zGetSuspiciousIpsInput,
   zListConversionSourcesInput,
   zRecordConversionEventInput,
+  zRemoveIpRuleInput,
   zUpdateConversionSourceInput,
+  zUpsertIpRuleInput,
 } from '../constants';
 import {
   archiveConversionSource,
   createConversionSource,
   getConversionStats,
+  getSuspiciousIps,
   listConversionSources,
+  listIpRules,
   recordConversionEvent,
+  removeIpRule,
   updateConversionSource,
+  upsertIpRule,
 } from './service';
 
 export const conversionTrackingRouter = router({
   /** Funnel de conversion par source × période (admin). */
   getStats: adminRoute.input(zGetConversionStatsInput).query(({ input }) => getConversionStats(input)),
+  /** Détection anti-abus : IP suspectes sur la période, filtrables par source/route/host (admin). */
+  getSuspiciousIps: adminRoute.input(zGetSuspiciousIpsInput).query(({ input }) => getSuspiciousIps(input)),
+
+  /** Règles IP/CIDR (bannir `exclude` / conserver `keep`). Toute modif réconcilie le flag `excluded`. */
+  ipRules: {
+    list: adminRoute.query(() => listIpRules()),
+    remove: adminRoute.input(zRemoveIpRuleInput).mutation(({ input }) => removeIpRule(input.ip)),
+    upsert: adminRoute.input(zUpsertIpRuleInput).mutation(({ ctx, input }) => upsertIpRule({ ...input, createdBy: ctx.user.id })),
+  },
   /** Enregistre un événement de conversion. Public (appelé depuis les iframes / pages) + rate-limité. */
   recordEvent: route
     .meta({ rateLimit: { limit: 60, windowMs: 60 * 1000 } })

--- a/src/modules/map/client/admin/IframeGeneratorPage.tsx
+++ b/src/modules/map/client/admin/IframeGeneratorPage.tsx
@@ -172,305 +172,305 @@ const IframeGeneratorPage = () => {
       title="Générateur d'iframes"
       description="Génère l'URL et le code d'intégration d'une carte ou d'un formulaire de test d'adresse à embarquer"
       mode="authenticated"
+      layout="center"
+      className="flex flex-col gap-8"
     >
-      <div className="fr-container fr-py-4w flex flex-col gap-8">
-        <div>
-          <Heading as="h1" color="blue-france">
-            Générateur d'iframes
-          </Heading>
-          <p className="mb-0 text-sm text-(--text-mention-grey)">
-            Configurez la carte, ajustez la vue dans l'aperçu, puis copiez le code à intégrer sur un site partenaire. Le formulaire de test
-            d'adresse (variante légère) est en bas de page.
-          </p>
+      <div>
+        <Heading as="h1" color="blue-france">
+          Générateur d'iframes
+        </Heading>
+        <p className="mb-0 text-sm text-(--text-mention-grey)">
+          Configurez la carte, ajustez la vue dans l'aperçu, puis copiez le code à intégrer sur un site partenaire. Le formulaire de test
+          d'adresse (variante légère) est en bas de page.
+        </p>
+      </div>
+
+      <Section title="Intégration">
+        <p className="mb-0 text-sm text-(--text-mention-grey)">
+          Chaque intégration = une iframe déployée chez un partenaire. Sa source identifie le tracking de conversion (affichages, tests,
+          demandes).
+        </p>
+        <div className="flex flex-col gap-2">
+          <div className="flex justify-end">
+            <Checkbox
+              label="Voir les archivées"
+              nativeInputProps={{
+                checked: showArchived,
+                name: 'showArchived',
+                onChange: (event) => setShowArchived(event.target.checked),
+              }}
+            />
+          </div>
+          {iframeSources.length === 0 ? (
+            <p className="mb-0 text-sm text-(--text-mention-grey)">Aucune intégration enregistrée.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse text-sm">
+                <thead>
+                  <tr className="border-b-2 border-(--border-default-grey) text-left">
+                    <th className="p-2">Nom</th>
+                    <th className="p-2 whitespace-nowrap">Créée le</th>
+                    {showArchived && <th className="p-2">Statut</th>}
+                    <th className="p-2" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {iframeSources.map((row) => (
+                    <tr
+                      key={row.id}
+                      aria-current={row.id === integrationId ? true : undefined}
+                      className={`border-b border-(--border-default-grey)${row.id === integrationId ? ' bg-(--background-open-blue-france)' : ''}`}
+                    >
+                      <td className="p-2">
+                        <button
+                          type="button"
+                          onClick={() => loadIntegration(row.id)}
+                          className="cursor-pointer text-left font-medium text-(--text-action-high-blue-france) hover:underline"
+                        >
+                          {row.label}
+                        </button>
+                      </td>
+                      <td className="p-2 whitespace-nowrap" title={formatFrenchDateTime(new Date(row.created_at))}>
+                        {formatFrenchDate(new Date(row.created_at))}
+                      </td>
+                      {showArchived && (
+                        <td className="p-2">
+                          {row.archived_at ? (
+                            <Badge small noIcon>
+                              Archivée
+                            </Badge>
+                          ) : (
+                            <span className="text-(--text-mention-grey)">Active</span>
+                          )}
+                        </td>
+                      )}
+                      <td className="p-2 text-right whitespace-nowrap">
+                        <Button
+                          priority="tertiary"
+                          size="small"
+                          iconId="fr-icon-bar-chart-box-line"
+                          title={`Voir la conversion de l'intégration « ${row.label} »`}
+                          linkProps={{ href: `/admin/conversion?source=${encodeURIComponent(row.id)}` }}
+                        />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+        <Input
+          label="Nom de l'intégration"
+          className="mb-0 max-w-md"
+          hintText="Ex : Engie — site corporate"
+          nativeInputProps={{
+            onChange: (event) => setLabel(event.target.value),
+            required: true,
+            value: label,
+          }}
+        />
+        <div className="flex flex-wrap items-center gap-2">
+          <Button type="button" size="small" onClick={saveIntegration} disabled={!label || isSaving}>
+            {integrationId ? "Enregistrer l'intégration" : "Créer l'intégration"}
+          </Button>
+          {integrationId && (
+            <>
+              <Button type="button" size="small" priority="tertiary" onClick={resetIntegration}>
+                Nouvelle
+              </Button>
+              <Button type="button" size="small" priority="tertiary" iconId="fr-icon-archive-line" onClick={archiveIntegration}>
+                Archiver
+              </Button>
+            </>
+          )}
+        </div>
+        {saveError && <p className="mb-0 text-sm text-(--text-default-error)">{saveError}</p>}
+      </Section>
+
+      <Section title="Données affichées">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
+          <fieldset className="flex flex-col gap-1 border-0 p-0 m-0">
+            <legend className="text-sm mb-1">Couches</legend>
+            {layerKeys.map((key) => (
+              <Checkbox
+                key={key}
+                label={layerLabels[key]}
+                nativeInputProps={{ checked: config.layers.includes(key), name: key, onChange: () => toggleLayer(key) }}
+              />
+            ))}
+          </fieldset>
+
+          <div className="flex flex-col gap-4">
+            <MultiAutocompleteField
+              label="Filtrer par gestionnaire"
+              hintText={scopeHint(
+                ['reseaux-de-chaleur', 'reseaux-de-froid', 'reseaux-en-construction'],
+                'Saisie ou suggestions — Entrée pour ajouter.'
+              )}
+              placeholder="Ex : dalkia"
+              values={config.gestionnaire}
+              onChange={(gestionnaire) => update({ gestionnaire: [...new Set(gestionnaire.map((value) => value.toLowerCase()))] })}
+              suggestions={gestionnaireSuggestions}
+              fetchFn={fetchGestionnaires}
+            />
+
+            <MultiAutocompleteField
+              label="Filtrer par maître d'ouvrage"
+              hintText={scopeHint(['reseaux-de-chaleur', 'reseaux-de-froid'], 'Saisie ou suggestions — Entrée pour ajouter.')}
+              placeholder="Ex : Métropole de Lyon"
+              values={config.maitreOuvrage}
+              onChange={(maitreOuvrage) => update({ maitreOuvrage })}
+              fetchFn={fetchMaitresOuvrage}
+            />
+
+            <MultiAutocompleteField
+              label="Filtrer par identifiants SNCU"
+              hintText={scopeHint(
+                ['reseaux-de-chaleur', 'reseaux-de-froid'],
+                'Isole ces réseaux. Limité aux identifiants SNCU pour le moment. Entrée pour ajouter.'
+              )}
+              placeholder="Ex : 7412C"
+              values={config.reseaux}
+              onChange={(reseaux) => update({ reseaux })}
+            />
+          </div>
+        </div>
+      </Section>
+
+      <Section title="Affichage de la carte">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
+          <Select
+            label="Légende"
+            nativeSelectProps={{
+              onChange: (event) => update({ legend: event.target.value as IframeConfig['legend'] }),
+              value: config.legend,
+            }}
+            options={[
+              { label: 'Masquée', value: 'off' },
+              { label: 'Repliée', value: 'hidden' },
+              { label: 'Ouverte (auto)', value: 'auto' },
+            ]}
+          />
+          <Select
+            label="Mode de la carte"
+            nativeSelectProps={{
+              onChange: (event) => update({ mode: event.target.value as IframeConfig['mode'] }),
+              value: config.mode,
+            }}
+            options={[
+              { label: 'Aucun', value: 'none' },
+              { label: 'Recherche commune / réseau', value: 'network' },
+              { label: "Éligibilité (test d'adresse)", value: 'eligibility' },
+            ]}
+          />
+          <div className="flex gap-4">
+            <Input
+              label="Zoom min"
+              className="mb-0 flex-1"
+              nativeInputProps={{
+                onChange: (event) => update({ minZoom: event.target.value === '' ? undefined : Number(event.target.value) }),
+                placeholder: String(defaultMinZoom),
+                type: 'number',
+                value: config.minZoom ?? '',
+              }}
+            />
+            <Input
+              label="Zoom max"
+              className="mb-0 flex-1"
+              nativeInputProps={{
+                onChange: (event) => update({ maxZoom: event.target.value === '' ? undefined : Number(event.target.value) }),
+                placeholder: String(defaultMaxZoom),
+                type: 'number',
+                value: config.maxZoom ?? '',
+              }}
+            />
+          </div>
+          <div className="flex gap-4">
+            <Input
+              label="Largeur de l'iframe"
+              className="mb-0 flex-1"
+              nativeInputProps={{
+                onChange: (event) => update({ width: event.target.value }),
+                placeholder: DEFAULT_IFRAME_WIDTH,
+                value: config.width,
+              }}
+            />
+            <Input
+              label="Hauteur de l'iframe"
+              className="mb-0 flex-1"
+              nativeInputProps={{
+                onChange: (event) => update({ height: event.target.value }),
+                placeholder: DEFAULT_IFRAME_HEIGHT,
+                value: config.height,
+              }}
+            />
+          </div>
         </div>
 
-        <Section title="Intégration">
+        <div className="flex flex-col gap-2">
+          <h3 className="text-sm font-bold mb-0">Centrage et limites</h3>
           <p className="mb-0 text-sm text-(--text-mention-grey)">
-            Chaque intégration = une iframe déployée chez un partenaire. Sa source identifie le tracking de conversion (affichages, tests,
-            demandes).
+            Réglez la position et le zoom de l'aperçu plus bas, puis capturez-les : «&nbsp;Utiliser le centrage de l'aperçu&nbsp;» fixe la
+            vue d'ouverture de l'iframe ; «&nbsp;Limiter le déplacement à l'aperçu&nbsp;» empêche l'utilisateur de sortir de la zone
+            visible.
           </p>
-          <div className="flex flex-col gap-2">
-            <div className="flex justify-end">
-              <Checkbox
-                label="Voir les archivées"
-                nativeInputProps={{
-                  checked: showArchived,
-                  name: 'showArchived',
-                  onChange: (event) => setShowArchived(event.target.checked),
-                }}
-              />
-            </div>
-            {iframeSources.length === 0 ? (
-              <p className="mb-0 text-sm text-(--text-mention-grey)">Aucune intégration enregistrée.</p>
-            ) : (
-              <div className="overflow-x-auto">
-                <table className="w-full border-collapse text-sm">
-                  <thead>
-                    <tr className="border-b-2 border-(--border-default-grey) text-left">
-                      <th className="p-2">Nom</th>
-                      <th className="p-2 whitespace-nowrap">Créée le</th>
-                      {showArchived && <th className="p-2">Statut</th>}
-                      <th className="p-2" />
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {iframeSources.map((row) => (
-                      <tr
-                        key={row.id}
-                        aria-current={row.id === integrationId ? true : undefined}
-                        className={`border-b border-(--border-default-grey)${row.id === integrationId ? ' bg-(--background-open-blue-france)' : ''}`}
-                      >
-                        <td className="p-2">
-                          <button
-                            type="button"
-                            onClick={() => loadIntegration(row.id)}
-                            className="cursor-pointer text-left font-medium text-(--text-action-high-blue-france) hover:underline"
-                          >
-                            {row.label}
-                          </button>
-                        </td>
-                        <td className="p-2 whitespace-nowrap" title={formatFrenchDateTime(new Date(row.created_at))}>
-                          {formatFrenchDate(new Date(row.created_at))}
-                        </td>
-                        {showArchived && (
-                          <td className="p-2">
-                            {row.archived_at ? (
-                              <Badge small noIcon>
-                                Archivée
-                              </Badge>
-                            ) : (
-                              <span className="text-(--text-mention-grey)">Active</span>
-                            )}
-                          </td>
-                        )}
-                        <td className="p-2 text-right whitespace-nowrap">
-                          <Button
-                            priority="tertiary"
-                            size="small"
-                            iconId="fr-icon-bar-chart-box-line"
-                            title={`Voir la conversion de l'intégration « ${row.label} »`}
-                            linkProps={{ href: `/admin/conversion?source=${encodeURIComponent(row.id)}` }}
-                          />
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </div>
-          <Input
-            label="Nom de l'intégration"
-            className="mb-0 max-w-md"
-            hintText="Ex : Engie — site corporate"
-            nativeInputProps={{
-              onChange: (event) => setLabel(event.target.value),
-              required: true,
-              value: label,
-            }}
-          />
           <div className="flex flex-wrap items-center gap-2">
-            <Button type="button" size="small" onClick={saveIntegration} disabled={!label || isSaving}>
-              {integrationId ? "Enregistrer l'intégration" : "Créer l'intégration"}
+            <Button type="button" size="small" priority="secondary" iconId="fr-icon-focus-3-line" onClick={captureView}>
+              Utiliser le centrage de l'aperçu
             </Button>
-            {integrationId && (
-              <>
-                <Button type="button" size="small" priority="tertiary" onClick={resetIntegration}>
-                  Nouvelle
-                </Button>
-                <Button type="button" size="small" priority="tertiary" iconId="fr-icon-archive-line" onClick={archiveIntegration}>
-                  Archiver
-                </Button>
-              </>
+            <Button type="button" size="small" priority="secondary" iconId="fr-icon-crop-line" onClick={captureBounds}>
+              Limiter le déplacement à l'aperçu
+            </Button>
+            {(config.center || config.maxBounds) && (
+              <Button
+                type="button"
+                size="small"
+                priority="tertiary"
+                iconId="fr-icon-close-line"
+                onClick={() => update({ center: undefined, maxBounds: undefined, zoom: undefined })}
+              >
+                Réinitialiser
+              </Button>
             )}
           </div>
-          {saveError && <p className="mb-0 text-sm text-(--text-default-error)">{saveError}</p>}
-        </Section>
+          <span className="text-xs text-(--text-mention-grey)">
+            {config.center
+              ? `Centrage : ${config.center[0]}, ${config.center[1]} · zoom ${config.zoom}`
+              : 'Centrage : France entière (défaut)'}
+            {config.maxBounds ? ' · déplacement limité' : ''}
+          </span>
+        </div>
+      </Section>
 
-        <Section title="Données affichées">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
-            <fieldset className="flex flex-col gap-1 border-0 p-0 m-0">
-              <legend className="text-sm mb-1">Couches</legend>
-              {layerKeys.map((key) => (
-                <Checkbox
-                  key={key}
-                  label={layerLabels[key]}
-                  nativeInputProps={{ checked: config.layers.includes(key), name: key, onChange: () => toggleLayer(key) }}
-                />
-              ))}
-            </fieldset>
+      {/* Remonte la carte au changement d'intégration : `initialView` est mount-only. */}
+      <MapPreview key={integrationId ?? 'new'} config={config} mapRef={mapRef} />
 
-            <div className="flex flex-col gap-4">
-              <MultiAutocompleteField
-                label="Filtrer par gestionnaire"
-                hintText={scopeHint(
-                  ['reseaux-de-chaleur', 'reseaux-de-froid', 'reseaux-en-construction'],
-                  'Saisie ou suggestions — Entrée pour ajouter.'
-                )}
-                placeholder="Ex : dalkia"
-                values={config.gestionnaire}
-                onChange={(gestionnaire) => update({ gestionnaire: [...new Set(gestionnaire.map((value) => value.toLowerCase()))] })}
-                suggestions={gestionnaireSuggestions}
-                fetchFn={fetchGestionnaires}
-              />
+      <Section title="Code à intégrer (carte)">
+        {integrationId ? (
+          <>
+            <Output label="URL" value={iframeUrl} openHref={iframeUrl} />
+            <Output label="Code iframe" value={iframeCode} />
+          </>
+        ) : (
+          <RequireIntegrationNotice />
+        )}
+      </Section>
 
-              <MultiAutocompleteField
-                label="Filtrer par maître d'ouvrage"
-                hintText={scopeHint(['reseaux-de-chaleur', 'reseaux-de-froid'], 'Saisie ou suggestions — Entrée pour ajouter.')}
-                placeholder="Ex : Métropole de Lyon"
-                values={config.maitreOuvrage}
-                onChange={(maitreOuvrage) => update({ maitreOuvrage })}
-                fetchFn={fetchMaitresOuvrage}
-              />
-
-              <MultiAutocompleteField
-                label="Filtrer par identifiants SNCU"
-                hintText={scopeHint(
-                  ['reseaux-de-chaleur', 'reseaux-de-froid'],
-                  'Isole ces réseaux. Limité aux identifiants SNCU pour le moment. Entrée pour ajouter.'
-                )}
-                placeholder="Ex : 7412C"
-                values={config.reseaux}
-                onChange={(reseaux) => update({ reseaux })}
-              />
-            </div>
-          </div>
-        </Section>
-
-        <Section title="Affichage de la carte">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
-            <Select
-              label="Légende"
-              nativeSelectProps={{
-                onChange: (event) => update({ legend: event.target.value as IframeConfig['legend'] }),
-                value: config.legend,
-              }}
-              options={[
-                { label: 'Masquée', value: 'off' },
-                { label: 'Repliée', value: 'hidden' },
-                { label: 'Ouverte (auto)', value: 'auto' },
-              ]}
-            />
-            <Select
-              label="Mode de la carte"
-              nativeSelectProps={{
-                onChange: (event) => update({ mode: event.target.value as IframeConfig['mode'] }),
-                value: config.mode,
-              }}
-              options={[
-                { label: 'Aucun', value: 'none' },
-                { label: 'Recherche commune / réseau', value: 'network' },
-                { label: "Éligibilité (test d'adresse)", value: 'eligibility' },
-              ]}
-            />
-            <div className="flex gap-4">
-              <Input
-                label="Zoom min"
-                className="mb-0 flex-1"
-                nativeInputProps={{
-                  onChange: (event) => update({ minZoom: event.target.value === '' ? undefined : Number(event.target.value) }),
-                  placeholder: String(defaultMinZoom),
-                  type: 'number',
-                  value: config.minZoom ?? '',
-                }}
-              />
-              <Input
-                label="Zoom max"
-                className="mb-0 flex-1"
-                nativeInputProps={{
-                  onChange: (event) => update({ maxZoom: event.target.value === '' ? undefined : Number(event.target.value) }),
-                  placeholder: String(defaultMaxZoom),
-                  type: 'number',
-                  value: config.maxZoom ?? '',
-                }}
-              />
-            </div>
-            <div className="flex gap-4">
-              <Input
-                label="Largeur de l'iframe"
-                className="mb-0 flex-1"
-                nativeInputProps={{
-                  onChange: (event) => update({ width: event.target.value }),
-                  placeholder: DEFAULT_IFRAME_WIDTH,
-                  value: config.width,
-                }}
-              />
-              <Input
-                label="Hauteur de l'iframe"
-                className="mb-0 flex-1"
-                nativeInputProps={{
-                  onChange: (event) => update({ height: event.target.value }),
-                  placeholder: DEFAULT_IFRAME_HEIGHT,
-                  value: config.height,
-                }}
-              />
-            </div>
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <h3 className="text-sm font-bold mb-0">Centrage et limites</h3>
-            <p className="mb-0 text-sm text-(--text-mention-grey)">
-              Réglez la position et le zoom de l'aperçu plus bas, puis capturez-les : «&nbsp;Utiliser le centrage de l'aperçu&nbsp;» fixe la
-              vue d'ouverture de l'iframe ; «&nbsp;Limiter le déplacement à l'aperçu&nbsp;» empêche l'utilisateur de sortir de la zone
-              visible.
-            </p>
-            <div className="flex flex-wrap items-center gap-2">
-              <Button type="button" size="small" priority="secondary" iconId="fr-icon-focus-3-line" onClick={captureView}>
-                Utiliser le centrage de l'aperçu
-              </Button>
-              <Button type="button" size="small" priority="secondary" iconId="fr-icon-crop-line" onClick={captureBounds}>
-                Limiter le déplacement à l'aperçu
-              </Button>
-              {(config.center || config.maxBounds) && (
-                <Button
-                  type="button"
-                  size="small"
-                  priority="tertiary"
-                  iconId="fr-icon-close-line"
-                  onClick={() => update({ center: undefined, maxBounds: undefined, zoom: undefined })}
-                >
-                  Réinitialiser
-                </Button>
-              )}
-            </div>
-            <span className="text-xs text-(--text-mention-grey)">
-              {config.center
-                ? `Centrage : ${config.center[0]}, ${config.center[1]} · zoom ${config.zoom}`
-                : 'Centrage : France entière (défaut)'}
-              {config.maxBounds ? ' · déplacement limité' : ''}
-            </span>
-          </div>
-        </Section>
-
-        {/* Remonte la carte au changement d'intégration : `initialView` est mount-only. */}
-        <MapPreview key={integrationId ?? 'new'} config={config} mapRef={mapRef} />
-
-        <Section title="Code à intégrer (carte)">
-          {integrationId ? (
-            <>
-              <Output label="URL" value={iframeUrl} openHref={iframeUrl} />
-              <Output label="Code iframe" value={iframeCode} />
-            </>
-          ) : (
-            <RequireIntegrationNotice />
-          )}
-        </Section>
-
-        <Section title="Code à intégrer (formulaire de test d'adresse)">
-          <p className="mb-0 text-sm text-(--text-mention-grey)">
-            Variante légère sans carte : un mini-formulaire (adresse + chauffage) qui redirige vers le site FCU pour réaliser le test. Le
-            test et la demande restent attribués à la source de l'intégration sélectionnée ci-dessus.
-          </p>
-          {integrationId ? (
-            <>
-              <Output label="URL" value={formIframeUrl} openHref={formIframeUrl} />
-              <Output label="Code iframe" value={formIframeCode} />
-            </>
-          ) : (
-            <RequireIntegrationNotice />
-          )}
-        </Section>
-      </div>
+      <Section title="Code à intégrer (formulaire de test d'adresse)">
+        <p className="mb-0 text-sm text-(--text-mention-grey)">
+          Variante légère sans carte : un mini-formulaire (adresse + chauffage) qui redirige vers le site FCU pour réaliser le test. Le test
+          et la demande restent attribués à la source de l'intégration sélectionnée ci-dessus.
+        </p>
+        {integrationId ? (
+          <>
+            <Output label="URL" value={formIframeUrl} openHref={formIframeUrl} />
+            <Output label="Code iframe" value={formIframeCode} />
+          </>
+        ) : (
+          <RequireIntegrationNotice />
+        )}
+      </Section>
     </SimplePage>
   );
 };

--- a/src/pages/admin/conversion/abus.tsx
+++ b/src/pages/admin/conversion/abus.tsx
@@ -1,0 +1,5 @@
+import { withAuthentication } from '@/server/authentication';
+
+export { default } from '@/modules/conversion-tracking/client/ConversionAbusePage';
+
+export const getServerSideProps = withAuthentication(['admin']);

--- a/src/server/cron/aggregateMonthlyStats.ts
+++ b/src/server/cron/aggregateMonthlyStats.ts
@@ -4,6 +4,7 @@ import { bulkFetchRangeFromMatomo } from '@/server/services/matomo';
 import type { MatomoActionMetrics, MatomoPageMetrics, MatomoUniqueVisitorsMetrics } from '@/server/services/matomo_types';
 import { Airtable } from '@/types/enum/Airtable';
 import { STAT_COMMUNES_SANS_RESEAU, STAT_KEY, STAT_LABEL, STAT_METHOD, STAT_PARAMS, STAT_PERIOD } from '@/types/enum/MatomoStats';
+import { formatAsISODate } from '@/utils/date';
 
 const DATA_ACTION_STATS: string[] = [
   STAT_LABEL.FORM_TEST_CARTE_UNELIGIBLE,
@@ -47,8 +48,8 @@ const getFullMonthsBetweenDates = (startDate: string, endDate: string): { startD
     // Only include the month if it's fully within the range
     if (lastDay <= end && currentMonth >= start) {
       months.push({
-        endDate: lastDay.toISOString().slice(0, 10),
-        startDate: currentMonth.toISOString().slice(0, 10),
+        endDate: formatAsISODate(lastDay),
+        startDate: formatAsISODate(currentMonth),
       });
     }
 
@@ -538,17 +539,17 @@ export const aggregateMonthlyStats = async (start?: string, end?: string) => {
     startDate.setMonth(startDate.getMonth() - 1);
     startDate.setDate(1);
   }
-  const stringStartDate = startDate.toISOString().slice(0, 10);
+  const stringStartDate = formatAsISODate(startDate);
   const endDate = end ? new Date(end) : new Date();
   if (!end) {
     endDate.setDate(0);
   }
-  const stringEndDate = endDate.toISOString().slice(0, 10);
+  const stringEndDate = formatAsISODate(endDate);
   console.info(`From ${stringStartDate} to ${stringEndDate}`);
 
   const endAirtableDate = endDate;
   endAirtableDate.setDate(endAirtableDate.getDate() + 1);
-  const stringEndAirtableDate = endAirtableDate.toISOString().slice(0, 10);
+  const stringEndAirtableDate = formatAsISODate(endAirtableDate);
 
   await Promise.all([
     saveDemandsStats(stringStartDate, stringEndAirtableDate),

--- a/src/server/db/kysely/database.ts
+++ b/src/server/db/kysely/database.ts
@@ -5,7 +5,7 @@
 
 import type { ColumnType, JSONColumnType } from 'kysely';
 
-import type { ConversionEventType, ConversionSourceConfig } from '@/modules/conversion-tracking/constants';
+import type { ConversionEventType, ConversionIpDisposition, ConversionSourceConfig } from '@/modules/conversion-tracking/constants';
 import type { AirtableLegacyRecord, PendingAssignmentChange } from '@/modules/demands/types';
 import type { EventType } from '@/modules/events/constants';
 import type { Permission } from '@/modules/permissions/types';
@@ -219,6 +219,7 @@ export interface CommunesFortPotentielPourCreationReseauxChaleurTiles {
 export interface ConversionEvents {
   created_at: Generated<Timestamp>;
   eligible: boolean | null;
+  excluded: Generated<boolean>;
   host: string | null;
   id: Generated<Int8>;
   ip: string | null;
@@ -227,6 +228,14 @@ export interface ConversionEvents {
   source: string | null;
   type: ConversionEventType;
   user_agent: string | null;
+}
+
+export interface ConversionIpRules {
+  created_at: Generated<Timestamp>;
+  created_by: string | null;
+  disposition: ConversionIpDisposition;
+  ip: string;
+  reason: string;
 }
 
 export interface ConversionSources {
@@ -977,6 +986,7 @@ export interface DB {
   communes: Communes;
   communes_fort_potentiel_pour_creation_reseaux_chaleur_tiles: CommunesFortPotentielPourCreationReseauxChaleurTiles;
   conversion_events: ConversionEvents;
+  conversion_ip_rules: ConversionIpRules;
   conversion_sources: ConversionSources;
   demand_emails: DemandEmails;
   demands: Demands;

--- a/src/server/db/migrations/20260707000000_conversion_ip_rules.ts
+++ b/src/server/db/migrations/20260707000000_conversion_ip_rules.ts
@@ -1,0 +1,38 @@
+import type { Kysely } from 'kysely';
+import { sql } from 'kysely';
+
+/**
+ * Anti-abus du module `conversion-tracking` : règles IP/CIDR (bannir ou conserver) + flag matérialisé.
+ *
+ * - `conversion_ip_rules` : décisions admin sur une IP ou plage CIDR (IPv4/IPv6). `disposition` :
+ *   `exclude` (retirée des stats) ou `keep` (IP légitime connue, à ne pas bannir — annotation).
+ *   `reason` obligatoire (mémoire de la décision). Matching par `<<=` (inclusion réseau, cross-famille
+ *   v4/v6 = `false`) ; la règle la plus spécifique (`masklen` max) l'emporte.
+ * - `conversion_events.excluded` : flag persisté sur la ligne. Indispensable car `ip`/`user_agent` sont
+ *   purgés à ~90 j → un filtrage « au read » par jointure ne couvrirait pas l'historique purgé. Toute
+ *   modification d'une règle réconcilie ce flag sur la plage (cf. service `reconcileExcludedForRange`),
+ *   ce qui nettoie les stats existantes et fige l'exclusion avant purge. `getStats` ne lit que
+ *   `excluded = false` ; `recordEvent` le repose à l'insert (règle « collante »).
+ *
+ * Cf. `src/modules/conversion-tracking/AGENTS.md`.
+ */
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`
+    ALTER TABLE conversion_events ADD COLUMN excluded boolean NOT NULL DEFAULT false;
+
+    CREATE TABLE conversion_ip_rules (
+      ip inet PRIMARY KEY,
+      disposition text NOT NULL CHECK (disposition IN ('exclude', 'keep')),
+      reason text NOT NULL,
+      created_by uuid REFERENCES users (id) ON DELETE SET NULL,
+      created_at timestamptz NOT NULL DEFAULT now()
+    );
+  `.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`
+    DROP TABLE conversion_ip_rules;
+    ALTER TABLE conversion_events DROP COLUMN excluded;
+  `.execute(db);
+}


### PR DESCRIPTION
Complète l'écran de suivi des conversion pour gérer tout ce qui est abus et spam :
- nouvel écran de controle des abus qui liste les adresses IP (90j, après elles sont mises à nulles pour le RGPD)
- possibilité d'exclure des IP si leur utilisation du site FCU est jugée non conforme.
- nouvelle table `conversion_ip_rules` pour contenir les patterns d'exlusion / rétention.