### PR TITLE
Ajout d'un champ commentaire utilisateur sur les demandes de raccordement

### DIFF
--- a/src/components/EligibilityForm/components/ContactForm.tsx
+++ b/src/components/EligibilityForm/components/ContactForm.tsx
@@ -32,6 +32,7 @@ export const ContactForm = ({ onSubmit, isLoading, cardMode, city }: ContactForm
 
   const { form, Form, Field, Fieldset, FieldsetLegend, FieldWrapper, Submit, useValue } = useForm({
     defaultValues: {
+      commentUser: '',
       company: userInfo.company ?? '',
       companyType: userInfo.companyType ?? '',
       demandArea: undefined as unknown as number,

--- a/src/components/EligibilityForm/components/DemandContactFields.tsx
+++ b/src/components/EligibilityForm/components/DemandContactFields.tsx
@@ -17,6 +17,7 @@ export type FormUi = {
     NumberInput: ComponentType<any>;
     PhoneInput: ComponentType<any>;
     Select: ComponentType<any>;
+    Textarea: ComponentType<any>;
   };
   FieldWrapper: ComponentType<HTMLAttributes<HTMLDivElement>>;
   Fieldset: ComponentType<HTMLAttributes<HTMLFieldSetElement>>;
@@ -154,6 +155,13 @@ export const DemandContactFields = <TFormUi extends FormUi>({
           }))}
         />
       )}
+      <Field.Textarea
+        label={fieldLabelInformation.commentUser}
+        name={fieldName('commentUser')}
+        nativeTextAreaProps={{
+          rows: 4,
+        }}
+      />
     </>
   );
 };

