### PR TITLE
Fix style pin demande sélectionnée + hover

### DIFF
--- a/src/modules/map/client/core/common.tsx
+++ b/src/modules/map/client/core/common.tsx
@@ -24,7 +24,6 @@ export type InternalSourceId =
   | 'linear-heat-density-labels'
   | 'buildings-data-extraction-polygons'
   | 'adressesEligibles'
-  | 'adressesEligiblesSelected'
   | 'customGeojson'
   | 'geomUpdate';
 

--- a/src/modules/map/client/layers/AdressesEligiblesLayer.tsx
+++ b/src/modules/map/client/layers/AdressesEligiblesLayer.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
+import { useMapInstance, useMapReady } from '@/modules/map/client/core/MapCanvasContext';
 import { useMapFeatureClick } from '@/modules/map/client/interactions/clickHandlers';
 import { MapFitBounds } from '@/modules/map/client/interactions/MapFitBounds';
 import { MapFlyTo } from '@/modules/map/client/interactions/MapFlyTo';
@@ -13,7 +14,7 @@ type AdressesEligiblesLayerProps = {
   autoFit?: boolean;
   /** Fly to this location when it changes. */
   flyToLocation?: { center: [number, number]; zoom: number };
-  /** Id of the selected address, highlighted via the dedicated single-feature source. */
+  /** Id of the selected address, highlighted via the `selected` feature-state. */
   selectedId?: string | null;
   /** Called with the demand id when a marker is clicked. */
   onSelect?: (id: string) => void;
@@ -28,35 +29,35 @@ const toFeature = (adresse: AdresseEligible): GeoJSON.Feature => ({
 
 /**
  * Drives the built-in `adressesEligibles` source from a list of addresses, plus optional
- * auto-fit / fly-to / click-selection. The selected address is pushed into its own
- * `adressesEligiblesSelected` source so selecting a row only updates one feature instead of
- * rebuilding the whole collection.
+ * auto-fit / fly-to / click-selection. The selected address is flagged via the `selected`
+ * feature-state (same mechanism as hover), so selecting a row only toggles paint properties —
+ * no source data nor layer rebuild.
  */
 export function AdressesEligiblesLayer({ adresses, autoFit = false, flyToLocation, selectedId, onSelect }: AdressesEligiblesLayerProps) {
-  // Each source's `data` is memoized independently so `useMapLayers` only calls `setData` on the
-  // source that actually changed (selecting a row leaves the big collection's reference intact).
+  const map = useMapInstance();
+  const mapReady = useMapReady();
+
   const adressesData = useMemo<GeoJSON.FeatureCollection>(
     () => ({ features: adresses.map(toFeature), type: 'FeatureCollection' }),
     [adresses]
   );
 
-  const selectedAdresse = useMemo(
-    () => (selectedId ? adresses.find((adresse) => adresse.id === selectedId) : undefined),
-    [adresses, selectedId]
-  );
-  const selectedData = useMemo<GeoJSON.FeatureCollection>(
-    () => ({ features: selectedAdresse ? [toFeature(selectedAdresse)] : [], type: 'FeatureCollection' }),
-    [selectedAdresse]
-  );
-
-  const sources = useMemo<MapDynamicSource[]>(
-    () => [
-      { data: adressesData, id: 'adressesEligibles' },
-      { data: selectedData, id: 'adressesEligiblesSelected' },
-    ],
-    [adressesData, selectedData]
-  );
+  const sources = useMemo<MapDynamicSource[]>(() => [{ data: adressesData, id: 'adressesEligibles' }], [adressesData]);
   useMapLayers({ sources });
+
+  // Feature-states survive `setData`, so this effect only depends on the selection itself.
+  useEffect(() => {
+    if (!mapReady || !selectedId) {
+      return;
+    }
+    map.setFeatureState({ id: selectedId, source: 'adressesEligibles' }, { selected: true });
+    return () => {
+      // the source may already be gone when the whole map is tearing down
+      if (map.getSource('adressesEligibles')) {
+        map.removeFeatureState({ id: selectedId, source: 'adressesEligibles' }, 'selected');
+      }
+    };
+  }, [map, mapReady, selectedId]);
 
   // Selection on marker click — routed through the single MapInteractions handler (same feature as
   // the popup it opens). The base layer keeps its popup; this just adds the side-effect.

--- a/src/modules/map/client/layers/specs/adressesEligibles.tsx
+++ b/src/modules/map/client/layers/specs/adressesEligibles.tsx
@@ -1,8 +1,23 @@
+import type { DataDrivenPropertyValueSpecification, ExpressionSpecification } from 'maplibre-gl';
+
 import Tag from '@/components/Manager/Tag';
-import { defineLayerPopup, ifHoverElse, type MapSourceLayersSpecification } from '@/modules/map/client/core/common';
+import { defineLayerPopup, type MapSourceLayersSpecification } from '@/modules/map/client/core/common';
 import { isDefined } from '@/utils/core';
 
 const popupOffset = [0, -22] as [number, number];
+
+// `icon-image` is a layout property and layout can't read feature-states, so each visual state
+// (base / hover / selected / hover+selected) gets its own layer, toggled via `icon-opacity` (paint).
+// This keeps hover AND selection as pure feature-states: no source data rebuild, no layer rebuild.
+const hovered: ExpressionSpecification = ['boolean', ['feature-state', 'hover'], false];
+const selected: ExpressionSpecification = ['boolean', ['feature-state', 'selected'], false];
+const not = (expression: ExpressionSpecification): ExpressionSpecification => ['!', expression];
+const visibleWhen = (...conditions: ExpressionSpecification[]): DataDrivenPropertyValueSpecification<number> => [
+  'case',
+  ['all', ...conditions],
+  1,
+  0,
+];
 
 export type AdresseEligible = {
   id: string;
@@ -50,8 +65,8 @@ export const adressesEligiblesLayersSpec = [
           'icon-overlap': 'always',
         },
         paint: {
-          // display all features except the hovered one
-          'icon-opacity': ifHoverElse(0, 1),
+          // display all features except the hovered / selected ones
+          'icon-opacity': visibleWhen(not(hovered), not(selected)),
         },
         popup: Popup,
         popupOffset,
@@ -68,8 +83,8 @@ export const adressesEligiblesLayersSpec = [
           'icon-overlap': 'always',
         },
         paint: {
-          // display all features except the hovered one
-          'icon-opacity': ifHoverElse(0, 1),
+          // display all features except the hovered / selected ones
+          'icon-opacity': visibleWhen(not(hovered), not(selected)),
         },
         popup: Popup,
         popupOffset,
@@ -86,8 +101,8 @@ export const adressesEligiblesLayersSpec = [
           'icon-overlap': 'always',
         },
         paint: {
-          // display all features except the hovered one
-          'icon-opacity': ifHoverElse(0, 1),
+          // display all features except the hovered / selected ones
+          'icon-opacity': visibleWhen(not(hovered), not(selected)),
         },
         popup: Popup,
         popupOffset,
@@ -111,8 +126,41 @@ export const adressesEligiblesLayersSpec = [
           'icon-size': 1.2,
         },
         paint: {
-          // only display the hovered feature
-          'icon-opacity': ifHoverElse(1, 0),
+          // only display the hovered feature, unless it is the selected one (red layers below)
+          'icon-opacity': visibleWhen(hovered, not(selected)),
+        },
+        type: 'symbol',
+        unselectable: true,
+      },
+      {
+        id: 'adressesEligibles-selected',
+        isVisible: () => true,
+        layout: {
+          'icon-anchor': 'bottom',
+          'icon-image': 'marker-red',
+          'icon-offset': [0, 5],
+          'icon-overlap': 'always',
+        },
+        paint: {
+          // only display the selected feature when not hovered
+          'icon-opacity': visibleWhen(selected, not(hovered)),
+        },
+        type: 'symbol',
+        unselectable: true,
+      },
+      {
+        id: 'adressesEligibles-selected-hover',
+        isVisible: () => true,
+        layout: {
+          'icon-anchor': 'bottom',
+          'icon-image': 'marker-red',
+          'icon-offset': [0, 5],
+          'icon-overlap': 'always',
+          'icon-size': 1.2,
+        },
+        paint: {
+          // only display the selected feature while hovered
+          'icon-opacity': visibleWhen(selected, hovered),
         },
         type: 'symbol',
         unselectable: true,
@@ -124,28 +172,5 @@ export const adressesEligiblesLayersSpec = [
       type: 'geojson',
     },
     sourceId: 'adressesEligibles',
-  },
-  {
-    // Source dédiée au point sélectionné (0 ou 1 feature)
-    layers: [
-      {
-        id: 'adressesEligibles-selected',
-        isVisible: () => true,
-        layout: {
-          'icon-anchor': 'bottom',
-          'icon-image': 'marker-red',
-          'icon-offset': [0, 5],
-          'icon-overlap': 'always',
-        },
-        type: 'symbol',
-        unselectable: true,
-      },
-    ],
-    source: {
-      data: { features: [], type: 'FeatureCollection' },
-      promoteId: 'id',
-      type: 'geojson',
-    },
-    sourceId: 'adressesEligiblesSelected',
   },
 ] as const satisfies readonly MapSourceLayersSpecification[];


### PR DESCRIPTION
Permet de passer de 
<img width="127" height="138" alt="image" src="https://github.com/user-attachments/assets/71fda0db-3b41-45c6-8413-e8d3df7b9924" />
à
<img width="130" height="110" alt="image" src="https://github.com/user-attachments/assets/80838912-81c7-4b41-94bc-4c5edc2e1aa5" />

Cad pas de bleu élargit au hover. => c'est du rouge maintenant qui s'élargit.

Simplifie aussi les couches et améliore un peu les performances.