--- a/src/modules/chaleur-renouvelable/server/service.ts
+++ b/src/modules/chaleur-renouvelable/server/service.ts
@@ -195,6 +195,7 @@ const createRaccordableDemand = async (input: DemandeChaleurRenouvelable): Promi
     {
       address: input.address,
       city: input.geoAddress.city,
+      commentUser: input.comments ?? '',
       company: organizationName,
       companyType: demandStructure.companyType,
       coords: { lat, lon },

--- a/src/modules/demands/client/Comment.tsx
+++ b/src/modules/demands/client/Comment.tsx
@@ -13,30 +13,32 @@ const Comment = <T extends Demand>({
 }: {
   demand: T;
   field: 'comment_gestionnaire' | 'comment_fcu' | 'comment_user';
-  updateDemand: (demandId: string, demand: Partial<T>) => Promise<void>;
+  updateDemand?: (demandId: string, demand: Partial<T>) => Promise<void>;
   disabled?: boolean;
 }) => {
   const [value, setValue] = useState(demand[field]);
 
   const debouncedUpdateDemand = useMemo(
     () =>
-      debounce(
-        (value: string) =>
-          updateDemand(demand.id, {
-            [field]: value,
-          } as Partial<T>),
-        500
-      ),
-    [demand.id, updateDemand]
+      updateDemand
+        ? debounce(
+            (value: string) =>
+              updateDemand(demand.id, {
+                [field]: value,
+              } as Partial<T>),
+            500
+          )
+        : undefined,
+    [demand.id, field, updateDemand]
   );
 
-  useEffect(() => () => debouncedUpdateDemand.cancel(), [debouncedUpdateDemand]);
+  useEffect(() => () => debouncedUpdateDemand?.cancel(), [debouncedUpdateDemand]);
 
   const onChangeHandler = useCallback(
     (e: ChangeEvent<HTMLTextAreaElement>) => {
       const value = e.target.value;
       setValue(value);
-      debouncedUpdateDemand(value);
+      debouncedUpdateDemand?.(value);
     },
     [debouncedUpdateDemand]
   );

--- a/src/modules/demands/client/Comment.tsx
+++ b/src/modules/demands/client/Comment.tsx
@@ -12,7 +12,7 @@ const Comment = <T extends Demand>({
   disabled = false,
 }: {
   demand: T;
-  field: 'comment_gestionnaire' | 'comment_fcu';
+  field: 'comment_gestionnaire' | 'comment_fcu' | 'comment_user';
   updateDemand: (demandId: string, demand: Partial<T>) => Promise<void>;
   disabled?: boolean;
 }) => {

--- a/src/modules/demands/constants.ts
+++ b/src/modules/demands/constants.ts
@@ -116,6 +116,7 @@ export const zAdminUpdateDemandInput = z.object({
 export const zCreateDemandInput = z.object({
   address: z.string().trim(),
   city: z.string(),
+  commentUser: z.string().trim().optional(),
   company: z.string().optional().default(''),
   companyType: z.string().optional().default(''),
   coords: z.object({
@@ -177,6 +178,7 @@ export type TypeDeChauffageLabel = (typeof typesDeChauffageLabels)[number];
 export const availableStructures = ['Tertiaire', 'Copropriété', 'Bailleur social', 'Maison individuelle', 'Autre'] as const;
 
 export const fieldLabelInformation = {
+  commentUser: 'Si besoin, vous pouvez ajouter ici toute autre information utile liée à votre projet',
   company: 'Nom de votre structure',
   companyTitle: 'Votre structure',
   companyType: {
@@ -229,6 +231,7 @@ export const fieldLabelInformation = {
 export type DemandCompanyType = (typeof fieldLabelInformation.companyType.inputs)[number]['value'];
 
 const demandContactShape = {
+  commentUser: z.string().trim().optional().default(''),
   company: z.string().optional().default(''),
   companyType: z.string().optional().default(''),
   demandArea: z.number().optional(),
@@ -361,6 +364,7 @@ export const zCreateBatchDemandInput = z.object({
     .array(zBatchDemandAddressSchema)
     .min(1, 'Au moins une adresse doit être sélectionnée')
     .max(50, 'Maximum 50 adresses par demande'),
+  commentUser: z.string().trim().optional().default(''),
   contact: zBatchDemandContactSchema.optional(),
   termOfUse: z.boolean().refine((val) => val, 'Vous devez accepter les conditions'),
 });

--- a/src/modules/demands/constants.validation.spec.ts
+++ b/src/modules/demands/constants.validation.spec.ts
@@ -65,6 +65,26 @@ describe('zContactFormCreateDemandInput', () => {
       const result = zContactFormCreateDemandInput.safeParse(input);
       expect(result.success).toBe(expectedOutput);
     });
+
+    it('accepte un commentaire utilisateur optionnel et le trim', () => {
+      const result = zContactFormCreateDemandInput.safeParse({
+        ...validBaseInput,
+        commentUser: '  Projet déjà audité.  ',
+      });
+
+      expect(result).toStrictEqual({
+        data: {
+          ...validBaseInput,
+          commentUser: 'Projet déjà audité.',
+          company: '',
+          companyType: '',
+          demandCompanyName: '',
+          demandCompanyType: '',
+          phone: '',
+        },
+        success: true,
+      });
+    });
   });
 
   describe('validation du téléphone', () => {

--- a/src/modules/demands/server/creation-batch.ts
+++ b/src/modules/demands/server/creation-batch.ts
@@ -45,6 +45,7 @@ const getBatchDemandContactFromUser = async (userId: string): Promise<BatchDeman
   const { structure, companyType } = structureTypeToDemandContact[userContact.structure_type ?? 'autre'];
 
   return {
+    commentUser: '',
     company: userContact.structure_name || '',
     companyType: companyType ?? '',
     demandArea: undefined,
@@ -96,6 +97,7 @@ export const createBatchDemands = async (
         {
           address: testAddress?.ban_address || '',
           city: eligibility.commune.nom || '',
+          commentUser: contact.commentUser || input.commentUser,
           company: contact.company,
           companyType: contact.companyType,
           coords,

--- a/src/modules/demands/server/creation-user.integration.spec.ts
+++ b/src/modules/demands/server/creation-user.integration.spec.ts
@@ -153,6 +153,20 @@ describe('creation-user', () => {
       expect(demandInDb?.user_id).toBeNull();
     });
 
+    it('stocke le commentaire utilisateur dans une colonne dédiée', async () => {
+      const input = buildDemandInput({
+        commentUser: 'Projet voté en assemblée générale.',
+      });
+
+      const result = await createDemand(input, { userId: testUserId });
+
+      const demandInDb = await kdb.selectFrom('demands').select(['comment_user']).where('id', '=', result.id).executeTakeFirst();
+
+      expect(demandInDb).toStrictEqual({
+        comment_user: 'Projet voté en assemblée générale.',
+      });
+    });
+
     it('associe une demande à une adresse de test existante', async () => {
       const input = buildDemandInput();
 

--- a/src/modules/demands/server/creation-user.ts
+++ b/src/modules/demands/server/creation-user.ts
@@ -65,6 +65,7 @@ export const createDemand = async (
   const [createdDemand] = await kdb
     .insertInto('demands')
     .values({
+      comment_user: values.commentUser || null,
       created_at: new Date(),
       legacy_values: sql<string>`${JSON.stringify(legacyRecord)}::jsonb`,
       origin_host: values.origin_host ?? null,

--- a/src/modules/demands/types.ts
+++ b/src/modules/demands/types.ts
@@ -53,6 +53,7 @@ export type Demand = AirtableLegacyRecord & {
   user_id: string | null;
   comment_gestionnaire?: string | null;
   comment_fcu?: string | null;
+  comment_user?: string | null;
   created_at: string;
   updated_at: string;
 };

--- a/src/modules/pro-eligibility-tests/client/BatchDemandMultiStepForm.tsx
+++ b/src/modules/pro-eligibility-tests/client/BatchDemandMultiStepForm.tsx
@@ -13,6 +13,7 @@ import trpc from '@/modules/trpc/client';
 
 const MAX_BATCH_DEMAND_ADDRESSES = 50;
 const emptyDedicatedContact: BatchDemandContactInfo = {
+  commentUser: '',
   company: '',
   companyType: '',
   demandArea: undefined,
@@ -58,6 +59,7 @@ export const BatchDemandMultiStepForm = ({ testId, addresses, onSuccess }: Batch
         heatingEnergy: undefined as unknown as 'électricité' | 'gaz' | 'fioul' | 'autre',
         heatingType: undefined as unknown as 'collectif' | 'individuel',
       })),
+      commentUser: '',
       contact: undefined as BatchDemandContactInfo | undefined,
       termOfUse: false,
       useDedicatedContact: false,
@@ -72,6 +74,7 @@ export const BatchDemandMultiStepForm = ({ testId, addresses, onSuccess }: Batch
     }: {
       value: {
         addresses: BatchDemandAddressData[];
+        commentUser: string;
         contact?: BatchDemandContactInfo;
         termOfUse: boolean;
         useDedicatedContact: boolean;
@@ -85,6 +88,7 @@ export const BatchDemandMultiStepForm = ({ testId, addresses, onSuccess }: Batch
       });
       await mutateAsync({
         addresses: value.addresses,
+        commentUser: value.commentUser,
         contact: isAdmin && value.useDedicatedContact ? value.contact : undefined,
         termOfUse: value.termOfUse,
       });
@@ -183,6 +187,13 @@ export const BatchDemandMultiStepForm = ({ testId, addresses, onSuccess }: Batch
             </div>
           </Alert>
         )}
+        <Field.Textarea
+          label="Si besoin, vous pouvez ajouter ici toute autre information utile liée à votre projet"
+          name="commentUser"
+          nativeTextAreaProps={{
+            rows: 4,
+          }}
+        />
         <Field.Checkbox
           name="termOfUse"
           label={

--- a/src/pages/admin/demandes.tsx
+++ b/src/pages/admin/demandes.tsx
@@ -512,6 +512,13 @@ function DemandesAdmin(): React.ReactElement {
         width: '280px',
       },
       {
+        accessorKey: 'comment_user',
+        cell: ({ row }) => <Comment demand={row.original} field="comment_user" updateDemand={updateDemand} />,
+        enableSorting: false,
+        header: 'Commentaire utilisateur',
+        width: '280px',
+      },
+      {
         accessorKey: 'comment_gestionnaire',
         header: 'Commentaire Gestionnaire',
         width: '280px',

--- a/src/pages/pro/demandes.tsx
+++ b/src/pages/pro/demandes.tsx
@@ -101,6 +101,7 @@ export const demandsExportColumns: ExportColumn<DemandsListItem>[] = [
     accessorFn: (demand) => (demand['Gestionnaire Conso'] === undefined ? demand.Conso : demand['Gestionnaire Conso']) ?? 0,
     name: 'Conso gaz (MWh)',
   },
+  { accessorKey: 'comment_user', name: 'Commentaire utilisateur' },
   { accessorKey: 'comment_gestionnaire', name: 'Commentaires' },
   {
     accessorFn: (demand) => demand.access_counts.gestionnaire,
@@ -491,6 +492,13 @@ function DemandesNew(): React.ReactElement {
         filterType: 'Range',
         header: 'Conso gaz (MWh)',
         width: '120px',
+      },
+      {
+        accessorKey: 'comment_user',
+        cell: ({ row }) => <Comment demand={row.original as unknown as Demand} field="comment_user" disabled />,
+        enableSorting: false,
+        header: 'Commentaire utilisateur',
+        width: '280px',
       },
       {
         accessorKey: 'comment_gestionnaire',

--- a/src/server/db/kysely/database.ts
+++ b/src/server/db/kysely/database.ts
@@ -323,6 +323,7 @@ export interface Demands {
   airtable_id: string | null;
   comment_fcu: string | null;
   comment_gestionnaire: string | null;
+  comment_user: string | null;
   commune_code: string | null;
   created_at: Generated<Timestamp>;
   deleted_at: Timestamp | null;

--- a/src/server/db/migrations/20260720000000_add_comment_user_to_demands.ts
+++ b/src/server/db/migrations/20260720000000_add_comment_user_to_demands.ts
@@ -1,0 +1,16 @@
+import type { Kysely } from 'kysely';
+import { sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`
+    ALTER TABLE demands
+      ADD COLUMN comment_user text;
+  `.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`
+    ALTER TABLE demands
+      DROP COLUMN comment_user;
+  `.execute(db);
+}


### PR DESCRIPTION
Partout où il est possible de faire une demande de raccordement, l'utilisateur (ou l'admin) doit avoir la possibilité de laisser un commentaire visible, mais non éditable, par le gestionnaire.