### PR TITLE
Formulaire de contribution - Demande de PDP

### DIFF
--- a/src/components/ContributionForm/ContributionForm.tsx
+++ b/src/components/ContributionForm/ContributionForm.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useState } from 'react';
 
 import Checkbox from '@/components/form/dsfr/Checkbox';
+import CallOut from '@/components/ui/CallOut';
 import { trackPostHogEvent } from '@/modules/analytics/client';
 import { Form } from '@/modules/form/Form';
 import { schemaValidation, useAppForm } from '@/modules/form/useAppForm';
@@ -195,13 +196,10 @@ function ContributionForm() {
     <>
       {isSelectedContributionNetworkClassed && (
         <>
-          <Alert
-            severity="info"
-            title="Votre réseau est classé."
-            description="Nous vous invitons à déposer le périmètre de développement prioritaire ci-dessous pour informer les bâtiments concernés de l’obligation d’étude du raccordement."
-            className="fr-mb-3w"
-            small
-          />
+          <CallOut title="Votre réseau est classé" className="fr-mb-3w">
+            Nous vous invitons à déposer le périmètre de développement prioritaire ci-dessous pour informer les bâtiments concernés de
+            l’obligation d’étude du raccordement.
+          </CallOut>
           <form.AppField
             name="reseauDeclasse"
             listeners={{
@@ -214,7 +212,20 @@ function ContributionForm() {
           >
             {(field) => (
               <field.CheckboxField
-                label="Le réseau a été déclassé par arrêté (si celui-ci n’est pas dans la liste des réseaux déclassés et/ou que vous n’avez pas encore transmis votre délibération, merci de l’envoyer à l’adresse Laurent.Cadiou@developpement-durable.gouv.fr)"
+                label={
+                  <span>
+                    Le réseau a été déclassé par arrêté (si celui-ci n’est pas dans la{' '}
+                    <Link
+                      href="https://www.ecologie.gouv.fr/politiques-publiques/reseaux-chaleur"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      liste des réseaux déclassés
+                    </Link>{' '}
+                    et/ou que vous n’avez pas encore transmis votre délibération, merci de l’envoyer à l’adresse
+                    Laurent.Cadiou@developpement-durable.gouv.fr)
+                  </span>
+                }
                 small={false}
                 className="fr-mb-3w"
               />

--- a/src/components/ContributionForm/ContributionForm.tsx
+++ b/src/components/ContributionForm/ContributionForm.tsx
@@ -251,14 +251,14 @@ function ContributionForm() {
     </>
   );
 
-  const renderNetworkFields = (withConstructionFields: boolean) => (
+  const renderReseauFields = (withDateMiseEnService: boolean) => (
     <>
       {renderSncuIdentificationFields(true)}
       <form.AppField name="nomReseau">{(field) => <field.TextField label="Nom du réseau :" />}</form.AppField>
       <form.AppField name="localisation">{(field) => <field.TextField label="Localisation :" />}</form.AppField>
       <form.AppField name="gestionnaire">{(field) => <field.TextField label="Gestionnaire :" />}</form.AppField>
       <form.AppField name="maitreOuvrage">{(field) => <field.TextField label="Maître d'ouvrage :" />}</form.AppField>
-      {withConstructionFields && (
+      {withDateMiseEnService && (
         <>
           <form.AppField name="dateMiseEnServicePrevisionnelle">
             {(field) => <field.TextField label="Date de mise en service prévisionnelle :" />}
@@ -355,8 +355,8 @@ function ContributionForm() {
         {(field) => <field.RadioField label="Vous souhaitez :" options={typeDemandeOptions} />}
       </form.AppField>
 
-      {typeDemande === 'ajout tracé réseau existant' && renderNetworkFields(false)}
-      {typeDemande === 'ajout tracé réseau en construction' && renderNetworkFields(true)}
+      {typeDemande === 'ajout tracé réseau existant' && renderReseauFields(false)}
+      {typeDemande === 'ajout tracé réseau en construction' && renderReseauFields(true)}
       {typeDemande === 'ajout périmètre développement prioritaire' && (
         <>
           {renderSncuIdentificationFields(false)}

--- a/src/components/ContributionForm/ContributionForm.tsx
+++ b/src/components/ContributionForm/ContributionForm.tsx
@@ -2,7 +2,6 @@ import Alert from '@codegouvfr/react-dsfr/Alert';
 import { useStore } from '@tanstack/react-form';
 import Link from 'next/link';
 import { useState } from 'react';
-import { z } from 'zod';
 
 import { trackPostHogEvent } from '@/modules/analytics/client';
 import { Form } from '@/modules/form/Form';
@@ -10,362 +9,21 @@ import { schemaValidation, useAppForm } from '@/modules/form/useAppForm';
 import { toastErrors } from '@/modules/notification';
 import { postFormDataFetchJSON } from '@/utils/network';
 import { formatFileSize } from '@/utils/strings';
-import { nonEmptyArray } from '@/utils/typescript';
 
 import { type ContributionNetworkSearchResult, ContributionNetworkSncuField } from './ContributionNetworkSncuField';
-
-const typesUtilisateur = [
-  {
-    key: 'Collectivité',
-    label: 'une collectivité',
-  },
-  {
-    key: 'Exploitant',
-    label: 'un exploitant',
-  },
-  {
-    key: 'Autre',
-    label: 'autre',
-  },
-] as const;
-
-type TypeUtilisateur = (typeof typesUtilisateur)[number]['key'];
-
-const typesDemande = [
-  {
-    key: 'ajout tracé réseau existant',
-    label: 'ajouter le tracé d’un réseau existant',
-  },
-  {
-    key: 'ajout tracé réseau en construction',
-    label: 'ajouter le tracé d’un réseau en construction (nouveau réseau ou extension)',
-  },
-  {
-    key: 'ajout périmètre développement prioritaire',
-    label: 'ajouter un périmètre de développement prioritaire',
-  },
-  {
-    key: 'ajout schéma directeur',
-    label: 'ajouter un schéma directeur',
-  },
-  {
-    key: 'autre',
-    label: 'autre',
-  },
-] as const;
-
-type TypeDemande = (typeof typesDemande)[number]['key'];
-
-const typesDemandeWithSncuIdentification = [
-  'ajout tracé réseau existant',
-  'ajout tracé réseau en construction',
-  'ajout périmètre développement prioritaire',
-] as const satisfies readonly TypeDemande[];
-
-export const filesLimits = {
-  maxFileSize: 50 * 1024 * 1024,
-  maxFiles: 10,
-  maxTotalFileSize: 250 * 1024 * 1024,
-};
-
-export const geoAllowedExtensions = [
-  '.geojson',
-  '.json',
-  '.shp',
-  '.shx',
-  '.dbf',
-  '.prj',
-  '.cpg',
-  '.qmd',
-  '.kml',
-  '.kmz',
-  '.gpkg',
-  '.zip',
-  '.pdf',
-];
-
-export const docAllowedExtensions = ['.pdf', '.doc', '.docx', '.odt', '.zip'];
-
-const requiredShapefileExtensions = ['.shp', '.prj'];
-
-/**
- * Validate file names against allowed extensions and shapefile completeness (.shp + .prj required).
- * Returns an error message if invalid, or null if valid.
- */
-const validateFileNames = (fileNames: string[], allowedExtensions: string[]): string | null => {
-  // Ensure all files are allowed
-  for (const name of fileNames) {
-    const ext = `.${name.split('.').pop()?.toLowerCase()}`;
-    if (!allowedExtensions.includes(ext)) {
-      return `L'extension "${ext}" du fichier "${name}" n'est pas autorisée. Extensions acceptées : ${allowedExtensions.join(', ')}.`;
-    }
-  }
-
-  // Ensure all shapefiles are complete (shp + prj). The name is not checked.
-  const extensions = fileNames.map((name) => `.${name.split('.').pop()?.toLowerCase()}`);
-  const shapefileExtensions = ['.shp', '.shx', '.dbf', '.prj', '.cpg'];
-  if (extensions.some((ext) => shapefileExtensions.includes(ext))) {
-    const missing = requiredShapefileExtensions.filter((ext) => !extensions.includes(ext));
-    if (missing.length > 0) {
-      return `Pour un Shapefile, les fichiers ${requiredShapefileExtensions.join(' et ')} sont requis. Fichier(s) manquant(s) : ${missing.join(', ')}.`;
-    }
-  }
-
-  return null;
-};
-
-// sync checks only — the async zip inspection is validated separately (field level on the
-// form, extra superRefine on the API schema) because a form-level async validator flickers
-const createFilesSchema = (allowedExtensions: string[]) =>
-  z
-    .array(z.instanceof(File), { error: 'Veuillez choisir un ou plusieurs fichiers' })
-    .refine((files) => files.length <= filesLimits.maxFiles, {
-      error: `Vous devez choisir au maximum ${filesLimits.maxFiles} fichiers.`,
-    })
-    .refine((files) => files.every((file) => file.size <= filesLimits.maxFileSize), {
-      error: `Chaque fichier doit être inférieur à ${formatFileSize(filesLimits.maxFileSize)}.`,
-    })
-    .refine((files) => files.reduce((acc, file) => acc + file.size, 0) <= filesLimits.maxTotalFileSize, {
-      error: `Le total des fichier doit être inférieur à ${formatFileSize(filesLimits.maxTotalFileSize)}.`,
-    })
-    .superRefine((files, ctx) => {
-      const directError = validateFileNames(
-        files.map((f) => f.name),
-        allowedExtensions
-      );
-      if (directError) {
-        ctx.addIssue({ code: 'custom', fatal: true, message: directError });
-        return z.NEVER;
-      }
-    });
-
-/**
- * Async inspection of uploaded .zip archives: their inner file names must match the
- * allowed extensions. Returns an error message, or null when everything is valid.
- * Revalidation re-runs on every change: the inspection is cached per File.
- */
-const createZipInspector = (allowedExtensions: string[]) => {
-  const zipInspectionCache = new WeakMap<File, string | null>();
-
-  return async (files: File[]): Promise<string | null> => {
-    for (const file of files) {
-      if (!file.name.toLowerCase().endsWith('.zip')) {
-        continue;
-      }
-      let zipError = zipInspectionCache.get(file);
-      if (zipError === undefined) {
-        const JSZip = (await import('jszip')).default;
-        const zip = await JSZip.loadAsync(await file.arrayBuffer());
-        const zipFileNames = Object.values(zip.files)
-          .filter((entry) => !entry.dir)
-          .map((entry) => entry.name.split('/').pop()!);
-        zipError = validateFileNames(
-          zipFileNames,
-          allowedExtensions.filter((e) => e !== '.zip')
-        );
-        zipInspectionCache.set(file, zipError);
-      }
-      if (zipError) {
-        return `Dans "${file.name}" : ${zipError}`;
-      }
-    }
-    return null;
-  };
-};
-
-// full validation for the API schema: sync checks + zip inspection in one schema
-const createFilesSchemaWithZipInspection = (allowedExtensions: string[]) => {
-  const inspectZips = createZipInspector(allowedExtensions);
-  return createFilesSchema(allowedExtensions).superRefine(async (files, ctx) => {
-    const zipError = await inspectZips(files);
-    if (zipError) {
-      ctx.addIssue({ code: 'custom', fatal: true, message: zipError });
-      return z.NEVER;
-    }
-  });
-};
-
-const stringSchema = z.string({ error: 'Ce champ est obligatoire' });
-
-const sncuIdentificationFieldsShape = {
-  identifiantReseau: z.string().optional(),
-  reseauSansIdentifiantSNCU: z.boolean().optional(),
-};
-
-export const zCommonFormData = z.object({
-  dansCadreDemandeADEME: z.boolean({ error: 'Ce choix est obligatoire' }),
-  email: z.email("L'adresse email n'est pas valide"),
-  nom: z.string({ error: 'Ce champ est obligatoire' }).min(1, 'Ce champ est obligatoire'),
-  prenom: z.string({ error: 'Ce champ est obligatoire' }).min(1, 'Ce champ est obligatoire'),
-  typeUtilisateur: z.enum(nonEmptyArray(typesUtilisateur.map((w) => w.key)), { error: 'Ce choix est obligatoire' }),
-  typeUtilisateurAutre: z.string().optional(),
-});
-
-// typeUtilisateurAutre is only required when typeUtilisateur is "Autre".
-// when: () => true because zod skips the checks of a schema whose base parse has an
-// aborting issue (e.g. a missing required sub-field) — the conditional requirement
-// must still be reported alongside the other field errors.
-export const isTypeUtilisateurAutreValid = (data: { typeUtilisateur?: string; typeUtilisateurAutre?: string }) =>
-  data.typeUtilisateur !== 'Autre' || !!data.typeUtilisateurAutre;
-export const typeUtilisateurAutreRefineParams = { message: 'Ce champ est obligatoire', path: ['typeUtilisateurAutre'], when: () => true };
-
-// emailReferentCommercial is only required when the network is open to connections
-// (typeDemande, present in every union branch, keeps the structural type compatible)
-export const isEmailReferentCommercialValid = (data: {
-  typeDemande?: string;
-  ouvertAuxRaccordements?: boolean;
-  emailReferentCommercial?: string;
-}) => !data.ouvertAuxRaccordements || !!data.emailReferentCommercial;
-export const emailReferentCommercialRefineParams = {
-  message: 'Le référent commercial est obligatoire si le réseau est ouvert aux raccordements',
-  path: ['emailReferentCommercial'],
-  when: () => true, // see typeUtilisateurAutreRefineParams
-};
-
-const isSncuIdentificationRequired = (typeDemande?: string) =>
-  typesDemandeWithSncuIdentification.some((sncuTypeDemande) => sncuTypeDemande === typeDemande);
-
-export const isSncuIdentificationValid = (data: {
-  identifiantReseau?: string;
-  reseauSansIdentifiantSNCU?: boolean;
-  typeDemande?: string;
-}) => !isSncuIdentificationRequired(data.typeDemande) || !!data.identifiantReseau || data.reseauSansIdentifiantSNCU === true;
-
-export const sncuIdentificationRefineParams = {
-  message: "Sélectionnez un identifiant SNCU ou cochez l'absence d'identifiant SNCU",
-  path: ['identifiantReseau'],
-  when: () => true,
-};
-
-// branches are built twice: with the full files schema (API) and with the sync-only one (form)
-const createContributionBranches = (filesSchema: typeof createFilesSchema) => {
-  // fields shared by the two "tracé de réseau" variants
-  const reseauFieldsShape = {
-    commentaire: z.string().optional(),
-    emailReferentCommercial: z.string().optional(), // conditionally required based on ouvertAuxRaccordements (see refine below)
-    fichiers: filesSchema(geoAllowedExtensions),
-    fichiersPDP: filesSchema(geoAllowedExtensions).optional(),
-    gestionnaire: stringSchema,
-    ...sncuIdentificationFieldsShape,
-    localisation: stringSchema,
-    maitreOuvrage: stringSchema,
-    nomReseau: stringSchema,
-    ouvertAuxRaccordements: z.boolean({ error: 'Ce choix est obligatoire' }),
-    reseauDeclasse: z.boolean().optional(),
-  };
-
-  return [
-    zCommonFormData.extend({
-      typeDemande: z.literal('ajout tracé réseau existant'),
-      ...reseauFieldsShape,
-    }),
-    zCommonFormData.extend({
-      typeDemande: z.literal('ajout tracé réseau en construction'),
-      ...reseauFieldsShape,
-      dateMiseEnServicePrevisionnelle: stringSchema,
-      puissanceTotalePrevisionnelleMW: z.number({ error: 'Ce champ est obligatoire' }).positive('La puissance doit être supérieure à 0'),
-    }),
-    zCommonFormData.extend({
-      fichiers: filesSchema(geoAllowedExtensions),
-      ...sncuIdentificationFieldsShape,
-      localisation: stringSchema,
-      nomReseau: stringSchema,
-      typeDemande: z.literal('ajout périmètre développement prioritaire'),
-    }),
-    zCommonFormData.extend({
-      fichiers: filesSchema(docAllowedExtensions),
-      nomReseau: stringSchema,
-      typeDemande: z.literal('ajout schéma directeur'),
-    }),
-    zCommonFormData.extend({
-      precisions: stringSchema,
-      typeDemande: z.literal('autre'),
-    }),
-  ] as const;
-};
-
-export const zContributionFormDataBase = z.discriminatedUnion(
-  'typeDemande',
-  createContributionBranches(createFilesSchemaWithZipInspection),
-  // message when no branch matches (invalid typeDemande)
-  { error: 'Ce choix est obligatoire' }
-);
-
-export const zContributionFormData = zContributionFormDataBase
-  .refine(isEmailReferentCommercialValid, emailReferentCommercialRefineParams)
-  .refine(isTypeUtilisateurAutreValid, typeUtilisateurAutreRefineParams)
-  .refine(isSncuIdentificationValid, sncuIdentificationRefineParams);
-
-// flat superset of all branches: the form holds every possible field, the union validates the selected branch
-type ContributionFormValues = Omit<z.input<typeof zCommonFormData>, 'dansCadreDemandeADEME' | 'typeUtilisateur'> & {
-  dansCadreDemandeADEME?: boolean;
-  typeUtilisateur: TypeUtilisateur | '';
-  typeDemande: TypeDemande | '';
-  commentaire?: string;
-  dateMiseEnServicePrevisionnelle?: string;
-  emailReferentCommercial?: string;
-  fichiers?: File[];
-  fichiersPDP?: File[];
-  gestionnaire?: string;
-  identifiantReseau?: string;
-  localisation?: string;
-  maitreOuvrage?: string;
-  nomReseau?: string;
-  ouvertAuxRaccordements?: boolean;
-  precisions?: string;
-  puissanceTotalePrevisionnelleMW?: number;
-  reseauDeclasse?: boolean;
-  reseauSansIdentifiantSNCU?: boolean;
-};
-
-const contributionDefaultValues: ContributionFormValues = {
-  dansCadreDemandeADEME: undefined,
-  email: '',
-  identifiantReseau: '',
-  nom: '',
-  prenom: '',
-  reseauDeclasse: false,
-  reseauSansIdentifiantSNCU: false,
-  typeDemande: '',
-  typeUtilisateur: '',
-  typeUtilisateurAutre: '',
-};
-
-// form-side union: sync-only files schemas (the zip inspection runs at the field level),
-// plus a branch matching the unselected state (''), so an empty typeDemande still reports
-// the common-field errors instead of stopping at the discriminator
-const zContributionForm = z
-  .discriminatedUnion('typeDemande', [
-    ...createContributionBranches(createFilesSchema),
-    zCommonFormData.extend({ typeDemande: z.literal('').refine(() => false, { message: 'Ce choix est obligatoire' }) }),
-  ])
-  .refine(isEmailReferentCommercialValid, emailReferentCommercialRefineParams)
-  // the union validates the mode-consistent runtime values; unify its type for TanStack
-  .refine(isTypeUtilisateurAutreValid, typeUtilisateurAutreRefineParams)
-  .refine(isSncuIdentificationValid, sncuIdentificationRefineParams) as unknown as z.ZodType<
-  ContributionFormValues,
-  ContributionFormValues
->;
-
-// the async zip inspection runs as a field-level validator: it only concerns the
-// fichiers field, and a form-level async validator would flicker (an aborted debounced
-// run clears every form-level error until the next run rewrites them). It runs the FULL
-// files schema (sync checks + zip inspection), not just the async part: sync and async
-// results share the same error-map slot, so returning undefined would erase the sync
-// error written by the form schema (e.g. a wrong extension) right after each submit.
-const createFichiersFieldValidator = (allowedExtensions: string[], options: { required?: boolean } = {}) => {
-  const schema =
-    options.required === false
-      ? createFilesSchemaWithZipInspection(allowedExtensions).optional()
-      : createFilesSchemaWithZipInspection(allowedExtensions);
-  return async ({ value }: { value: File[] | undefined }) => {
-    const result = await schema.safeParseAsync(value);
-    return result.success ? undefined : result.error.issues[0]?.message;
-  };
-};
-const geoFichiersValidator = createFichiersFieldValidator(geoAllowedExtensions);
-const optionalGeoFichiersValidator = createFichiersFieldValidator(geoAllowedExtensions, { required: false });
-const docFichiersValidator = createFichiersFieldValidator(docAllowedExtensions);
+import {
+  contributionDefaultValues,
+  docAllowedExtensions,
+  docFichiersValidator,
+  filesLimits,
+  geoAllowedExtensions,
+  geoFichiersValidator,
+  optionalGeoFichiersValidator,
+  typesDemande,
+  typesUtilisateur,
+  zContributionForm,
+  zContributionFormData,
+} from './schema';
 
 const typeUtilisateurOptions = typesUtilisateur.map((option) => ({
   label: option.label,
@@ -382,7 +40,7 @@ const typeDemandeOptions = typesDemande.map((option) => ({
  * (network traces, priority perimeters, master plans) with file uploads.
  * The fields depend on the selected demand type (discriminated union schema).
  */
-const ContributionForm = () => {
+function ContributionForm() {
   const [formSuccess, setFormSuccess] = useState(false);
   const [selectedContributionNetwork, setSelectedContributionNetwork] = useState<ContributionNetworkSearchResult | null>(null);
 
@@ -418,6 +76,28 @@ const ContributionForm = () => {
     form.setFieldValue('fichiersPDP', undefined, { dontUpdateMeta: true });
   };
 
+  const resetSncuIdentificationFields = () => {
+    setSelectedContributionNetwork(null);
+    form.setFieldValue('identifiantReseau', '', { dontUpdateMeta: true });
+    form.setFieldValue('reseauSansIdentifiantSNCU', false, { dontUpdateMeta: true });
+    resetClassedNetworkFields();
+  };
+
+  const resetTypeDemandeDependentFields = () => {
+    resetSncuIdentificationFields();
+    form.setFieldValue('commentaire', '', { dontUpdateMeta: true });
+    form.setFieldValue('dateMiseEnServicePrevisionnelle', '', { dontUpdateMeta: true });
+    form.setFieldValue('emailReferentCommercial', '', { dontUpdateMeta: true });
+    form.setFieldValue('fichiers', undefined, { dontUpdateMeta: true });
+    form.setFieldValue('gestionnaire', '', { dontUpdateMeta: true });
+    form.setFieldValue('localisation', '', { dontUpdateMeta: true });
+    form.setFieldValue('maitreOuvrage', '', { dontUpdateMeta: true });
+    form.setFieldValue('nomReseau', '', { dontUpdateMeta: true });
+    form.setFieldValue('ouvertAuxRaccordements', undefined, { dontUpdateMeta: true });
+    form.setFieldValue('precisions', '', { dontUpdateMeta: true });
+    form.setFieldValue('puissanceTotalePrevisionnelleMW', undefined, { dontUpdateMeta: true });
+  };
+
   const handleContributionNetworkClear = () => {
     setSelectedContributionNetwork(null);
     form.setFieldValue('identifiantReseau', '');
@@ -439,7 +119,6 @@ const ContributionForm = () => {
     form.setFieldValue('maitreOuvrage', network.maitre_ouvrage ?? '');
   };
 
-  // plain render helpers (not components) shared by the demand type branches
   const renderNomReseauField = (label: string) => (
     <form.AppField name="nomReseau">{(field) => <field.TextField label={label} />}</form.AppField>
   );
@@ -619,7 +298,6 @@ const ContributionForm = () => {
       </form.AppField>
       {typeUtilisateur === 'Autre' && (
         <form.AppField name="typeUtilisateurAutre">
-          {/* only rendered when "autre" is selected, where it is expected to be filled */}
           {(field) => <field.TextField label="Précisez :" nativeInputProps={{ required: true }} />}
         </form.AppField>
       )}
@@ -648,7 +326,12 @@ const ContributionForm = () => {
         />
       )}
 
-      <form.AppField name="typeDemande">
+      <form.AppField
+        name="typeDemande"
+        listeners={{
+          onChange: () => resetTypeDemandeDependentFields(),
+        }}
+      >
         {(field) => <field.RadioField label="Vous souhaitez :" options={typeDemandeOptions} />}
       </form.AppField>
 
@@ -685,6 +368,6 @@ const ContributionForm = () => {
       <form.SubmitButton>Envoyer</form.SubmitButton>
     </Form>
   );
-};
+}
 
 export default ContributionForm;

--- a/src/components/ContributionForm/ContributionForm.tsx
+++ b/src/components/ContributionForm/ContributionForm.tsx
@@ -7,13 +7,14 @@ import Checkbox from '@/components/form/dsfr/Checkbox';
 import CallOut from '@/components/ui/CallOut';
 import { trackPostHogEvent } from '@/modules/analytics/client';
 import { Form } from '@/modules/form/Form';
-import { schemaValidation, useAppForm } from '@/modules/form/useAppForm';
+import { schemaValidation, useAppForm, withFieldGroup } from '@/modules/form/useAppForm';
 import { toastErrors } from '@/modules/notification';
 import { postFormDataFetchJSON } from '@/utils/network';
 import { formatFileSize } from '@/utils/strings';
 
 import { type ContributionNetworkSearchResult, ContributionNetworkSncuField } from './ContributionNetworkSncuField';
 import {
+  type ContributionFormValues,
   contributionDefaultValues,
   docAllowedExtensions,
   docFichiersValidator,
@@ -36,6 +37,65 @@ const typeDemandeOptions = typesDemande.map((option) => ({
   label: option.label,
   nativeInputProps: { value: option.key },
 }));
+
+const contributionFormRootFields = {
+  commentaire: 'commentaire',
+  dansCadreDemandeADEME: 'dansCadreDemandeADEME',
+  dateMiseEnServicePrevisionnelle: 'dateMiseEnServicePrevisionnelle',
+  email: 'email',
+  emailReferentCommercial: 'emailReferentCommercial',
+  fichiers: 'fichiers',
+  fichiersPDP: 'fichiersPDP',
+  gestionnaire: 'gestionnaire',
+  identifiantReseau: 'identifiantReseau',
+  localisation: 'localisation',
+  maitreOuvrage: 'maitreOuvrage',
+  nom: 'nom',
+  nomReseau: 'nomReseau',
+  ouvertAuxRaccordements: 'ouvertAuxRaccordements',
+  precisions: 'precisions',
+  prenom: 'prenom',
+  puissanceTotalePrevisionnelleMW: 'puissanceTotalePrevisionnelleMW',
+  reseauDeclasse: 'reseauDeclasse',
+  typeDemande: 'typeDemande',
+  typeUtilisateur: 'typeUtilisateur',
+  typeUtilisateurAutre: 'typeUtilisateurAutre',
+} as const;
+
+const typeDemandeStringResetFieldNames = [
+  'commentaire',
+  'dateMiseEnServicePrevisionnelle',
+  'emailReferentCommercial',
+  'gestionnaire',
+  'localisation',
+  'maitreOuvrage',
+  'nomReseau',
+  'precisions',
+] as const;
+const typeDemandeUndefinedResetFieldNames = ['fichiers', 'ouvertAuxRaccordements', 'puissanceTotalePrevisionnelleMW'] as const;
+
+type ContributionUploadConfig = {
+  allowedExtensions: string[];
+  formatsHint: string;
+  fichiersValidator: typeof geoFichiersValidator;
+};
+
+const geoUploadConfig = {
+  allowedExtensions: geoAllowedExtensions,
+  fichiersValidator: geoFichiersValidator,
+  formatsHint: 'Formats préférentiels : GeoJSON, Shapefile (au moins shp + prj), KML, GeoPackage.',
+} satisfies ContributionUploadConfig;
+
+const optionalPdpUploadConfig = {
+  ...geoUploadConfig,
+  fichiersValidator: optionalGeoFichiersValidator,
+} satisfies ContributionUploadConfig;
+
+const docUploadConfig = {
+  allowedExtensions: docAllowedExtensions,
+  fichiersValidator: docFichiersValidator,
+  formatsHint: 'Formats préférentiels : PDF, Word.',
+} satisfies ContributionUploadConfig;
 
 /**
  * Public contribution form: network managers/collectivités submit geo data
@@ -69,8 +129,6 @@ function ContributionForm() {
   const typeUtilisateur = useStore(form.store, (state) => state.values.typeUtilisateur);
   const typeDemande = useStore(form.store, (state) => state.values.typeDemande);
   const dansCadreDemandeADEME = useStore(form.store, (state) => state.values.dansCadreDemandeADEME);
-  const ouvertAuxRaccordements = useStore(form.store, (state) => state.values.ouvertAuxRaccordements);
-  const reseauDeclasse = useStore(form.store, (state) => state.values.reseauDeclasse);
   const isSelectedContributionNetworkClassed = selectedContributionNetwork?.is_classe === true;
 
   const resetClassedNetworkFields = () => {
@@ -87,17 +145,8 @@ function ContributionForm() {
 
   const resetTypeDemandeDependentFields = () => {
     resetSncuIdentificationFields();
-    form.setFieldValue('commentaire', '', { dontUpdateMeta: true });
-    form.setFieldValue('dateMiseEnServicePrevisionnelle', '', { dontUpdateMeta: true });
-    form.setFieldValue('emailReferentCommercial', '', { dontUpdateMeta: true });
-    form.setFieldValue('fichiers', undefined, { dontUpdateMeta: true });
-    form.setFieldValue('gestionnaire', '', { dontUpdateMeta: true });
-    form.setFieldValue('localisation', '', { dontUpdateMeta: true });
-    form.setFieldValue('maitreOuvrage', '', { dontUpdateMeta: true });
-    form.setFieldValue('nomReseau', '', { dontUpdateMeta: true });
-    form.setFieldValue('ouvertAuxRaccordements', undefined, { dontUpdateMeta: true });
-    form.setFieldValue('precisions', '', { dontUpdateMeta: true });
-    form.setFieldValue('puissanceTotalePrevisionnelleMW', undefined, { dontUpdateMeta: true });
+    typeDemandeStringResetFieldNames.forEach((fieldName) => form.setFieldValue(fieldName, '', { dontUpdateMeta: true }));
+    typeDemandeUndefinedResetFieldNames.forEach((fieldName) => form.setFieldValue(fieldName, undefined, { dontUpdateMeta: true }));
   };
 
   const handleContributionNetworkClear = () => {
@@ -127,163 +176,6 @@ function ContributionForm() {
       handleContributionNetworkClear();
     }
   };
-
-  const renderNomReseauField = (label: string) => (
-    <form.AppField name="nomReseau">{(field) => <field.TextField label={label} />}</form.AppField>
-  );
-
-  const renderLocalisationField = () => (
-    <form.AppField name="localisation">{(field) => <field.TextField label="Localisation :" />}</form.AppField>
-  );
-
-  const renderFichiersField = (
-    name: 'fichiers' | 'fichiersPDP',
-    label: string,
-    allowedExtensions: string[],
-    fichiersValidator: typeof geoFichiersValidator,
-    formatsHint: string
-  ) => (
-    <form.AppField name={name} validators={{ onDynamicAsync: fichiersValidator }}>
-      {(field) => (
-        <field.UploadField
-          className="fr-mb-2w"
-          label={label}
-          hint={
-            <>
-              Taille maximale : {formatFileSize(filesLimits.maxFileSize)}. Maximum {filesLimits.maxFiles} fichiers. {formatsHint}
-              <br />
-              Pour téléverser plusieurs fichiers, merci de les sélectionner simultanément et non l'un après l'autre.
-            </>
-          }
-          multiple
-          nativeInputProps={{ accept: allowedExtensions.join(',') }}
-        />
-      )}
-    </form.AppField>
-  );
-
-  const renderSncuIdentificationFields = (shouldPrefillNetworkFields: boolean) => (
-    <>
-      <form.AppField name="identifiantReseau">
-        {(field) => (
-          <field.CustomField
-            Component={ContributionNetworkSncuField}
-            label="Identifiant SNCU du réseau :"
-            hintText="Sélectionnez un identifiant dans la liste de suggestions."
-            nativeInputProps={{
-              disabled: hasNoSncuIdentifier,
-            }}
-            onNetworkClear={handleContributionNetworkClear}
-            onNetworkSelect={(network) => handleContributionNetworkSelect(network, shouldPrefillNetworkFields)}
-            selectedNetwork={selectedContributionNetwork}
-          />
-        )}
-      </form.AppField>
-      <Checkbox
-        label="Le réseau n’a pas d’identifiant SNCU"
-        className="fr-mb-3w"
-        nativeInputProps={{
-          checked: hasNoSncuIdentifier,
-          name: 'hasNoSncuIdentifier',
-          onChange: (event) => handleNoSncuIdentifierChange(event.target.checked),
-        }}
-        small={false}
-      />
-    </>
-  );
-
-  const renderClassedNetworkFields = () => (
-    <>
-      {isSelectedContributionNetworkClassed && (
-        <>
-          <CallOut title="Votre réseau est classé" className="fr-mb-3w">
-            Nous vous invitons à déposer le périmètre de développement prioritaire ci-dessous pour informer les bâtiments concernés de
-            l’obligation d’étude du raccordement.
-          </CallOut>
-          <form.AppField
-            name="reseauDeclasse"
-            listeners={{
-              onChange: ({ value }) => {
-                if (value === true) {
-                  form.setFieldValue('fichiersPDP', undefined, { dontUpdateMeta: true });
-                }
-              },
-            }}
-          >
-            {(field) => (
-              <field.CheckboxField
-                label={
-                  <span>
-                    Le réseau a été déclassé par arrêté (si celui-ci n’est pas dans la{' '}
-                    <Link
-                      href="https://www.ecologie.gouv.fr/politiques-publiques/reseaux-chaleur"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      liste des réseaux déclassés
-                    </Link>{' '}
-                    et/ou que vous n’avez pas encore transmis votre délibération, merci de l’envoyer à l’adresse
-                    Laurent.Cadiou@developpement-durable.gouv.fr)
-                  </span>
-                }
-                small={false}
-                className="fr-mb-3w"
-              />
-            )}
-          </form.AppField>
-        </>
-      )}
-      {isSelectedContributionNetworkClassed &&
-        reseauDeclasse !== true &&
-        renderFichiersField(
-          'fichiersPDP',
-          'Téléverser le périmètre de développement prioritaire :',
-          geoAllowedExtensions,
-          optionalGeoFichiersValidator,
-          'Formats préférentiels : GeoJSON, Shapefile (au moins shp + prj), KML, GeoPackage.'
-        )}
-    </>
-  );
-
-  const renderReseauFields = (withDateMiseEnService: boolean) => (
-    <>
-      {renderSncuIdentificationFields(true)}
-      {renderNomReseauField('Nom du réseau :')}
-      {renderLocalisationField()}
-      <form.AppField name="gestionnaire">{(field) => <field.TextField label="Gestionnaire :" />}</form.AppField>
-      <form.AppField name="maitreOuvrage">{(field) => <field.TextField label="Maître d'ouvrage :" />}</form.AppField>
-      {withDateMiseEnService && (
-        <>
-          <form.AppField name="dateMiseEnServicePrevisionnelle">
-            {(field) => <field.TextField label="Date de mise en service prévisionnelle :" />}
-          </form.AppField>
-          <form.AppField name="puissanceTotalePrevisionnelleMW">
-            {(field) => <field.NumberField label="Puissance totale prévisionnelle (MW) :" nativeInputProps={{ min: 0, step: 'any' }} />}
-          </form.AppField>
-        </>
-      )}
-      <form.AppField name="ouvertAuxRaccordements">
-        {(field) => <field.BooleanRadioField label="Le réseau est-il ouvert aux raccordements ?" />}
-      </form.AppField>
-      <form.AppField name="emailReferentCommercial">
-        {(field) => (
-          <field.TextField
-            label="Référent commercial à qui transmettre les demandes de raccordement"
-            nativeInputProps={{ required: ouvertAuxRaccordements === true }}
-          />
-        )}
-      </form.AppField>
-      <form.AppField name="commentaire">{(field) => <field.TextField label="Commentaire :" />}</form.AppField>
-      {renderClassedNetworkFields()}
-      {renderFichiersField(
-        'fichiers',
-        isSelectedContributionNetworkClassed && reseauDeclasse !== true ? 'Téléverser le tracé du réseau :' : 'Téléverser vos fichiers :',
-        geoAllowedExtensions,
-        geoFichiersValidator,
-        'Formats préférentiels : GeoJSON, Shapefile (au moins shp + prj), KML, GeoPackage.'
-      )}
-    </>
-  );
 
   return formSuccess ? (
     <Alert
@@ -351,39 +243,314 @@ function ContributionForm() {
         {(field) => <field.RadioField label="Vous souhaitez :" options={typeDemandeOptions} />}
       </form.AppField>
 
-      {typeDemande === 'ajout tracé réseau existant' && renderReseauFields(false)}
-      {typeDemande === 'ajout tracé réseau en construction' && renderReseauFields(true)}
+      {typeDemande === 'ajout tracé réseau existant' && (
+        <ContributionNetworkFields
+          form={form}
+          fields={contributionFormRootFields}
+          hasNoSncuIdentifier={hasNoSncuIdentifier}
+          isSelectedContributionNetworkClassed={isSelectedContributionNetworkClassed}
+          onNoSncuIdentifierChange={handleNoSncuIdentifierChange}
+          onNetworkClear={handleContributionNetworkClear}
+          onNetworkSelect={handleContributionNetworkSelect}
+          selectedContributionNetwork={selectedContributionNetwork}
+        />
+      )}
+      {typeDemande === 'ajout tracé réseau en construction' && (
+        <ContributionNetworkFields
+          form={form}
+          fields={contributionFormRootFields}
+          hasNoSncuIdentifier={hasNoSncuIdentifier}
+          isSelectedContributionNetworkClassed={isSelectedContributionNetworkClassed}
+          onNoSncuIdentifierChange={handleNoSncuIdentifierChange}
+          onNetworkClear={handleContributionNetworkClear}
+          onNetworkSelect={handleContributionNetworkSelect}
+          selectedContributionNetwork={selectedContributionNetwork}
+          withConstructionFields
+        />
+      )}
       {typeDemande === 'ajout périmètre développement prioritaire' && (
-        <>
-          {renderSncuIdentificationFields(false)}
-          {renderNomReseauField('Nom du réseau :')}
-          {renderLocalisationField()}
-          {renderFichiersField(
-            'fichiers',
-            'Téléverser vos fichiers :',
-            geoAllowedExtensions,
-            geoFichiersValidator,
-            'Formats préférentiels : GeoJSON, Shapefile (au moins shp + prj), KML, GeoPackage.'
-          )}
-        </>
+        <ContributionPriorityPerimeterFields
+          form={form}
+          fields={contributionFormRootFields}
+          hasNoSncuIdentifier={hasNoSncuIdentifier}
+          onNoSncuIdentifierChange={handleNoSncuIdentifierChange}
+          onNetworkClear={handleContributionNetworkClear}
+          onNetworkSelect={handleContributionNetworkSelect}
+          selectedContributionNetwork={selectedContributionNetwork}
+        />
       )}
-      {typeDemande === 'ajout schéma directeur' && (
-        <>
-          {renderNomReseauField('Nom du réseau ou du territoire concerné :')}
-          {renderFichiersField(
-            'fichiers',
-            'Téléverser vos fichiers :',
-            docAllowedExtensions,
-            docFichiersValidator,
-            'Formats préférentiels : PDF, Word.'
-          )}
-        </>
-      )}
+      {typeDemande === 'ajout schéma directeur' && <ContributionMasterPlanFields form={form} fields={contributionFormRootFields} />}
       {typeDemande === 'autre' && <form.AppField name="precisions">{(field) => <field.TextField label="Précisez :" />}</form.AppField>}
 
       <form.SubmitButton>Envoyer</form.SubmitButton>
     </Form>
   );
 }
+
+type ContributionNetworkSelectHandler = (network: ContributionNetworkSearchResult, shouldPrefillNetworkFields: boolean) => void;
+
+type ContributionSncuIdentificationFieldsProps = {
+  hasNoSncuIdentifier: boolean;
+  onNetworkClear: () => void;
+  onNetworkSelect: ContributionNetworkSelectHandler;
+  onNoSncuIdentifierChange: (checked: boolean) => void;
+  selectedContributionNetwork: ContributionNetworkSearchResult | null;
+  shouldPrefillNetworkFields: boolean;
+};
+
+const ContributionSncuIdentificationFields = withFieldGroup<ContributionFormValues, unknown, ContributionSncuIdentificationFieldsProps>({
+  defaultValues: contributionDefaultValues,
+  // biome-ignore lint: a named PascalCase function is required for the hooks rules.
+  render: function ContributionSncuIdentificationFieldsRender({
+    group,
+    hasNoSncuIdentifier,
+    onNetworkClear,
+    onNetworkSelect,
+    onNoSncuIdentifierChange,
+    selectedContributionNetwork,
+    shouldPrefillNetworkFields,
+  }) {
+    return (
+      <>
+        <group.AppField name="identifiantReseau">
+          {(field) => (
+            <field.CustomField
+              Component={ContributionNetworkSncuField}
+              label="Identifiant SNCU du réseau :"
+              nativeInputProps={{
+                disabled: hasNoSncuIdentifier,
+              }}
+              onNetworkClear={onNetworkClear}
+              onNetworkSelect={(network) => onNetworkSelect(network, shouldPrefillNetworkFields)}
+              selectedNetwork={selectedContributionNetwork}
+            />
+          )}
+        </group.AppField>
+        <Checkbox
+          label="Le réseau n’a pas d’identifiant SNCU"
+          className="fr-mb-3w"
+          nativeInputProps={{
+            checked: hasNoSncuIdentifier,
+            name: 'hasNoSncuIdentifier',
+            onChange: (event) => onNoSncuIdentifierChange(event.target.checked),
+          }}
+          small={false}
+        />
+      </>
+    );
+  },
+});
+
+type ContributionUploadFieldProps = {
+  label: string;
+  name: 'fichiers' | 'fichiersPDP';
+  uploadConfig: ContributionUploadConfig;
+};
+
+const ContributionUploadField = withFieldGroup<ContributionFormValues, unknown, ContributionUploadFieldProps>({
+  defaultValues: contributionDefaultValues,
+  // biome-ignore lint: a named PascalCase function is required for the hooks rules.
+  render: function ContributionUploadFieldRender({ group, label, name, uploadConfig }) {
+    return (
+      <group.AppField name={name} validators={{ onDynamicAsync: uploadConfig.fichiersValidator }}>
+        {(field) => (
+          <field.UploadField
+            className="fr-mb-2w"
+            label={label}
+            hint={
+              <>
+                Taille maximale : {formatFileSize(filesLimits.maxFileSize)}. Maximum {filesLimits.maxFiles} fichiers.{' '}
+                {uploadConfig.formatsHint}
+                <br />
+                Pour téléverser plusieurs fichiers, merci de les sélectionner simultanément et non l'un après l'autre.
+              </>
+            }
+            multiple
+            nativeInputProps={{ accept: uploadConfig.allowedExtensions.join(',') }}
+          />
+        )}
+      </group.AppField>
+    );
+  },
+});
+
+type ContributionNetworkFieldsProps = Omit<ContributionSncuIdentificationFieldsProps, 'shouldPrefillNetworkFields'> & {
+  isSelectedContributionNetworkClassed: boolean;
+  withConstructionFields?: boolean;
+};
+
+const ContributionNetworkFields = withFieldGroup<ContributionFormValues, unknown, ContributionNetworkFieldsProps>({
+  defaultValues: contributionDefaultValues,
+  // biome-ignore lint: a named PascalCase function is required for the hooks rules.
+  render: function ContributionNetworkFieldsRender({
+    group,
+    hasNoSncuIdentifier,
+    isSelectedContributionNetworkClassed,
+    onNetworkClear,
+    onNetworkSelect,
+    onNoSncuIdentifierChange,
+    selectedContributionNetwork,
+    withConstructionFields = false,
+  }) {
+    const ouvertAuxRaccordements = useStore(group.store, (state) => state.values.ouvertAuxRaccordements);
+    const reseauDeclasse = useStore(group.store, (state) => state.values.reseauDeclasse);
+    const traceUploadLabel =
+      isSelectedContributionNetworkClassed && reseauDeclasse !== true ? 'Téléverser le tracé du réseau :' : 'Téléverser vos fichiers :';
+
+    return (
+      <>
+        <ContributionSncuIdentificationFields
+          form={group}
+          fields={contributionFormRootFields}
+          hasNoSncuIdentifier={hasNoSncuIdentifier}
+          onNetworkClear={onNetworkClear}
+          onNetworkSelect={onNetworkSelect}
+          onNoSncuIdentifierChange={onNoSncuIdentifierChange}
+          selectedContributionNetwork={selectedContributionNetwork}
+          shouldPrefillNetworkFields
+        />
+        <group.AppField name="nomReseau">{(field) => <field.TextField label="Nom du réseau :" />}</group.AppField>
+        <group.AppField name="localisation">{(field) => <field.TextField label="Localisation :" />}</group.AppField>
+        <group.AppField name="gestionnaire">{(field) => <field.TextField label="Gestionnaire :" />}</group.AppField>
+        <group.AppField name="maitreOuvrage">{(field) => <field.TextField label="Maître d'ouvrage :" />}</group.AppField>
+        {withConstructionFields && (
+          <>
+            <group.AppField name="dateMiseEnServicePrevisionnelle">
+              {(field) => <field.TextField label="Date de mise en service prévisionnelle :" />}
+            </group.AppField>
+            <group.AppField name="puissanceTotalePrevisionnelleMW">
+              {(field) => <field.NumberField label="Puissance totale prévisionnelle (MW) :" nativeInputProps={{ min: 0, step: 'any' }} />}
+            </group.AppField>
+          </>
+        )}
+        <group.AppField name="ouvertAuxRaccordements">
+          {(field) => <field.BooleanRadioField label="Le réseau est-il ouvert aux raccordements ?" />}
+        </group.AppField>
+        <group.AppField name="emailReferentCommercial">
+          {(field) => (
+            <field.TextField
+              label="Référent commercial à qui transmettre les demandes de raccordement"
+              nativeInputProps={{ required: ouvertAuxRaccordements === true }}
+            />
+          )}
+        </group.AppField>
+        <group.AppField name="commentaire">{(field) => <field.TextField label="Commentaire :" />}</group.AppField>
+        {isSelectedContributionNetworkClassed && (
+          <>
+            <CallOut title="Votre réseau est classé" className="fr-mb-3w">
+              Nous vous invitons à déposer le périmètre de développement prioritaire ci-dessous pour informer les bâtiments concernés de
+              l’obligation d’étude du raccordement.
+            </CallOut>
+            <group.AppField
+              name="reseauDeclasse"
+              listeners={{
+                onChange: ({ value }) => {
+                  if (value === true) {
+                    group.setFieldValue('fichiersPDP', undefined, { dontUpdateMeta: true });
+                  }
+                },
+              }}
+            >
+              {(field) => (
+                <field.CheckboxField
+                  label={
+                    <span>
+                      Le réseau a été déclassé par arrêté (si celui-ci n’est pas dans la{' '}
+                      <Link
+                        href="https://www.ecologie.gouv.fr/politiques-publiques/reseaux-chaleur"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        liste des réseaux déclassés
+                      </Link>{' '}
+                      et/ou que vous n’avez pas encore transmis votre délibération, merci de l’envoyer à l’adresse
+                      Laurent.Cadiou@developpement-durable.gouv.fr)
+                    </span>
+                  }
+                  small={false}
+                  className="fr-mb-3w"
+                />
+              )}
+            </group.AppField>
+          </>
+        )}
+        {isSelectedContributionNetworkClassed && reseauDeclasse !== true && (
+          <ContributionUploadField
+            form={group}
+            fields={contributionFormRootFields}
+            name="fichiersPDP"
+            label="Téléverser le périmètre de développement prioritaire :"
+            uploadConfig={optionalPdpUploadConfig}
+          />
+        )}
+        <ContributionUploadField
+          form={group}
+          fields={contributionFormRootFields}
+          name="fichiers"
+          label={traceUploadLabel}
+          uploadConfig={geoUploadConfig}
+        />
+      </>
+    );
+  },
+});
+
+type ContributionPriorityPerimeterFieldsProps = Omit<ContributionSncuIdentificationFieldsProps, 'shouldPrefillNetworkFields'>;
+
+const ContributionPriorityPerimeterFields = withFieldGroup<ContributionFormValues, unknown, ContributionPriorityPerimeterFieldsProps>({
+  defaultValues: contributionDefaultValues,
+  // biome-ignore lint: a named PascalCase function is required for the hooks rules.
+  render: function ContributionPriorityPerimeterFieldsRender({
+    group,
+    hasNoSncuIdentifier,
+    onNetworkClear,
+    onNetworkSelect,
+    onNoSncuIdentifierChange,
+    selectedContributionNetwork,
+  }) {
+    return (
+      <>
+        <ContributionSncuIdentificationFields
+          form={group}
+          fields={contributionFormRootFields}
+          hasNoSncuIdentifier={hasNoSncuIdentifier}
+          onNetworkClear={onNetworkClear}
+          onNetworkSelect={onNetworkSelect}
+          onNoSncuIdentifierChange={onNoSncuIdentifierChange}
+          selectedContributionNetwork={selectedContributionNetwork}
+          shouldPrefillNetworkFields={false}
+        />
+        <group.AppField name="nomReseau">{(field) => <field.TextField label="Nom du réseau :" />}</group.AppField>
+        <group.AppField name="localisation">{(field) => <field.TextField label="Localisation :" />}</group.AppField>
+        <ContributionUploadField
+          form={group}
+          fields={contributionFormRootFields}
+          name="fichiers"
+          label="Téléverser vos fichiers :"
+          uploadConfig={geoUploadConfig}
+        />
+      </>
+    );
+  },
+});
+
+const ContributionMasterPlanFields = withFieldGroup<ContributionFormValues, unknown, Record<never, never>>({
+  defaultValues: contributionDefaultValues,
+  // biome-ignore lint: a named PascalCase function is required for the hooks rules.
+  render: function ContributionMasterPlanFieldsRender({ group }) {
+    return (
+      <>
+        <group.AppField name="nomReseau">{(field) => <field.TextField label="Nom du réseau ou du territoire concerné :" />}</group.AppField>
+        <ContributionUploadField
+          form={group}
+          fields={contributionFormRootFields}
+          name="fichiers"
+          label="Téléverser vos fichiers :"
+          uploadConfig={docUploadConfig}
+        />
+      </>
+    );
+  },
+});
 
 export default ContributionForm;

--- a/src/components/ContributionForm/ContributionForm.tsx
+++ b/src/components/ContributionForm/ContributionForm.tsx
@@ -7,14 +7,13 @@ import Checkbox from '@/components/form/dsfr/Checkbox';
 import CallOut from '@/components/ui/CallOut';
 import { trackPostHogEvent } from '@/modules/analytics/client';
 import { Form } from '@/modules/form/Form';
-import { schemaValidation, useAppForm, withFieldGroup } from '@/modules/form/useAppForm';
+import { schemaValidation, useAppForm } from '@/modules/form/useAppForm';
 import { toastErrors } from '@/modules/notification';
 import { postFormDataFetchJSON } from '@/utils/network';
 import { formatFileSize } from '@/utils/strings';
 
 import { type ContributionNetworkSearchResult, ContributionNetworkSncuField } from './ContributionNetworkSncuField';
 import {
-  type ContributionFormValues,
   contributionDefaultValues,
   docAllowedExtensions,
   docFichiersValidator,
@@ -37,30 +36,6 @@ const typeDemandeOptions = typesDemande.map((option) => ({
   label: option.label,
   nativeInputProps: { value: option.key },
 }));
-
-const contributionFormRootFields = {
-  commentaire: 'commentaire',
-  dansCadreDemandeADEME: 'dansCadreDemandeADEME',
-  dateMiseEnServicePrevisionnelle: 'dateMiseEnServicePrevisionnelle',
-  email: 'email',
-  emailReferentCommercial: 'emailReferentCommercial',
-  fichiers: 'fichiers',
-  fichiersPDP: 'fichiersPDP',
-  gestionnaire: 'gestionnaire',
-  identifiantReseau: 'identifiantReseau',
-  localisation: 'localisation',
-  maitreOuvrage: 'maitreOuvrage',
-  nom: 'nom',
-  nomReseau: 'nomReseau',
-  ouvertAuxRaccordements: 'ouvertAuxRaccordements',
-  precisions: 'precisions',
-  prenom: 'prenom',
-  puissanceTotalePrevisionnelleMW: 'puissanceTotalePrevisionnelleMW',
-  reseauDeclasse: 'reseauDeclasse',
-  typeDemande: 'typeDemande',
-  typeUtilisateur: 'typeUtilisateur',
-  typeUtilisateurAutre: 'typeUtilisateurAutre',
-} as const;
 
 const typeDemandeStringResetFieldNames = [
   'commentaire',
@@ -129,6 +104,8 @@ function ContributionForm() {
   const typeUtilisateur = useStore(form.store, (state) => state.values.typeUtilisateur);
   const typeDemande = useStore(form.store, (state) => state.values.typeDemande);
   const dansCadreDemandeADEME = useStore(form.store, (state) => state.values.dansCadreDemandeADEME);
+  const ouvertAuxRaccordements = useStore(form.store, (state) => state.values.ouvertAuxRaccordements);
+  const reseauDeclasse = useStore(form.store, (state) => state.values.reseauDeclasse);
   const isSelectedContributionNetworkClassed = selectedContributionNetwork?.is_classe === true;
 
   const resetClassedNetworkFields = () => {
@@ -176,6 +153,141 @@ function ContributionForm() {
       handleContributionNetworkClear();
     }
   };
+
+  const renderSncuIdentificationFields = (shouldPrefillNetworkFields: boolean) => (
+    <>
+      <form.AppField name="identifiantReseau">
+        {(field) => (
+          <field.CustomField
+            Component={ContributionNetworkSncuField}
+            label="Identifiant SNCU du réseau :"
+            nativeInputProps={{
+              disabled: hasNoSncuIdentifier,
+            }}
+            onNetworkClear={handleContributionNetworkClear}
+            onNetworkSelect={(network) => handleContributionNetworkSelect(network, shouldPrefillNetworkFields)}
+            selectedNetwork={selectedContributionNetwork}
+          />
+        )}
+      </form.AppField>
+      <Checkbox
+        label="Le réseau n’a pas d’identifiant SNCU"
+        className="fr-mb-3w"
+        nativeInputProps={{
+          checked: hasNoSncuIdentifier,
+          name: 'hasNoSncuIdentifier',
+          onChange: (event) => handleNoSncuIdentifierChange(event.target.checked),
+        }}
+        small={false}
+      />
+    </>
+  );
+
+  const renderUploadField = (name: 'fichiers' | 'fichiersPDP', label: string, uploadConfig: ContributionUploadConfig) => (
+    <form.AppField name={name} validators={{ onDynamicAsync: uploadConfig.fichiersValidator }}>
+      {(field) => (
+        <field.UploadField
+          className="fr-mb-2w"
+          label={label}
+          hint={
+            <>
+              Taille maximale : {formatFileSize(filesLimits.maxFileSize)}. Maximum {filesLimits.maxFiles} fichiers.{' '}
+              {uploadConfig.formatsHint}
+              <br />
+              Pour téléverser plusieurs fichiers, merci de les sélectionner simultanément et non l'un après l'autre.
+            </>
+          }
+          multiple
+          nativeInputProps={{ accept: uploadConfig.allowedExtensions.join(',') }}
+        />
+      )}
+    </form.AppField>
+  );
+
+  const renderClassedNetworkFields = () => (
+    <>
+      {isSelectedContributionNetworkClassed && (
+        <>
+          <CallOut title="Votre réseau est classé" className="fr-mb-3w">
+            Nous vous invitons à déposer le périmètre de développement prioritaire ci-dessous pour informer les bâtiments concernés de
+            l’obligation d’étude du raccordement.
+          </CallOut>
+          <form.AppField
+            name="reseauDeclasse"
+            listeners={{
+              onChange: ({ value }) => {
+                if (value === true) {
+                  form.setFieldValue('fichiersPDP', undefined, { dontUpdateMeta: true });
+                }
+              },
+            }}
+          >
+            {(field) => (
+              <field.CheckboxField
+                label={
+                  <span>
+                    Le réseau a été déclassé par arrêté (si celui-ci n’est pas dans la{' '}
+                    <Link
+                      href="https://www.ecologie.gouv.fr/politiques-publiques/reseaux-chaleur"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      liste des réseaux déclassés
+                    </Link>{' '}
+                    et/ou que vous n’avez pas encore transmis votre délibération, merci de l’envoyer à l’adresse
+                    Laurent.Cadiou@developpement-durable.gouv.fr)
+                  </span>
+                }
+                small={false}
+                className="fr-mb-3w"
+              />
+            )}
+          </form.AppField>
+        </>
+      )}
+      {isSelectedContributionNetworkClassed &&
+        reseauDeclasse !== true &&
+        renderUploadField('fichiersPDP', 'Téléverser le périmètre de développement prioritaire :', optionalPdpUploadConfig)}
+    </>
+  );
+
+  const renderNetworkFields = (withConstructionFields: boolean) => (
+    <>
+      {renderSncuIdentificationFields(true)}
+      <form.AppField name="nomReseau">{(field) => <field.TextField label="Nom du réseau :" />}</form.AppField>
+      <form.AppField name="localisation">{(field) => <field.TextField label="Localisation :" />}</form.AppField>
+      <form.AppField name="gestionnaire">{(field) => <field.TextField label="Gestionnaire :" />}</form.AppField>
+      <form.AppField name="maitreOuvrage">{(field) => <field.TextField label="Maître d'ouvrage :" />}</form.AppField>
+      {withConstructionFields && (
+        <>
+          <form.AppField name="dateMiseEnServicePrevisionnelle">
+            {(field) => <field.TextField label="Date de mise en service prévisionnelle :" />}
+          </form.AppField>
+          <form.AppField name="puissanceTotalePrevisionnelleMW">
+            {(field) => <field.NumberField label="Puissance totale prévisionnelle (MW) :" nativeInputProps={{ min: 0, step: 'any' }} />}
+          </form.AppField>
+        </>
+      )}
+      <form.AppField name="ouvertAuxRaccordements">
+        {(field) => <field.BooleanRadioField label="Le réseau est-il ouvert aux raccordements ?" />}
+      </form.AppField>
+      <form.AppField name="emailReferentCommercial">
+        {(field) => (
+          <field.TextField
+            label="Référent commercial à qui transmettre les demandes de raccordement"
+            nativeInputProps={{ required: ouvertAuxRaccordements === true }}
+          />
+        )}
+      </form.AppField>
+      <form.AppField name="commentaire">{(field) => <field.TextField label="Commentaire :" />}</form.AppField>
+      {renderClassedNetworkFields()}
+      {renderUploadField(
+        'fichiers',
+        isSelectedContributionNetworkClassed && reseauDeclasse !== true ? 'Téléverser le tracé du réseau :' : 'Téléverser vos fichiers :',
+        geoUploadConfig
+      )}
+    </>
+  );
 
   return formSuccess ? (
     <Alert
@@ -243,314 +355,27 @@ function ContributionForm() {
         {(field) => <field.RadioField label="Vous souhaitez :" options={typeDemandeOptions} />}
       </form.AppField>
 
-      {typeDemande === 'ajout tracé réseau existant' && (
-        <ContributionNetworkFields
-          form={form}
-          fields={contributionFormRootFields}
-          hasNoSncuIdentifier={hasNoSncuIdentifier}
-          isSelectedContributionNetworkClassed={isSelectedContributionNetworkClassed}
-          onNoSncuIdentifierChange={handleNoSncuIdentifierChange}
-          onNetworkClear={handleContributionNetworkClear}
-          onNetworkSelect={handleContributionNetworkSelect}
-          selectedContributionNetwork={selectedContributionNetwork}
-        />
-      )}
-      {typeDemande === 'ajout tracé réseau en construction' && (
-        <ContributionNetworkFields
-          form={form}
-          fields={contributionFormRootFields}
-          hasNoSncuIdentifier={hasNoSncuIdentifier}
-          isSelectedContributionNetworkClassed={isSelectedContributionNetworkClassed}
-          onNoSncuIdentifierChange={handleNoSncuIdentifierChange}
-          onNetworkClear={handleContributionNetworkClear}
-          onNetworkSelect={handleContributionNetworkSelect}
-          selectedContributionNetwork={selectedContributionNetwork}
-          withConstructionFields
-        />
-      )}
+      {typeDemande === 'ajout tracé réseau existant' && renderNetworkFields(false)}
+      {typeDemande === 'ajout tracé réseau en construction' && renderNetworkFields(true)}
       {typeDemande === 'ajout périmètre développement prioritaire' && (
-        <ContributionPriorityPerimeterFields
-          form={form}
-          fields={contributionFormRootFields}
-          hasNoSncuIdentifier={hasNoSncuIdentifier}
-          onNoSncuIdentifierChange={handleNoSncuIdentifierChange}
-          onNetworkClear={handleContributionNetworkClear}
-          onNetworkSelect={handleContributionNetworkSelect}
-          selectedContributionNetwork={selectedContributionNetwork}
-        />
+        <>
+          {renderSncuIdentificationFields(false)}
+          <form.AppField name="nomReseau">{(field) => <field.TextField label="Nom du réseau :" />}</form.AppField>
+          <form.AppField name="localisation">{(field) => <field.TextField label="Localisation :" />}</form.AppField>
+          {renderUploadField('fichiers', 'Téléverser vos fichiers :', geoUploadConfig)}
+        </>
       )}
-      {typeDemande === 'ajout schéma directeur' && <ContributionMasterPlanFields form={form} fields={contributionFormRootFields} />}
+      {typeDemande === 'ajout schéma directeur' && (
+        <>
+          <form.AppField name="nomReseau">{(field) => <field.TextField label="Nom du réseau ou du territoire concerné :" />}</form.AppField>
+          {renderUploadField('fichiers', 'Téléverser vos fichiers :', docUploadConfig)}
+        </>
+      )}
       {typeDemande === 'autre' && <form.AppField name="precisions">{(field) => <field.TextField label="Précisez :" />}</form.AppField>}
 
       <form.SubmitButton>Envoyer</form.SubmitButton>
     </Form>
   );
 }
-
-type ContributionNetworkSelectHandler = (network: ContributionNetworkSearchResult, shouldPrefillNetworkFields: boolean) => void;
-
-type ContributionSncuIdentificationFieldsProps = {
-  hasNoSncuIdentifier: boolean;
-  onNetworkClear: () => void;
-  onNetworkSelect: ContributionNetworkSelectHandler;
-  onNoSncuIdentifierChange: (checked: boolean) => void;
-  selectedContributionNetwork: ContributionNetworkSearchResult | null;
-  shouldPrefillNetworkFields: boolean;
-};
-
-const ContributionSncuIdentificationFields = withFieldGroup<ContributionFormValues, unknown, ContributionSncuIdentificationFieldsProps>({
-  defaultValues: contributionDefaultValues,
-  // biome-ignore lint: a named PascalCase function is required for the hooks rules.
-  render: function ContributionSncuIdentificationFieldsRender({
-    group,
-    hasNoSncuIdentifier,
-    onNetworkClear,
-    onNetworkSelect,
-    onNoSncuIdentifierChange,
-    selectedContributionNetwork,
-    shouldPrefillNetworkFields,
-  }) {
-    return (
-      <>
-        <group.AppField name="identifiantReseau">
-          {(field) => (
-            <field.CustomField
-              Component={ContributionNetworkSncuField}
-              label="Identifiant SNCU du réseau :"
-              nativeInputProps={{
-                disabled: hasNoSncuIdentifier,
-              }}
-              onNetworkClear={onNetworkClear}
-              onNetworkSelect={(network) => onNetworkSelect(network, shouldPrefillNetworkFields)}
-              selectedNetwork={selectedContributionNetwork}
-            />
-          )}
-        </group.AppField>
-        <Checkbox
-          label="Le réseau n’a pas d’identifiant SNCU"
-          className="fr-mb-3w"
-          nativeInputProps={{
-            checked: hasNoSncuIdentifier,
-            name: 'hasNoSncuIdentifier',
-            onChange: (event) => onNoSncuIdentifierChange(event.target.checked),
-          }}
-          small={false}
-        />
-      </>
-    );
-  },
-});
-
-type ContributionUploadFieldProps = {
-  label: string;
-  name: 'fichiers' | 'fichiersPDP';
-  uploadConfig: ContributionUploadConfig;
-};
-
-const ContributionUploadField = withFieldGroup<ContributionFormValues, unknown, ContributionUploadFieldProps>({
-  defaultValues: contributionDefaultValues,
-  // biome-ignore lint: a named PascalCase function is required for the hooks rules.
-  render: function ContributionUploadFieldRender({ group, label, name, uploadConfig }) {
-    return (
-      <group.AppField name={name} validators={{ onDynamicAsync: uploadConfig.fichiersValidator }}>
-        {(field) => (
-          <field.UploadField
-            className="fr-mb-2w"
-            label={label}
-            hint={
-              <>
-                Taille maximale : {formatFileSize(filesLimits.maxFileSize)}. Maximum {filesLimits.maxFiles} fichiers.{' '}
-                {uploadConfig.formatsHint}
-                <br />
-                Pour téléverser plusieurs fichiers, merci de les sélectionner simultanément et non l'un après l'autre.
-              </>
-            }
-            multiple
-            nativeInputProps={{ accept: uploadConfig.allowedExtensions.join(',') }}
-          />
-        )}
-      </group.AppField>
-    );
-  },
-});
-
-type ContributionNetworkFieldsProps = Omit<ContributionSncuIdentificationFieldsProps, 'shouldPrefillNetworkFields'> & {
-  isSelectedContributionNetworkClassed: boolean;
-  withConstructionFields?: boolean;
-};
-
-const ContributionNetworkFields = withFieldGroup<ContributionFormValues, unknown, ContributionNetworkFieldsProps>({
-  defaultValues: contributionDefaultValues,
-  // biome-ignore lint: a named PascalCase function is required for the hooks rules.
-  render: function ContributionNetworkFieldsRender({
-    group,
-    hasNoSncuIdentifier,
-    isSelectedContributionNetworkClassed,
-    onNetworkClear,
-    onNetworkSelect,
-    onNoSncuIdentifierChange,
-    selectedContributionNetwork,
-    withConstructionFields = false,
-  }) {
-    const ouvertAuxRaccordements = useStore(group.store, (state) => state.values.ouvertAuxRaccordements);
-    const reseauDeclasse = useStore(group.store, (state) => state.values.reseauDeclasse);
-    const traceUploadLabel =
-      isSelectedContributionNetworkClassed && reseauDeclasse !== true ? 'Téléverser le tracé du réseau :' : 'Téléverser vos fichiers :';
-
-    return (
-      <>
-        <ContributionSncuIdentificationFields
-          form={group}
-          fields={contributionFormRootFields}
-          hasNoSncuIdentifier={hasNoSncuIdentifier}
-          onNetworkClear={onNetworkClear}
-          onNetworkSelect={onNetworkSelect}
-          onNoSncuIdentifierChange={onNoSncuIdentifierChange}
-          selectedContributionNetwork={selectedContributionNetwork}
-          shouldPrefillNetworkFields
-        />
-        <group.AppField name="nomReseau">{(field) => <field.TextField label="Nom du réseau :" />}</group.AppField>
-        <group.AppField name="localisation">{(field) => <field.TextField label="Localisation :" />}</group.AppField>
-        <group.AppField name="gestionnaire">{(field) => <field.TextField label="Gestionnaire :" />}</group.AppField>
-        <group.AppField name="maitreOuvrage">{(field) => <field.TextField label="Maître d'ouvrage :" />}</group.AppField>
-        {withConstructionFields && (
-          <>
-            <group.AppField name="dateMiseEnServicePrevisionnelle">
-              {(field) => <field.TextField label="Date de mise en service prévisionnelle :" />}
-            </group.AppField>
-            <group.AppField name="puissanceTotalePrevisionnelleMW">
-              {(field) => <field.NumberField label="Puissance totale prévisionnelle (MW) :" nativeInputProps={{ min: 0, step: 'any' }} />}
-            </group.AppField>
-          </>
-        )}
-        <group.AppField name="ouvertAuxRaccordements">
-          {(field) => <field.BooleanRadioField label="Le réseau est-il ouvert aux raccordements ?" />}
-        </group.AppField>
-        <group.AppField name="emailReferentCommercial">
-          {(field) => (
-            <field.TextField
-              label="Référent commercial à qui transmettre les demandes de raccordement"
-              nativeInputProps={{ required: ouvertAuxRaccordements === true }}
-            />
-          )}
-        </group.AppField>
-        <group.AppField name="commentaire">{(field) => <field.TextField label="Commentaire :" />}</group.AppField>
-        {isSelectedContributionNetworkClassed && (
-          <>
-            <CallOut title="Votre réseau est classé" className="fr-mb-3w">
-              Nous vous invitons à déposer le périmètre de développement prioritaire ci-dessous pour informer les bâtiments concernés de
-              l’obligation d’étude du raccordement.
-            </CallOut>
-            <group.AppField
-              name="reseauDeclasse"
-              listeners={{
-                onChange: ({ value }) => {
-                  if (value === true) {
-                    group.setFieldValue('fichiersPDP', undefined, { dontUpdateMeta: true });
-                  }
-                },
-              }}
-            >
-              {(field) => (
-                <field.CheckboxField
-                  label={
-                    <span>
-                      Le réseau a été déclassé par arrêté (si celui-ci n’est pas dans la{' '}
-                      <Link
-                        href="https://www.ecologie.gouv.fr/politiques-publiques/reseaux-chaleur"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        liste des réseaux déclassés
-                      </Link>{' '}
-                      et/ou que vous n’avez pas encore transmis votre délibération, merci de l’envoyer à l’adresse
-                      Laurent.Cadiou@developpement-durable.gouv.fr)
-                    </span>
-                  }
-                  small={false}
-                  className="fr-mb-3w"
-                />
-              )}
-            </group.AppField>
-          </>
-        )}
-        {isSelectedContributionNetworkClassed && reseauDeclasse !== true && (
-          <ContributionUploadField
-            form={group}
-            fields={contributionFormRootFields}
-            name="fichiersPDP"
-            label="Téléverser le périmètre de développement prioritaire :"
-            uploadConfig={optionalPdpUploadConfig}
-          />
-        )}
-        <ContributionUploadField
-          form={group}
-          fields={contributionFormRootFields}
-          name="fichiers"
-          label={traceUploadLabel}
-          uploadConfig={geoUploadConfig}
-        />
-      </>
-    );
-  },
-});
-
-type ContributionPriorityPerimeterFieldsProps = Omit<ContributionSncuIdentificationFieldsProps, 'shouldPrefillNetworkFields'>;
-
-const ContributionPriorityPerimeterFields = withFieldGroup<ContributionFormValues, unknown, ContributionPriorityPerimeterFieldsProps>({
-  defaultValues: contributionDefaultValues,
-  // biome-ignore lint: a named PascalCase function is required for the hooks rules.
-  render: function ContributionPriorityPerimeterFieldsRender({
-    group,
-    hasNoSncuIdentifier,
-    onNetworkClear,
-    onNetworkSelect,
-    onNoSncuIdentifierChange,
-    selectedContributionNetwork,
-  }) {
-    return (
-      <>
-        <ContributionSncuIdentificationFields
-          form={group}
-          fields={contributionFormRootFields}
-          hasNoSncuIdentifier={hasNoSncuIdentifier}
-          onNetworkClear={onNetworkClear}
-          onNetworkSelect={onNetworkSelect}
-          onNoSncuIdentifierChange={onNoSncuIdentifierChange}
-          selectedContributionNetwork={selectedContributionNetwork}
-          shouldPrefillNetworkFields={false}
-        />
-        <group.AppField name="nomReseau">{(field) => <field.TextField label="Nom du réseau :" />}</group.AppField>
-        <group.AppField name="localisation">{(field) => <field.TextField label="Localisation :" />}</group.AppField>
-        <ContributionUploadField
-          form={group}
-          fields={contributionFormRootFields}
-          name="fichiers"
-          label="Téléverser vos fichiers :"
-          uploadConfig={geoUploadConfig}
-        />
-      </>
-    );
-  },
-});
-
-const ContributionMasterPlanFields = withFieldGroup<ContributionFormValues, unknown, Record<never, never>>({
-  defaultValues: contributionDefaultValues,
-  // biome-ignore lint: a named PascalCase function is required for the hooks rules.
-  render: function ContributionMasterPlanFieldsRender({ group }) {
-    return (
-      <>
-        <group.AppField name="nomReseau">{(field) => <field.TextField label="Nom du réseau ou du territoire concerné :" />}</group.AppField>
-        <ContributionUploadField
-          form={group}
-          fields={contributionFormRootFields}
-          name="fichiers"
-          label="Téléverser vos fichiers :"
-          uploadConfig={docUploadConfig}
-        />
-      </>
-    );
-  },
-});
 
 export default ContributionForm;

--- a/src/components/ContributionForm/ContributionForm.tsx
+++ b/src/components/ContributionForm/ContributionForm.tsx
@@ -12,6 +12,8 @@ import { postFormDataFetchJSON } from '@/utils/network';
 import { formatFileSize } from '@/utils/strings';
 import { nonEmptyArray } from '@/utils/typescript';
 
+import { type ContributionNetworkSearchResult, ContributionNetworkSncuField } from './ContributionNetworkSncuField';
+
 const typesUtilisateur = [
   {
     key: 'Collectivité',
@@ -53,6 +55,12 @@ const typesDemande = [
 ] as const;
 
 type TypeDemande = (typeof typesDemande)[number]['key'];
+
+const typesDemandeWithSncuIdentification = [
+  'ajout tracé réseau existant',
+  'ajout tracé réseau en construction',
+  'ajout périmètre développement prioritaire',
+] as const satisfies readonly TypeDemande[];
 
 export const filesLimits = {
   maxFileSize: 50 * 1024 * 1024,
@@ -179,6 +187,11 @@ const createFilesSchemaWithZipInspection = (allowedExtensions: string[]) => {
 
 const stringSchema = z.string({ error: 'Ce champ est obligatoire' });
 
+const sncuIdentificationFieldsShape = {
+  identifiantReseau: z.string().optional(),
+  reseauSansIdentifiantSNCU: z.boolean().optional(),
+};
+
 export const zCommonFormData = z.object({
   dansCadreDemandeADEME: z.boolean({ error: 'Ce choix est obligatoire' }),
   email: z.email("L'adresse email n'est pas valide"),
@@ -192,21 +205,36 @@ export const zCommonFormData = z.object({
 // when: () => true because zod skips the checks of a schema whose base parse has an
 // aborting issue (e.g. a missing required sub-field) — the conditional requirement
 // must still be reported alongside the other field errors.
-const isTypeUtilisateurAutreValid = (data: { typeUtilisateur?: string; typeUtilisateurAutre?: string }) =>
+export const isTypeUtilisateurAutreValid = (data: { typeUtilisateur?: string; typeUtilisateurAutre?: string }) =>
   data.typeUtilisateur !== 'Autre' || !!data.typeUtilisateurAutre;
-const typeUtilisateurAutreRefineParams = { message: 'Ce champ est obligatoire', path: ['typeUtilisateurAutre'], when: () => true };
+export const typeUtilisateurAutreRefineParams = { message: 'Ce champ est obligatoire', path: ['typeUtilisateurAutre'], when: () => true };
 
 // emailReferentCommercial is only required when the network is open to connections
 // (typeDemande, present in every union branch, keeps the structural type compatible)
-const isEmailReferentCommercialValid = (data: {
+export const isEmailReferentCommercialValid = (data: {
   typeDemande?: string;
   ouvertAuxRaccordements?: boolean;
   emailReferentCommercial?: string;
 }) => !data.ouvertAuxRaccordements || !!data.emailReferentCommercial;
-const emailReferentCommercialRefineParams = {
+export const emailReferentCommercialRefineParams = {
   message: 'Le référent commercial est obligatoire si le réseau est ouvert aux raccordements',
   path: ['emailReferentCommercial'],
   when: () => true, // see typeUtilisateurAutreRefineParams
+};
+
+const isSncuIdentificationRequired = (typeDemande?: string) =>
+  typesDemandeWithSncuIdentification.some((sncuTypeDemande) => sncuTypeDemande === typeDemande);
+
+export const isSncuIdentificationValid = (data: {
+  identifiantReseau?: string;
+  reseauSansIdentifiantSNCU?: boolean;
+  typeDemande?: string;
+}) => !isSncuIdentificationRequired(data.typeDemande) || !!data.identifiantReseau || data.reseauSansIdentifiantSNCU === true;
+
+export const sncuIdentificationRefineParams = {
+  message: "Sélectionnez un identifiant SNCU ou cochez l'absence d'identifiant SNCU",
+  path: ['identifiantReseau'],
+  when: () => true,
 };
 
 // branches are built twice: with the full files schema (API) and with the sync-only one (form)
@@ -216,11 +244,14 @@ const createContributionBranches = (filesSchema: typeof createFilesSchema) => {
     commentaire: z.string().optional(),
     emailReferentCommercial: z.string().optional(), // conditionally required based on ouvertAuxRaccordements (see refine below)
     fichiers: filesSchema(geoAllowedExtensions),
+    fichiersPDP: filesSchema(geoAllowedExtensions).optional(),
     gestionnaire: stringSchema,
+    ...sncuIdentificationFieldsShape,
     localisation: stringSchema,
     maitreOuvrage: stringSchema,
     nomReseau: stringSchema,
     ouvertAuxRaccordements: z.boolean({ error: 'Ce choix est obligatoire' }),
+    reseauDeclasse: z.boolean().optional(),
   };
 
   return [
@@ -232,9 +263,11 @@ const createContributionBranches = (filesSchema: typeof createFilesSchema) => {
       typeDemande: z.literal('ajout tracé réseau en construction'),
       ...reseauFieldsShape,
       dateMiseEnServicePrevisionnelle: stringSchema,
+      puissanceTotalePrevisionnelleMW: z.number({ error: 'Ce champ est obligatoire' }).positive('La puissance doit être supérieure à 0'),
     }),
     zCommonFormData.extend({
       fichiers: filesSchema(geoAllowedExtensions),
+      ...sncuIdentificationFieldsShape,
       localisation: stringSchema,
       nomReseau: stringSchema,
       typeDemande: z.literal('ajout périmètre développement prioritaire'),
@@ -260,7 +293,8 @@ export const zContributionFormDataBase = z.discriminatedUnion(
 
 export const zContributionFormData = zContributionFormDataBase
   .refine(isEmailReferentCommercialValid, emailReferentCommercialRefineParams)
-  .refine(isTypeUtilisateurAutreValid, typeUtilisateurAutreRefineParams);
+  .refine(isTypeUtilisateurAutreValid, typeUtilisateurAutreRefineParams)
+  .refine(isSncuIdentificationValid, sncuIdentificationRefineParams);
 
 // flat superset of all branches: the form holds every possible field, the union validates the selected branch
 type ContributionFormValues = Omit<z.input<typeof zCommonFormData>, 'dansCadreDemandeADEME' | 'typeUtilisateur'> & {
@@ -271,19 +305,27 @@ type ContributionFormValues = Omit<z.input<typeof zCommonFormData>, 'dansCadreDe
   dateMiseEnServicePrevisionnelle?: string;
   emailReferentCommercial?: string;
   fichiers?: File[];
+  fichiersPDP?: File[];
   gestionnaire?: string;
+  identifiantReseau?: string;
   localisation?: string;
   maitreOuvrage?: string;
   nomReseau?: string;
   ouvertAuxRaccordements?: boolean;
   precisions?: string;
+  puissanceTotalePrevisionnelleMW?: number;
+  reseauDeclasse?: boolean;
+  reseauSansIdentifiantSNCU?: boolean;
 };
 
 const contributionDefaultValues: ContributionFormValues = {
   dansCadreDemandeADEME: undefined,
   email: '',
+  identifiantReseau: '',
   nom: '',
   prenom: '',
+  reseauDeclasse: false,
+  reseauSansIdentifiantSNCU: false,
   typeDemande: '',
   typeUtilisateur: '',
   typeUtilisateurAutre: '',
@@ -299,7 +341,8 @@ const zContributionForm = z
   ])
   .refine(isEmailReferentCommercialValid, emailReferentCommercialRefineParams)
   // the union validates the mode-consistent runtime values; unify its type for TanStack
-  .refine(isTypeUtilisateurAutreValid, typeUtilisateurAutreRefineParams) as unknown as z.ZodType<
+  .refine(isTypeUtilisateurAutreValid, typeUtilisateurAutreRefineParams)
+  .refine(isSncuIdentificationValid, sncuIdentificationRefineParams) as unknown as z.ZodType<
   ContributionFormValues,
   ContributionFormValues
 >;
@@ -310,14 +353,18 @@ const zContributionForm = z
 // files schema (sync checks + zip inspection), not just the async part: sync and async
 // results share the same error-map slot, so returning undefined would erase the sync
 // error written by the form schema (e.g. a wrong extension) right after each submit.
-const createFichiersFieldValidator = (allowedExtensions: string[]) => {
-  const schema = createFilesSchemaWithZipInspection(allowedExtensions);
+const createFichiersFieldValidator = (allowedExtensions: string[], options: { required?: boolean } = {}) => {
+  const schema =
+    options.required === false
+      ? createFilesSchemaWithZipInspection(allowedExtensions).optional()
+      : createFilesSchemaWithZipInspection(allowedExtensions);
   return async ({ value }: { value: File[] | undefined }) => {
     const result = await schema.safeParseAsync(value);
     return result.success ? undefined : result.error.issues[0]?.message;
   };
 };
 const geoFichiersValidator = createFichiersFieldValidator(geoAllowedExtensions);
+const optionalGeoFichiersValidator = createFichiersFieldValidator(geoAllowedExtensions, { required: false });
 const docFichiersValidator = createFichiersFieldValidator(docAllowedExtensions);
 
 const typeUtilisateurOptions = typesUtilisateur.map((option) => ({
@@ -337,6 +384,7 @@ const typeDemandeOptions = typesDemande.map((option) => ({
  */
 const ContributionForm = () => {
   const [formSuccess, setFormSuccess] = useState(false);
+  const [selectedContributionNetwork, setSelectedContributionNetwork] = useState<ContributionNetworkSearchResult | null>(null);
 
   const form = useAppForm({
     ...schemaValidation(zContributionForm),
@@ -361,6 +409,35 @@ const ContributionForm = () => {
   const typeDemande = useStore(form.store, (state) => state.values.typeDemande);
   const dansCadreDemandeADEME = useStore(form.store, (state) => state.values.dansCadreDemandeADEME);
   const ouvertAuxRaccordements = useStore(form.store, (state) => state.values.ouvertAuxRaccordements);
+  const reseauSansIdentifiantSNCU = useStore(form.store, (state) => state.values.reseauSansIdentifiantSNCU);
+  const reseauDeclasse = useStore(form.store, (state) => state.values.reseauDeclasse);
+  const isSelectedContributionNetworkClassed = selectedContributionNetwork?.is_classe === true;
+
+  const resetClassedNetworkFields = () => {
+    form.setFieldValue('reseauDeclasse', false, { dontUpdateMeta: true });
+    form.setFieldValue('fichiersPDP', undefined, { dontUpdateMeta: true });
+  };
+
+  const handleContributionNetworkClear = () => {
+    setSelectedContributionNetwork(null);
+    form.setFieldValue('identifiantReseau', '');
+    resetClassedNetworkFields();
+  };
+
+  const handleContributionNetworkSelect = (network: ContributionNetworkSearchResult, shouldPrefillNetworkFields: boolean) => {
+    setSelectedContributionNetwork(network);
+    form.setFieldValue('reseauSansIdentifiantSNCU', false, { dontUpdateMeta: true });
+    resetClassedNetworkFields();
+
+    if (!shouldPrefillNetworkFields) {
+      return;
+    }
+
+    form.setFieldValue('nomReseau', network.nom_reseau ?? '');
+    form.setFieldValue('localisation', network.localisation ?? '');
+    form.setFieldValue('gestionnaire', network.gestionnaire ?? '');
+    form.setFieldValue('maitreOuvrage', network.maitre_ouvrage ?? '');
+  };
 
   // plain render helpers (not components) shared by the demand type branches
   const renderNomReseauField = (label: string) => (
@@ -371,12 +448,18 @@ const ContributionForm = () => {
     <form.AppField name="localisation">{(field) => <field.TextField label="Localisation :" />}</form.AppField>
   );
 
-  const renderFichiersField = (allowedExtensions: string[], fichiersValidator: typeof geoFichiersValidator, formatsHint: string) => (
-    <form.AppField name="fichiers" validators={{ onDynamicAsync: fichiersValidator }}>
+  const renderFichiersField = (
+    name: 'fichiers' | 'fichiersPDP',
+    label: string,
+    allowedExtensions: string[],
+    fichiersValidator: typeof geoFichiersValidator,
+    formatsHint: string
+  ) => (
+    <form.AppField name={name} validators={{ onDynamicAsync: fichiersValidator }}>
       {(field) => (
         <field.UploadField
           className="fr-mb-2w"
-          label="Téléverser vos fichiers :"
+          label={label}
           hint={
             <>
               Taille maximale : {formatFileSize(filesLimits.maxFileSize)}. Maximum {filesLimits.maxFiles} fichiers. {formatsHint}
@@ -391,16 +474,98 @@ const ContributionForm = () => {
     </form.AppField>
   );
 
+  const renderSncuIdentificationFields = (shouldPrefillNetworkFields: boolean) => (
+    <>
+      <form.AppField name="identifiantReseau">
+        {(field) => (
+          <field.CustomField
+            Component={ContributionNetworkSncuField}
+            label="Identifiant SNCU du réseau :"
+            hintText="Sélectionnez un identifiant dans la liste de suggestions."
+            nativeInputProps={{
+              disabled: reseauSansIdentifiantSNCU === true,
+              required: reseauSansIdentifiantSNCU !== true,
+            }}
+            onNetworkClear={handleContributionNetworkClear}
+            onNetworkSelect={(network) => handleContributionNetworkSelect(network, shouldPrefillNetworkFields)}
+            selectedNetwork={selectedContributionNetwork}
+          />
+        )}
+      </form.AppField>
+      <form.AppField
+        name="reseauSansIdentifiantSNCU"
+        listeners={{
+          onChange: ({ value }) => {
+            if (value === true) {
+              handleContributionNetworkClear();
+            }
+          },
+        }}
+      >
+        {(field) => <field.CheckboxField label="Le réseau n’a pas d’identifiant SNCU" small={false} className="fr-mb-3w" />}
+      </form.AppField>
+    </>
+  );
+
+  const renderClassedNetworkFields = () => (
+    <>
+      {isSelectedContributionNetworkClassed && (
+        <>
+          <Alert
+            severity="info"
+            title="Votre réseau est classé."
+            description="Nous vous invitons à déposer le périmètre de développement prioritaire ci-dessous pour informer les bâtiments concernés de l’obligation d’étude du raccordement."
+            className="fr-mb-3w"
+            small
+          />
+          <form.AppField
+            name="reseauDeclasse"
+            listeners={{
+              onChange: ({ value }) => {
+                if (value === true) {
+                  form.setFieldValue('fichiersPDP', undefined, { dontUpdateMeta: true });
+                }
+              },
+            }}
+          >
+            {(field) => (
+              <field.CheckboxField
+                label="Le réseau a été déclassé par arrêté (si celui-ci n’est pas dans la liste des réseaux déclassés et/ou que vous n’avez pas encore transmis votre délibération, merci de l’envoyer à l’adresse Laurent.Cadiou@developpement-durable.gouv.fr)"
+                small={false}
+                className="fr-mb-3w"
+              />
+            )}
+          </form.AppField>
+        </>
+      )}
+      {isSelectedContributionNetworkClassed &&
+        reseauDeclasse !== true &&
+        renderFichiersField(
+          'fichiersPDP',
+          'Téléverser le périmètre de développement prioritaire :',
+          geoAllowedExtensions,
+          optionalGeoFichiersValidator,
+          'Formats préférentiels : GeoJSON, Shapefile (au moins shp + prj), KML, GeoPackage.'
+        )}
+    </>
+  );
+
   const renderReseauFields = (withDateMiseEnService: boolean) => (
     <>
+      {renderSncuIdentificationFields(true)}
       {renderNomReseauField('Nom du réseau :')}
       {renderLocalisationField()}
       <form.AppField name="gestionnaire">{(field) => <field.TextField label="Gestionnaire :" />}</form.AppField>
       <form.AppField name="maitreOuvrage">{(field) => <field.TextField label="Maître d'ouvrage :" />}</form.AppField>
       {withDateMiseEnService && (
-        <form.AppField name="dateMiseEnServicePrevisionnelle">
-          {(field) => <field.TextField label="Date de mise en service prévisionnelle :" />}
-        </form.AppField>
+        <>
+          <form.AppField name="dateMiseEnServicePrevisionnelle">
+            {(field) => <field.TextField label="Date de mise en service prévisionnelle :" />}
+          </form.AppField>
+          <form.AppField name="puissanceTotalePrevisionnelleMW">
+            {(field) => <field.NumberField label="Puissance totale prévisionnelle (MW) :" nativeInputProps={{ min: 0, step: 'any' }} />}
+          </form.AppField>
+        </>
       )}
       <form.AppField name="ouvertAuxRaccordements">
         {(field) => <field.BooleanRadioField label="Le réseau est-il ouvert aux raccordements ?" />}
@@ -414,7 +579,10 @@ const ContributionForm = () => {
         )}
       </form.AppField>
       <form.AppField name="commentaire">{(field) => <field.TextField label="Commentaire :" />}</form.AppField>
+      {renderClassedNetworkFields()}
       {renderFichiersField(
+        'fichiers',
+        isSelectedContributionNetworkClassed && reseauDeclasse !== true ? 'Téléverser le tracé du réseau :' : 'Téléverser vos fichiers :',
         geoAllowedExtensions,
         geoFichiersValidator,
         'Formats préférentiels : GeoJSON, Shapefile (au moins shp + prj), KML, GeoPackage.'
@@ -488,9 +656,12 @@ const ContributionForm = () => {
       {typeDemande === 'ajout tracé réseau en construction' && renderReseauFields(true)}
       {typeDemande === 'ajout périmètre développement prioritaire' && (
         <>
+          {renderSncuIdentificationFields(false)}
           {renderNomReseauField('Nom du réseau :')}
           {renderLocalisationField()}
           {renderFichiersField(
+            'fichiers',
+            'Téléverser vos fichiers :',
             geoAllowedExtensions,
             geoFichiersValidator,
             'Formats préférentiels : GeoJSON, Shapefile (au moins shp + prj), KML, GeoPackage.'
@@ -500,7 +671,13 @@ const ContributionForm = () => {
       {typeDemande === 'ajout schéma directeur' && (
         <>
           {renderNomReseauField('Nom du réseau ou du territoire concerné :')}
-          {renderFichiersField(docAllowedExtensions, docFichiersValidator, 'Formats préférentiels : PDF, Word.')}
+          {renderFichiersField(
+            'fichiers',
+            'Téléverser vos fichiers :',
+            docAllowedExtensions,
+            docFichiersValidator,
+            'Formats préférentiels : PDF, Word.'
+          )}
         </>
       )}
       {typeDemande === 'autre' && <form.AppField name="precisions">{(field) => <field.TextField label="Précisez :" />}</form.AppField>}

--- a/src/components/ContributionForm/ContributionForm.tsx
+++ b/src/components/ContributionForm/ContributionForm.tsx
@@ -3,6 +3,7 @@ import { useStore } from '@tanstack/react-form';
 import Link from 'next/link';
 import { useState } from 'react';
 
+import Checkbox from '@/components/form/dsfr/Checkbox';
 import { trackPostHogEvent } from '@/modules/analytics/client';
 import { Form } from '@/modules/form/Form';
 import { schemaValidation, useAppForm } from '@/modules/form/useAppForm';
@@ -43,6 +44,7 @@ const typeDemandeOptions = typesDemande.map((option) => ({
 function ContributionForm() {
   const [formSuccess, setFormSuccess] = useState(false);
   const [selectedContributionNetwork, setSelectedContributionNetwork] = useState<ContributionNetworkSearchResult | null>(null);
+  const [hasNoSncuIdentifier, setHasNoSncuIdentifier] = useState(false);
 
   const form = useAppForm({
     ...schemaValidation(zContributionForm),
@@ -67,7 +69,6 @@ function ContributionForm() {
   const typeDemande = useStore(form.store, (state) => state.values.typeDemande);
   const dansCadreDemandeADEME = useStore(form.store, (state) => state.values.dansCadreDemandeADEME);
   const ouvertAuxRaccordements = useStore(form.store, (state) => state.values.ouvertAuxRaccordements);
-  const reseauSansIdentifiantSNCU = useStore(form.store, (state) => state.values.reseauSansIdentifiantSNCU);
   const reseauDeclasse = useStore(form.store, (state) => state.values.reseauDeclasse);
   const isSelectedContributionNetworkClassed = selectedContributionNetwork?.is_classe === true;
 
@@ -78,8 +79,8 @@ function ContributionForm() {
 
   const resetSncuIdentificationFields = () => {
     setSelectedContributionNetwork(null);
+    setHasNoSncuIdentifier(false);
     form.setFieldValue('identifiantReseau', '', { dontUpdateMeta: true });
-    form.setFieldValue('reseauSansIdentifiantSNCU', false, { dontUpdateMeta: true });
     resetClassedNetworkFields();
   };
 
@@ -106,7 +107,7 @@ function ContributionForm() {
 
   const handleContributionNetworkSelect = (network: ContributionNetworkSearchResult, shouldPrefillNetworkFields: boolean) => {
     setSelectedContributionNetwork(network);
-    form.setFieldValue('reseauSansIdentifiantSNCU', false, { dontUpdateMeta: true });
+    setHasNoSncuIdentifier(false);
     resetClassedNetworkFields();
 
     if (!shouldPrefillNetworkFields) {
@@ -117,6 +118,13 @@ function ContributionForm() {
     form.setFieldValue('localisation', network.localisation ?? '');
     form.setFieldValue('gestionnaire', network.gestionnaire ?? '');
     form.setFieldValue('maitreOuvrage', network.maitre_ouvrage ?? '');
+  };
+
+  const handleNoSncuIdentifierChange = (checked: boolean) => {
+    setHasNoSncuIdentifier(checked);
+    if (checked) {
+      handleContributionNetworkClear();
+    }
   };
 
   const renderNomReseauField = (label: string) => (
@@ -162,8 +170,7 @@ function ContributionForm() {
             label="Identifiant SNCU du réseau :"
             hintText="Sélectionnez un identifiant dans la liste de suggestions."
             nativeInputProps={{
-              disabled: reseauSansIdentifiantSNCU === true,
-              required: reseauSansIdentifiantSNCU !== true,
+              disabled: hasNoSncuIdentifier,
             }}
             onNetworkClear={handleContributionNetworkClear}
             onNetworkSelect={(network) => handleContributionNetworkSelect(network, shouldPrefillNetworkFields)}
@@ -171,18 +178,16 @@ function ContributionForm() {
           />
         )}
       </form.AppField>
-      <form.AppField
-        name="reseauSansIdentifiantSNCU"
-        listeners={{
-          onChange: ({ value }) => {
-            if (value === true) {
-              handleContributionNetworkClear();
-            }
-          },
+      <Checkbox
+        label="Le réseau n’a pas d’identifiant SNCU"
+        className="fr-mb-3w"
+        nativeInputProps={{
+          checked: hasNoSncuIdentifier,
+          name: 'hasNoSncuIdentifier',
+          onChange: (event) => handleNoSncuIdentifierChange(event.target.checked),
         }}
-      >
-        {(field) => <field.CheckboxField label="Le réseau n’a pas d’identifiant SNCU" small={false} className="fr-mb-3w" />}
-      </form.AppField>
+        small={false}
+      />
     </>
   );
 

--- a/src/components/ContributionForm/ContributionForm.tsx
+++ b/src/components/ContributionForm/ContributionForm.tsx
@@ -247,7 +247,7 @@ function ContributionForm() {
       )}
       {isSelectedContributionNetworkClassed &&
         reseauDeclasse !== true &&
-        renderUploadField('fichiersPDP', 'Téléverser le périmètre de développement prioritaire :', optionalPdpUploadConfig)}
+        renderUploadField('fichiersPDP', 'Téléverser le tracé du périmètre de développement prioritaire :', optionalPdpUploadConfig)}
     </>
   );
 

--- a/src/components/ContributionForm/ContributionNetworkSncuField.tsx
+++ b/src/components/ContributionForm/ContributionNetworkSncuField.tsx
@@ -24,11 +24,6 @@ type ContributionNetworkSncuFieldProps = {
   nativeInputProps?: Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange'>;
 };
 
-/**
- * SNCU identifier autocomplete for the public contribution form.
- * The stored form value is updated only after selecting a suggestion, so free
- * text never satisfies validation by itself.
- */
 export function ContributionNetworkSncuField({
   label,
   selectedNetwork,
@@ -129,11 +124,9 @@ export function ContributionNetworkSncuField({
 }
 
 const formatSelectedNetwork = (network: ContributionNetworkSearchResult) =>
-  [network.identifiant_reseau, network.nom_reseau, network.localisation].filter(isNonEmptyString).join(' - ');
+  [network.identifiant_reseau, network.nom_reseau].filter(isNonEmptyString).join(' - ');
 
-const formatNetworkDetails = (network: ContributionNetworkSearchResult) => {
-  const details = [network.nom_reseau, network.localisation].filter(isNonEmptyString).join(' · ');
-  return details ? <span className="text-(--text-mention-grey)"> - {details}</span> : null;
-};
+const formatNetworkDetails = (network: ContributionNetworkSearchResult) =>
+  isNonEmptyString(network.nom_reseau) ? <span className="text-(--text-mention-grey)"> - {network.nom_reseau}</span> : null;
 
 const isNonEmptyString = (value: string | null | undefined): value is string => typeof value === 'string' && value.length > 0;

--- a/src/components/ContributionForm/ContributionNetworkSncuField.tsx
+++ b/src/components/ContributionForm/ContributionNetworkSncuField.tsx
@@ -1,0 +1,135 @@
+import { fr } from '@codegouvfr/react-dsfr';
+import type React from 'react';
+import { useCallback, useId } from 'react';
+
+import FieldWrapper from '@/components/form/dsfr/FieldWrapper';
+import { highlightMatch } from '@/modules/form/AddressSearch';
+import { Autocomplete } from '@/modules/form/Autocomplete';
+import trpc, { type RouterOutput } from '@/modules/trpc/client';
+import cx from '@/utils/cx';
+
+export type ContributionNetworkSearchResult = RouterOutput['reseaux']['searchForContribution'][number];
+
+type ContributionNetworkSncuFieldProps = {
+  label: React.ReactNode;
+  selectedNetwork: ContributionNetworkSearchResult | null;
+  onNetworkSelect: (network: ContributionNetworkSearchResult) => void;
+  onNetworkClear: () => void;
+  value?: string;
+  onChange?: (value: string) => void;
+  hintText?: React.ReactNode;
+  state?: 'error' | 'default';
+  stateRelatedMessage?: string;
+  className?: string;
+  nativeInputProps?: Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange'>;
+};
+
+/**
+ * SNCU identifier autocomplete for the public contribution form.
+ * The stored form value is updated only after selecting a suggestion, so free
+ * text never satisfies validation by itself.
+ */
+export function ContributionNetworkSncuField({
+  label,
+  selectedNetwork,
+  onNetworkSelect,
+  onNetworkClear,
+  value,
+  onChange,
+  hintText,
+  state = 'default',
+  stateRelatedMessage,
+  className,
+  nativeInputProps,
+}: ContributionNetworkSncuFieldProps) {
+  const id = useId();
+  const utils = trpc.useUtils();
+  const isRequired = nativeInputProps?.required === true;
+  const isDisabled = nativeInputProps?.disabled === true;
+
+  const fetchFn = useCallback(
+    async (query: string) => {
+      return await utils.reseaux.searchForContribution.fetch({ search: query });
+    },
+    [utils]
+  );
+
+  const handleSelect = useCallback(
+    (network: ContributionNetworkSearchResult) => {
+      onChange?.(network.identifiant_reseau);
+      onNetworkSelect(network);
+    },
+    [onChange, onNetworkSelect]
+  );
+
+  const handleClear = useCallback(() => {
+    onChange?.('');
+    onNetworkClear();
+  }, [onChange, onNetworkClear]);
+
+  const decoratedLabel = (
+    <>
+      {label}
+      {!isRequired && <small> (Optionnel)</small>}
+    </>
+  );
+
+  return (
+    <FieldWrapper
+      fieldId={id}
+      label={decoratedLabel}
+      hintText={hintText}
+      disabled={isDisabled}
+      state={state}
+      stateRelatedMessage={stateRelatedMessage}
+      className={className}
+    >
+      {selectedNetwork ? (
+        <button
+          type="button"
+          className={fr.cx('fr-tag', 'fr-tag--sm', 'fr-tag--dismiss', 'fr-mt-2w')}
+          title="Supprimer la sélection du réseau"
+          onClick={handleClear}
+        >
+          {formatSelectedNetwork(selectedNetwork)}
+        </button>
+      ) : (
+        <Autocomplete<ContributionNetworkSearchResult>
+          id={id}
+          fetchFn={fetchFn}
+          getOptionValue={(network) => network.identifiant_reseau}
+          getOptionLabel={(network, query) => (
+            <div className="flex flex-col">
+              <span className="font-medium">{highlightMatch(network.identifiant_reseau, query)}</span>
+              <span className="text-xs text-gray-500">{formatNetworkDetails(network)}</span>
+            </div>
+          )}
+          value={value ?? ''}
+          onSelect={handleSelect}
+          onClear={handleClear}
+          minCharThreshold={2}
+          emptyMessage="Aucun identifiant SNCU trouvé"
+          nativeInputProps={{
+            className: cx(
+              fr.cx('fr-input', {
+                'fr-input--error': state === 'error',
+              })
+            ),
+            disabled: isDisabled,
+            placeholder: 'Ex. 7501C',
+            required: isRequired,
+            ...nativeInputProps,
+          }}
+        />
+      )}
+    </FieldWrapper>
+  );
+}
+
+const formatSelectedNetwork = (network: ContributionNetworkSearchResult): string =>
+  [network.identifiant_reseau, network.nom_reseau].filter(isNonEmptyString).join(' - ');
+
+const formatNetworkDetails = (network: ContributionNetworkSearchResult): string =>
+  [network.nom_reseau, network.localisation].filter(isNonEmptyString).join(' · ');
+
+const isNonEmptyString = (value: string | null | undefined): value is string => Boolean(value);

--- a/src/components/ContributionForm/ContributionNetworkSncuField.tsx
+++ b/src/components/ContributionForm/ContributionNetworkSncuField.tsx
@@ -42,19 +42,29 @@ export function ContributionNetworkSncuField({
   className,
   nativeInputProps,
 }: ContributionNetworkSncuFieldProps) {
-  const id = useId();
-  const utils = trpc.useUtils();
+  const inputId = useId();
+  const trpcUtils = trpc.useUtils();
   const isRequired = nativeInputProps?.required === true;
   const isDisabled = nativeInputProps?.disabled === true;
 
   const fetchFn = useCallback(
-    async (query: string) => {
-      return await utils.reseaux.searchForContribution.fetch({ search: query });
-    },
-    [utils]
+    (query: string) => trpcUtils.reseaux.searchForContribution.fetch({ search: query }),
+    [trpcUtils.reseaux.searchForContribution]
   );
 
-  const handleSelect = useCallback(
+  const getOptionValue = useCallback((network: ContributionNetworkSearchResult) => network.identifiant_reseau, []);
+
+  const getOptionLabel = useCallback(
+    (network: ContributionNetworkSearchResult, query: string) => (
+      <span>
+        {highlightMatch(network.identifiant_reseau, query)}
+        {formatNetworkDetails(network)}
+      </span>
+    ),
+    []
+  );
+
+  const handleNetworkSelect = useCallback(
     (network: ContributionNetworkSearchResult) => {
       onChange?.(network.identifiant_reseau);
       onNetworkSelect(network);
@@ -62,63 +72,55 @@ export function ContributionNetworkSncuField({
     [onChange, onNetworkSelect]
   );
 
-  const handleClear = useCallback(() => {
+  const handleNetworkClear = useCallback(() => {
     onChange?.('');
     onNetworkClear();
   }, [onChange, onNetworkClear]);
 
-  const decoratedLabel = (
-    <>
-      {label}
-      {!isRequired && <small> (Optionnel)</small>}
-    </>
-  );
-
   return (
     <FieldWrapper
-      fieldId={id}
-      label={decoratedLabel}
+      className={className}
+      fieldId={inputId}
+      label={
+        isRequired ? (
+          label
+        ) : (
+          <>
+            {label} <span className="font-normal">(Optionnel)</span>
+          </>
+        )
+      }
       hintText={hintText}
-      disabled={isDisabled}
       state={state}
       stateRelatedMessage={stateRelatedMessage}
-      className={className}
+      disabled={isDisabled}
     >
       {selectedNetwork ? (
         <button
           type="button"
           className={fr.cx('fr-tag', 'fr-tag--sm', 'fr-tag--dismiss', 'fr-mt-2w')}
           title="Supprimer la sélection du réseau"
-          onClick={handleClear}
+          onClick={handleNetworkClear}
         >
           {formatSelectedNetwork(selectedNetwork)}
         </button>
       ) : (
         <Autocomplete<ContributionNetworkSearchResult>
-          id={id}
+          id={inputId}
           fetchFn={fetchFn}
-          getOptionValue={(network) => network.identifiant_reseau}
-          getOptionLabel={(network, query) => (
-            <div className="flex flex-col">
-              <span className="font-medium">{highlightMatch(network.identifiant_reseau, query)}</span>
-              <span className="text-xs text-gray-500">{formatNetworkDetails(network)}</span>
-            </div>
-          )}
+          getOptionValue={getOptionValue}
+          getOptionLabel={getOptionLabel}
           value={value ?? ''}
-          onSelect={handleSelect}
-          onClear={handleClear}
+          onSelect={handleNetworkSelect}
+          onClear={handleNetworkClear}
           minCharThreshold={2}
           emptyMessage="Aucun identifiant SNCU trouvé"
           nativeInputProps={{
-            className: cx(
-              fr.cx('fr-input', {
-                'fr-input--error': state === 'error',
-              })
-            ),
+            ...nativeInputProps,
+            className: cx(fr.cx('fr-input', { 'fr-input--error': state === 'error' }), nativeInputProps?.className),
             disabled: isDisabled,
             placeholder: 'Ex. 7501C',
             required: isRequired,
-            ...nativeInputProps,
           }}
         />
       )}
@@ -126,10 +128,12 @@ export function ContributionNetworkSncuField({
   );
 }
 
-const formatSelectedNetwork = (network: ContributionNetworkSearchResult): string =>
-  [network.identifiant_reseau, network.nom_reseau].filter(isNonEmptyString).join(' - ');
+const formatSelectedNetwork = (network: ContributionNetworkSearchResult) =>
+  [network.identifiant_reseau, network.nom_reseau, network.localisation].filter(isNonEmptyString).join(' - ');
 
-const formatNetworkDetails = (network: ContributionNetworkSearchResult): string =>
-  [network.nom_reseau, network.localisation].filter(isNonEmptyString).join(' · ');
+const formatNetworkDetails = (network: ContributionNetworkSearchResult) => {
+  const details = [network.nom_reseau, network.localisation].filter(isNonEmptyString).join(' · ');
+  return details ? <span className="text-(--text-mention-grey)"> - {details}</span> : null;
+};
 
-const isNonEmptyString = (value: string | null | undefined): value is string => Boolean(value);
+const isNonEmptyString = (value: string | null | undefined): value is string => typeof value === 'string' && value.length > 0;

--- a/src/components/ContributionForm/ContributionNetworkSncuField.tsx
+++ b/src/components/ContributionForm/ContributionNetworkSncuField.tsx
@@ -7,6 +7,7 @@ import { highlightMatch } from '@/modules/form/AddressSearch';
 import { Autocomplete } from '@/modules/form/Autocomplete';
 import trpc, { type RouterOutput } from '@/modules/trpc/client';
 import cx from '@/utils/cx';
+import { isNonEmptyString } from '@/utils/typescript';
 
 export type ContributionNetworkSearchResult = RouterOutput['reseaux']['searchForContribution'][number];
 
@@ -125,5 +126,3 @@ const formatSelectedNetwork = (network: ContributionNetworkSearchResult) =>
 
 const formatNetworkDetails = (network: ContributionNetworkSearchResult) =>
   isNonEmptyString(network.nom_reseau) ? <span className="text-(--text-mention-grey)"> - {network.nom_reseau}</span> : null;
-
-const isNonEmptyString = (value: string | null | undefined): value is string => typeof value === 'string' && value.length > 0;

--- a/src/components/ContributionForm/ContributionNetworkSncuField.tsx
+++ b/src/components/ContributionForm/ContributionNetworkSncuField.tsx
@@ -17,7 +17,6 @@ type ContributionNetworkSncuFieldProps = {
   onNetworkClear: () => void;
   value?: string;
   onChange?: (value: string) => void;
-  hintText?: React.ReactNode;
   state?: 'error' | 'default';
   stateRelatedMessage?: string;
   className?: string;
@@ -31,7 +30,6 @@ export function ContributionNetworkSncuField({
   onNetworkClear,
   value,
   onChange,
-  hintText,
   state = 'default',
   stateRelatedMessage,
   className,
@@ -85,7 +83,6 @@ export function ContributionNetworkSncuField({
           </>
         )
       }
-      hintText={hintText}
       state={state}
       stateRelatedMessage={stateRelatedMessage}
       disabled={isDisabled}

--- a/src/components/ContributionForm/schema.ts
+++ b/src/components/ContributionForm/schema.ts
@@ -45,12 +45,6 @@ export const typesDemande = [
 
 export type TypeDemande = (typeof typesDemande)[number]['key'];
 
-const typesDemandeWithSncuIdentification = [
-  'ajout tracé réseau existant',
-  'ajout tracé réseau en construction',
-  'ajout périmètre développement prioritaire',
-] as const satisfies readonly TypeDemande[];
-
 export const filesLimits = {
   maxFileSize: 50 * 1024 * 1024,
   maxFiles: 10,
@@ -177,7 +171,6 @@ const positiveNumberSchema = z.number({ error: 'Ce champ est obligatoire' }).pos
 
 const sncuIdentificationFieldsShape = {
   identifiantReseau: z.string().optional(),
-  reseauSansIdentifiantSNCU: z.boolean().optional(),
 };
 
 export const zCommonFormData = z.object({
@@ -203,21 +196,6 @@ export const isEmailReferentCommercialValid = (data: {
 export const emailReferentCommercialRefineParams = {
   message: 'Le référent commercial est obligatoire si le réseau est ouvert aux raccordements',
   path: ['emailReferentCommercial'],
-  when: () => true,
-};
-
-const isSncuIdentificationRequired = (typeDemande?: string) =>
-  typesDemandeWithSncuIdentification.some((sncuTypeDemande) => sncuTypeDemande === typeDemande);
-
-export const isSncuIdentificationValid = (data: {
-  identifiantReseau?: string;
-  reseauSansIdentifiantSNCU?: boolean;
-  typeDemande?: string;
-}) => !isSncuIdentificationRequired(data.typeDemande) || !!data.identifiantReseau || data.reseauSansIdentifiantSNCU === true;
-
-export const sncuIdentificationRefineParams = {
-  message: "Sélectionnez un identifiant SNCU ou cochez l'absence d'identifiant SNCU",
-  path: ['identifiantReseau'],
   when: () => true,
 };
 
@@ -274,8 +252,7 @@ export const zContributionFormDataBase = z.discriminatedUnion(
 
 export const zContributionFormData = zContributionFormDataBase
   .refine(isEmailReferentCommercialValid, emailReferentCommercialRefineParams)
-  .refine(isTypeUtilisateurAutreValid, typeUtilisateurAutreRefineParams)
-  .refine(isSncuIdentificationValid, sncuIdentificationRefineParams);
+  .refine(isTypeUtilisateurAutreValid, typeUtilisateurAutreRefineParams);
 
 export type ContributionFormValues = Omit<z.input<typeof zCommonFormData>, 'dansCadreDemandeADEME' | 'typeUtilisateur'> & {
   dansCadreDemandeADEME?: boolean;
@@ -295,7 +272,6 @@ export type ContributionFormValues = Omit<z.input<typeof zCommonFormData>, 'dans
   precisions?: string;
   puissanceTotalePrevisionnelleMW?: number;
   reseauDeclasse?: boolean;
-  reseauSansIdentifiantSNCU?: boolean;
 };
 
 export const contributionDefaultValues: ContributionFormValues = {
@@ -305,7 +281,6 @@ export const contributionDefaultValues: ContributionFormValues = {
   nom: '',
   prenom: '',
   reseauDeclasse: false,
-  reseauSansIdentifiantSNCU: false,
   typeDemande: '',
   typeUtilisateur: '',
   typeUtilisateurAutre: '',
@@ -317,8 +292,7 @@ export const zContributionForm = z
     zCommonFormData.extend({ typeDemande: z.literal('').refine(() => false, { message: 'Ce choix est obligatoire' }) }),
   ])
   .refine(isEmailReferentCommercialValid, emailReferentCommercialRefineParams)
-  .refine(isTypeUtilisateurAutreValid, typeUtilisateurAutreRefineParams)
-  .refine(isSncuIdentificationValid, sncuIdentificationRefineParams) as unknown as z.ZodType<
+  .refine(isTypeUtilisateurAutreValid, typeUtilisateurAutreRefineParams) as unknown as z.ZodType<
   ContributionFormValues,
   ContributionFormValues
 >;

--- a/src/components/ContributionForm/schema.ts
+++ b/src/components/ContributionForm/schema.ts
@@ -1,0 +1,339 @@
+import { z } from 'zod';
+
+import { formatFileSize } from '@/utils/strings';
+import { nonEmptyArray } from '@/utils/typescript';
+
+export const typesUtilisateur = [
+  {
+    key: 'Collectivité',
+    label: 'une collectivité',
+  },
+  {
+    key: 'Exploitant',
+    label: 'un exploitant',
+  },
+  {
+    key: 'Autre',
+    label: 'autre',
+  },
+] as const;
+
+export type TypeUtilisateur = (typeof typesUtilisateur)[number]['key'];
+
+export const typesDemande = [
+  {
+    key: 'ajout tracé réseau existant',
+    label: 'ajouter le tracé d’un réseau existant',
+  },
+  {
+    key: 'ajout tracé réseau en construction',
+    label: 'ajouter le tracé d’un réseau en construction (nouveau réseau ou extension)',
+  },
+  {
+    key: 'ajout périmètre développement prioritaire',
+    label: 'ajouter un périmètre de développement prioritaire',
+  },
+  {
+    key: 'ajout schéma directeur',
+    label: 'ajouter un schéma directeur',
+  },
+  {
+    key: 'autre',
+    label: 'autre',
+  },
+] as const;
+
+export type TypeDemande = (typeof typesDemande)[number]['key'];
+
+const typesDemandeWithSncuIdentification = [
+  'ajout tracé réseau existant',
+  'ajout tracé réseau en construction',
+  'ajout périmètre développement prioritaire',
+] as const satisfies readonly TypeDemande[];
+
+export const filesLimits = {
+  maxFileSize: 50 * 1024 * 1024,
+  maxFiles: 10,
+  maxTotalFileSize: 250 * 1024 * 1024,
+};
+
+export const geoAllowedExtensions = [
+  '.geojson',
+  '.json',
+  '.shp',
+  '.shx',
+  '.dbf',
+  '.prj',
+  '.cpg',
+  '.qmd',
+  '.kml',
+  '.kmz',
+  '.gpkg',
+  '.zip',
+  '.pdf',
+];
+
+export const docAllowedExtensions = ['.pdf', '.doc', '.docx', '.odt', '.zip'];
+
+const requiredShapefileExtensions = ['.shp', '.prj'];
+
+/**
+ * Validate file names against allowed extensions and shapefile completeness (.shp + .prj required).
+ * Returns an error message if invalid, or null if valid.
+ */
+export const validateFileNames = (fileNames: string[], allowedExtensions: string[]): string | null => {
+  for (const name of fileNames) {
+    const ext = `.${name.split('.').pop()?.toLowerCase()}`;
+    if (!allowedExtensions.includes(ext)) {
+      return `L'extension "${ext}" du fichier "${name}" n'est pas autorisée. Extensions acceptées : ${allowedExtensions.join(', ')}.`;
+    }
+  }
+
+  const extensions = fileNames.map((name) => `.${name.split('.').pop()?.toLowerCase()}`);
+  const shapefileExtensions = ['.shp', '.shx', '.dbf', '.prj', '.cpg'];
+  if (extensions.some((ext) => shapefileExtensions.includes(ext))) {
+    const missing = requiredShapefileExtensions.filter((ext) => !extensions.includes(ext));
+    if (missing.length > 0) {
+      return `Pour un Shapefile, les fichiers ${requiredShapefileExtensions.join(' et ')} sont requis. Fichier(s) manquant(s) : ${missing.join(', ')}.`;
+    }
+  }
+
+  return null;
+};
+
+// sync checks only — the async zip inspection is validated separately (field level on the
+// form, extra superRefine on the API schema) because a form-level async validator flickers
+const createFilesSchema = (allowedExtensions: string[]) =>
+  z
+    .array(z.instanceof(File), { error: 'Veuillez choisir un ou plusieurs fichiers' })
+    .refine((files) => files.length <= filesLimits.maxFiles, {
+      error: `Vous devez choisir au maximum ${filesLimits.maxFiles} fichiers.`,
+    })
+    .refine((files) => files.every((file) => file.size <= filesLimits.maxFileSize), {
+      error: `Chaque fichier doit être inférieur à ${formatFileSize(filesLimits.maxFileSize)}.`,
+    })
+    .refine((files) => files.reduce((totalFileSize, file) => totalFileSize + file.size, 0) <= filesLimits.maxTotalFileSize, {
+      error: `Le total des fichier doit être inférieur à ${formatFileSize(filesLimits.maxTotalFileSize)}.`,
+    })
+    .superRefine((files, ctx) => {
+      const directError = validateFileNames(
+        files.map((file) => file.name),
+        allowedExtensions
+      );
+      if (directError) {
+        ctx.addIssue({ code: 'custom', fatal: true, message: directError });
+        return z.NEVER;
+      }
+    });
+
+/**
+ * Async inspection of uploaded .zip archives: their inner file names must match the
+ * allowed extensions. Returns an error message, or null when everything is valid.
+ * Revalidation re-runs on every change: the inspection is cached per File.
+ */
+const createZipInspector = (allowedExtensions: string[]) => {
+  const zipInspectionCache = new WeakMap<File, string | null>();
+
+  return async (files: File[]): Promise<string | null> => {
+    for (const file of files) {
+      if (!file.name.toLowerCase().endsWith('.zip')) {
+        continue;
+      }
+      let zipError = zipInspectionCache.get(file);
+      if (zipError === undefined) {
+        const JSZip = (await import('jszip')).default;
+        const zip = await JSZip.loadAsync(await file.arrayBuffer());
+        const zipFileNames = Object.values(zip.files)
+          .filter((entry) => !entry.dir)
+          .map((entry) => entry.name.split('/').pop()!);
+        zipError = validateFileNames(
+          zipFileNames,
+          allowedExtensions.filter((extension) => extension !== '.zip')
+        );
+        zipInspectionCache.set(file, zipError);
+      }
+      if (zipError) {
+        return `Dans "${file.name}" : ${zipError}`;
+      }
+    }
+    return null;
+  };
+};
+
+// full validation for the API schema: sync checks + zip inspection in one schema
+const createFilesSchemaWithZipInspection = (allowedExtensions: string[]) => {
+  const inspectZips = createZipInspector(allowedExtensions);
+  return createFilesSchema(allowedExtensions).superRefine(async (files, ctx) => {
+    const zipError = await inspectZips(files);
+    if (zipError) {
+      ctx.addIssue({ code: 'custom', fatal: true, message: zipError });
+      return z.NEVER;
+    }
+  });
+};
+
+const stringSchema = z.string({ error: 'Ce champ est obligatoire' });
+const positiveNumberSchema = z.number({ error: 'Ce champ est obligatoire' }).positive('La puissance doit être supérieure à 0');
+
+const sncuIdentificationFieldsShape = {
+  identifiantReseau: z.string().optional(),
+  reseauSansIdentifiantSNCU: z.boolean().optional(),
+};
+
+export const zCommonFormData = z.object({
+  dansCadreDemandeADEME: z.boolean({ error: 'Ce choix est obligatoire' }),
+  email: z.email("L'adresse email n'est pas valide"),
+  nom: z.string({ error: 'Ce champ est obligatoire' }).min(1, 'Ce champ est obligatoire'),
+  prenom: z.string({ error: 'Ce champ est obligatoire' }).min(1, 'Ce champ est obligatoire'),
+  typeUtilisateur: z.enum(nonEmptyArray(typesUtilisateur.map((typeUtilisateur) => typeUtilisateur.key)), {
+    error: 'Ce choix est obligatoire',
+  }),
+  typeUtilisateurAutre: z.string().optional(),
+});
+
+export const isTypeUtilisateurAutreValid = (data: { typeUtilisateur?: string; typeUtilisateurAutre?: string }) =>
+  data.typeUtilisateur !== 'Autre' || !!data.typeUtilisateurAutre;
+export const typeUtilisateurAutreRefineParams = { message: 'Ce champ est obligatoire', path: ['typeUtilisateurAutre'], when: () => true };
+
+export const isEmailReferentCommercialValid = (data: {
+  typeDemande?: string;
+  ouvertAuxRaccordements?: boolean;
+  emailReferentCommercial?: string;
+}) => !data.ouvertAuxRaccordements || !!data.emailReferentCommercial;
+export const emailReferentCommercialRefineParams = {
+  message: 'Le référent commercial est obligatoire si le réseau est ouvert aux raccordements',
+  path: ['emailReferentCommercial'],
+  when: () => true,
+};
+
+const isSncuIdentificationRequired = (typeDemande?: string) =>
+  typesDemandeWithSncuIdentification.some((sncuTypeDemande) => sncuTypeDemande === typeDemande);
+
+export const isSncuIdentificationValid = (data: {
+  identifiantReseau?: string;
+  reseauSansIdentifiantSNCU?: boolean;
+  typeDemande?: string;
+}) => !isSncuIdentificationRequired(data.typeDemande) || !!data.identifiantReseau || data.reseauSansIdentifiantSNCU === true;
+
+export const sncuIdentificationRefineParams = {
+  message: "Sélectionnez un identifiant SNCU ou cochez l'absence d'identifiant SNCU",
+  path: ['identifiantReseau'],
+  when: () => true,
+};
+
+const createContributionBranches = (filesSchema: typeof createFilesSchema) => {
+  const reseauFieldsShape = {
+    commentaire: z.string().optional(),
+    emailReferentCommercial: z.string().optional(),
+    fichiers: filesSchema(geoAllowedExtensions),
+    fichiersPDP: filesSchema(geoAllowedExtensions).optional(),
+    gestionnaire: stringSchema,
+    ...sncuIdentificationFieldsShape,
+    localisation: stringSchema,
+    maitreOuvrage: stringSchema,
+    nomReseau: stringSchema,
+    ouvertAuxRaccordements: z.boolean({ error: 'Ce choix est obligatoire' }),
+    reseauDeclasse: z.boolean().optional(),
+  };
+
+  return [
+    zCommonFormData.extend({
+      typeDemande: z.literal('ajout tracé réseau existant'),
+      ...reseauFieldsShape,
+    }),
+    zCommonFormData.extend({
+      typeDemande: z.literal('ajout tracé réseau en construction'),
+      ...reseauFieldsShape,
+      dateMiseEnServicePrevisionnelle: stringSchema,
+      puissanceTotalePrevisionnelleMW: positiveNumberSchema,
+    }),
+    zCommonFormData.extend({
+      fichiers: filesSchema(geoAllowedExtensions),
+      ...sncuIdentificationFieldsShape,
+      localisation: stringSchema,
+      nomReseau: stringSchema,
+      typeDemande: z.literal('ajout périmètre développement prioritaire'),
+    }),
+    zCommonFormData.extend({
+      fichiers: filesSchema(docAllowedExtensions),
+      nomReseau: stringSchema,
+      typeDemande: z.literal('ajout schéma directeur'),
+    }),
+    zCommonFormData.extend({
+      precisions: stringSchema,
+      typeDemande: z.literal('autre'),
+    }),
+  ] as const;
+};
+
+export const zContributionFormDataBase = z.discriminatedUnion(
+  'typeDemande',
+  createContributionBranches(createFilesSchemaWithZipInspection),
+  { error: 'Ce choix est obligatoire' }
+);
+
+export const zContributionFormData = zContributionFormDataBase
+  .refine(isEmailReferentCommercialValid, emailReferentCommercialRefineParams)
+  .refine(isTypeUtilisateurAutreValid, typeUtilisateurAutreRefineParams)
+  .refine(isSncuIdentificationValid, sncuIdentificationRefineParams);
+
+export type ContributionFormValues = Omit<z.input<typeof zCommonFormData>, 'dansCadreDemandeADEME' | 'typeUtilisateur'> & {
+  dansCadreDemandeADEME?: boolean;
+  typeUtilisateur: TypeUtilisateur | '';
+  typeDemande: TypeDemande | '';
+  commentaire?: string;
+  dateMiseEnServicePrevisionnelle?: string;
+  emailReferentCommercial?: string;
+  fichiers?: File[];
+  fichiersPDP?: File[];
+  gestionnaire?: string;
+  identifiantReseau?: string;
+  localisation?: string;
+  maitreOuvrage?: string;
+  nomReseau?: string;
+  ouvertAuxRaccordements?: boolean;
+  precisions?: string;
+  puissanceTotalePrevisionnelleMW?: number;
+  reseauDeclasse?: boolean;
+  reseauSansIdentifiantSNCU?: boolean;
+};
+
+export const contributionDefaultValues: ContributionFormValues = {
+  dansCadreDemandeADEME: undefined,
+  email: '',
+  identifiantReseau: '',
+  nom: '',
+  prenom: '',
+  reseauDeclasse: false,
+  reseauSansIdentifiantSNCU: false,
+  typeDemande: '',
+  typeUtilisateur: '',
+  typeUtilisateurAutre: '',
+};
+
+export const zContributionForm = z
+  .discriminatedUnion('typeDemande', [
+    ...createContributionBranches(createFilesSchema),
+    zCommonFormData.extend({ typeDemande: z.literal('').refine(() => false, { message: 'Ce choix est obligatoire' }) }),
+  ])
+  .refine(isEmailReferentCommercialValid, emailReferentCommercialRefineParams)
+  .refine(isTypeUtilisateurAutreValid, typeUtilisateurAutreRefineParams)
+  .refine(isSncuIdentificationValid, sncuIdentificationRefineParams) as unknown as z.ZodType<
+  ContributionFormValues,
+  ContributionFormValues
+>;
+
+export const createFichiersFieldValidator = (allowedExtensions: string[], options: { required?: boolean } = {}) => {
+  const schema =
+    options.required === false
+      ? createFilesSchemaWithZipInspection(allowedExtensions).optional()
+      : createFilesSchemaWithZipInspection(allowedExtensions);
+  return async ({ value }: { value: File[] | undefined }) => {
+    const result = await schema.safeParseAsync(value);
+    return result.success ? undefined : result.error.issues[0]?.message;
+  };
+};
+
+export const geoFichiersValidator = createFichiersFieldValidator(geoAllowedExtensions);
+export const optionalGeoFichiersValidator = createFichiersFieldValidator(geoAllowedExtensions, { required: false });
+export const docFichiersValidator = createFichiersFieldValidator(docAllowedExtensions);

--- a/src/components/ContributionForm/schema.ts
+++ b/src/components/ContributionForm/schema.ts
@@ -167,7 +167,7 @@ const createFilesSchemaWithZipInspection = (allowedExtensions: string[]) => {
 };
 
 const stringSchema = z.string({ error: 'Ce champ est obligatoire' });
-const positiveNumberSchema = z.number({ error: 'Ce champ est obligatoire' }).positive('La puissance doit être supérieure à 0');
+const optionalPositiveNumberSchema = z.number().positive('La puissance doit être supérieure à 0').optional();
 
 const sncuIdentificationFieldsShape = {
   identifiantReseau: z.string().optional(),
@@ -223,7 +223,7 @@ const createContributionBranches = (filesSchema: typeof createFilesSchema) => {
       typeDemande: z.literal('ajout tracé réseau en construction'),
       ...reseauFieldsShape,
       dateMiseEnServicePrevisionnelle: stringSchema,
-      puissanceTotalePrevisionnelleMW: positiveNumberSchema,
+      puissanceTotalePrevisionnelleMW: optionalPositiveNumberSchema,
     }),
     zCommonFormData.extend({
       fichiers: filesSchema(geoAllowedExtensions),

--- a/src/modules/reseaux/server/service.integration.spec.ts
+++ b/src/modules/reseaux/server/service.integration.spec.ts
@@ -153,50 +153,77 @@ describe('searchNetworkOperators()', () => {
 });
 
 describe('searchHeatNetworksForContribution()', () => {
+  const classedHeatNetwork: ContributionNetworkSearchResult = {
+    gestionnaire: 'Dalkia',
+    id_fcu: 4001,
+    identifiant_reseau: '3301C',
+    is_classe: true,
+    localisation: 'Bordeaux, Mérignac',
+    maitre_ouvrage: 'Bordeaux Métropole',
+    nom_reseau: 'Contribution chaleur classée',
+  };
+
+  const unclassedHeatNetwork: ContributionNetworkSearchResult = {
+    gestionnaire: 'ENGIE Solutions',
+    id_fcu: 4002,
+    identifiant_reseau: '3302C',
+    is_classe: false,
+    localisation: 'Pessac',
+    maitre_ouvrage: 'Ville de Pessac',
+    nom_reseau: 'Contribution chaleur non classée',
+  };
+
   beforeAll(async () => {
     await cleanDatabase();
 
     await Promise.all([
       seedReseauDeChaleur({
-        communes: ['Paris', 'Ivry-sur-Seine'],
-        Gestionnaire: 'Société chaleur',
-        'Identifiant reseau': '9901C',
-        id_fcu: 4001,
-        MO: 'Métropole exemple',
-        nom_reseau: 'Réseau contribution',
+        communes: ['Bordeaux', 'Mérignac'],
+        Gestionnaire: classedHeatNetwork.gestionnaire,
+        'Identifiant reseau': classedHeatNetwork.identifiant_reseau,
+        id_fcu: classedHeatNetwork.id_fcu,
+        MO: classedHeatNetwork.maitre_ouvrage,
+        nom_reseau: classedHeatNetwork.nom_reseau,
         ouvert_aux_raccordements: true,
         'reseaux classes': true,
       }),
+      seedReseauDeChaleur({
+        communes: ['Pessac'],
+        Gestionnaire: unclassedHeatNetwork.gestionnaire,
+        'Identifiant reseau': unclassedHeatNetwork.identifiant_reseau,
+        id_fcu: unclassedHeatNetwork.id_fcu,
+        MO: unclassedHeatNetwork.maitre_ouvrage,
+        nom_reseau: unclassedHeatNetwork.nom_reseau,
+        ouvert_aux_raccordements: true,
+        'reseaux classes': false,
+      }),
       seedReseauDeFroid({
-        Gestionnaire: 'Société froid',
-        'Identifiant reseau': '9901F',
-        id_fcu: 4002,
-        MO: 'Collectivité froid',
-        nom_reseau: 'Réseau froid contribution',
+        communes: ['Bordeaux'],
+        Gestionnaire: 'Dalkia',
+        'Identifiant reseau': '3303F',
+        id_fcu: 4003,
+        MO: 'Bordeaux Métropole',
+        nom_reseau: 'Contribution froid',
       }),
       seedZoneEtReseauEnConstruction({
-        gestionnaire: 'Société futur',
-        id_fcu: 4003,
+        gestionnaire: 'IDEX',
+        id_fcu: 4004,
         is_zone: false,
-        nom_reseau: 'Réseau futur contribution',
+        nom_reseau: 'Contribution futur réseau',
         ouvert_aux_raccordements: false,
       }),
     ]);
   });
 
-  const expectedNetwork: ContributionNetworkSearchResult = {
-    gestionnaire: 'Société chaleur',
-    id_fcu: 4001,
-    identifiant_reseau: '9901C',
-    is_classe: true,
-    localisation: 'Paris, Ivry-sur-Seine',
-    maitre_ouvrage: 'Métropole exemple',
-    nom_reseau: 'Réseau contribution',
-  };
-
   const cases: TestCase<string, ContributionNetworkSearchResult[]>[] = [
-    { expectedOutput: [expectedNetwork], input: '9901', label: 'renvoie les métadonnées du réseau de chaleur par ID SNCU' },
-    { expectedOutput: [], input: 'contribution', label: 'ne cherche pas par nom de réseau' },
+    {
+      expectedOutput: [classedHeatNetwork, unclassedHeatNetwork],
+      input: '330',
+      label: 'matche uniquement les réseaux de chaleur par identifiant SNCU',
+    },
+    { expectedOutput: [classedHeatNetwork], input: '3301c', label: 'matche un identifiant SNCU sans tenir compte de la casse' },
+    { expectedOutput: [], input: 'Contribution', label: 'ne cherche pas dans le nom du réseau' },
+    { expectedOutput: [], input: '4004', label: 'ignore les réseaux en construction' },
   ];
 
   it.each(cases)('$label', async ({ input, expectedOutput }) => {

--- a/src/modules/reseaux/server/service.integration.spec.ts
+++ b/src/modules/reseaux/server/service.integration.spec.ts
@@ -3,7 +3,13 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import { cleanDatabase, seedReseauDeChaleur, seedReseauDeFroid, seedZoneEtReseauEnConstruction } from '@/tests/fixtures';
 import type { TestCase } from '@/tests/trpc-helpers';
 
-import { type NetworkSearchResult, searchNetworkOperators, searchNetworks } from './service';
+import {
+  type ContributionNetworkSearchResult,
+  type NetworkSearchResult,
+  searchHeatNetworksForContribution,
+  searchNetworkOperators,
+  searchNetworks,
+} from './service';
 
 const chaleurNord: NetworkSearchResult = {
   gestionnaire: 'Dalkia',
@@ -143,5 +149,57 @@ describe('searchNetworkOperators()', () => {
 
   it.each(cases)('$label', async ({ field, search, expected }) => {
     expect(await searchNetworkOperators(field, search)).toStrictEqual(expected);
+  });
+});
+
+describe('searchHeatNetworksForContribution()', () => {
+  beforeAll(async () => {
+    await cleanDatabase();
+
+    await Promise.all([
+      seedReseauDeChaleur({
+        communes: ['Paris', 'Ivry-sur-Seine'],
+        Gestionnaire: 'Société chaleur',
+        'Identifiant reseau': '9901C',
+        id_fcu: 4001,
+        MO: 'Métropole exemple',
+        nom_reseau: 'Réseau contribution',
+        ouvert_aux_raccordements: true,
+        'reseaux classes': true,
+      }),
+      seedReseauDeFroid({
+        Gestionnaire: 'Société froid',
+        'Identifiant reseau': '9901F',
+        id_fcu: 4002,
+        MO: 'Collectivité froid',
+        nom_reseau: 'Réseau froid contribution',
+      }),
+      seedZoneEtReseauEnConstruction({
+        gestionnaire: 'Société futur',
+        id_fcu: 4003,
+        is_zone: false,
+        nom_reseau: 'Réseau futur contribution',
+        ouvert_aux_raccordements: false,
+      }),
+    ]);
+  });
+
+  const expectedNetwork: ContributionNetworkSearchResult = {
+    gestionnaire: 'Société chaleur',
+    id_fcu: 4001,
+    identifiant_reseau: '9901C',
+    is_classe: true,
+    localisation: 'Paris, Ivry-sur-Seine',
+    maitre_ouvrage: 'Métropole exemple',
+    nom_reseau: 'Réseau contribution',
+  };
+
+  const cases: TestCase<string, ContributionNetworkSearchResult[]>[] = [
+    { expectedOutput: [expectedNetwork], input: '9901', label: 'renvoie les métadonnées du réseau de chaleur par ID SNCU' },
+    { expectedOutput: [], input: 'contribution', label: 'ne cherche pas par nom de réseau' },
+  ];
+
+  it.each(cases)('$label', async ({ input, expectedOutput }) => {
+    expect(await searchHeatNetworksForContribution(input)).toStrictEqual(expectedOutput);
   });
 });

--- a/src/modules/reseaux/server/service.ts
+++ b/src/modules/reseaux/server/service.ts
@@ -861,10 +861,6 @@ export type ContributionNetworkSearchResult = {
   is_classe: boolean;
 };
 
-/**
- * Public contribution-form search by SNCU identifier.
- * Only heat networks are suggested: cold networks are intentionally excluded.
- */
 export const searchHeatNetworksForContribution = async (search: string): Promise<ContributionNetworkSearchResult[]> => {
   const pattern = `%${search}%`;
 

--- a/src/modules/reseaux/server/service.ts
+++ b/src/modules/reseaux/server/service.ts
@@ -851,6 +851,52 @@ export type NetworkSearchResult = {
   gestionnaire: string | null;
 };
 
+export type ContributionNetworkSearchResult = {
+  id_fcu: number;
+  identifiant_reseau: string;
+  nom_reseau: string | null;
+  localisation: string | null;
+  gestionnaire: string | null;
+  maitre_ouvrage: string | null;
+  is_classe: boolean;
+};
+
+/**
+ * Récupère les informations d'un réseau pour alimenter les suggestions du formulaire de contribution
+ */
+export const searchHeatNetworksForContribution = async (search: string): Promise<ContributionNetworkSearchResult[]> => {
+  const pattern = `%${search}%`;
+
+  const rows = await kdb
+    .selectFrom('reseaux_de_chaleur')
+    .select((eb) => [
+      'id_fcu',
+      'nom_reseau',
+      'communes',
+      eb.ref('Identifiant reseau').as('identifiant_reseau'),
+      eb.ref('Gestionnaire').as('gestionnaire'),
+      eb.ref('MO').as('maitre_ouvrage'),
+      eb.ref('reseaux classes').as('is_classe'),
+    ])
+    .where('Identifiant reseau', 'is not', null)
+    .where((eb) => eb(eb.ref('Identifiant reseau'), 'ilike', pattern))
+    .orderBy(sql<string>`"Identifiant reseau"`, 'asc')
+    .limit(10)
+    .execute();
+
+  return rows
+    .filter((row): row is typeof row & { identifiant_reseau: string } => row.identifiant_reseau !== null)
+    .map((row) => ({
+      gestionnaire: row.gestionnaire,
+      id_fcu: row.id_fcu,
+      identifiant_reseau: row.identifiant_reseau,
+      is_classe: row.is_classe === true,
+      localisation: row.communes?.join(', ') ?? null,
+      maitre_ouvrage: row.maitre_ouvrage,
+      nom_reseau: row.nom_reseau,
+    }));
+};
+
 /**
  * Search networks (existing + construction) by name, SNCU identifier or FCU id.
  * Includes zones (`is_zone = true`) since demands can be affected to them.

--- a/src/modules/reseaux/server/service.ts
+++ b/src/modules/reseaux/server/service.ts
@@ -853,8 +853,8 @@ export type NetworkSearchResult = {
 
 export type ContributionNetworkSearchResult = {
   id_fcu: number;
-  identifiant_reseau: string;
   nom_reseau: string | null;
+  identifiant_reseau: string;
   localisation: string | null;
   gestionnaire: string | null;
   maitre_ouvrage: string | null;
@@ -862,39 +862,44 @@ export type ContributionNetworkSearchResult = {
 };
 
 /**
- * Récupère les informations d'un réseau pour alimenter les suggestions du formulaire de contribution
+ * Public contribution-form search by SNCU identifier.
+ * Only heat networks are suggested: cold networks are intentionally excluded.
  */
 export const searchHeatNetworksForContribution = async (search: string): Promise<ContributionNetworkSearchResult[]> => {
   const pattern = `%${search}%`;
 
   const rows = await kdb
     .selectFrom('reseaux_de_chaleur')
-    .select((eb) => [
+    .select((expressionBuilder) => [
       'id_fcu',
       'nom_reseau',
       'communes',
-      eb.ref('Identifiant reseau').as('identifiant_reseau'),
-      eb.ref('Gestionnaire').as('gestionnaire'),
-      eb.ref('MO').as('maitre_ouvrage'),
-      eb.ref('reseaux classes').as('is_classe'),
+      expressionBuilder.ref('Identifiant reseau').as('identifiant_reseau'),
+      expressionBuilder.ref('Gestionnaire').as('gestionnaire'),
+      expressionBuilder.ref('MO').as('maitre_ouvrage'),
+      expressionBuilder.ref('reseaux classes').as('is_classe'),
     ])
     .where('Identifiant reseau', 'is not', null)
-    .where((eb) => eb(eb.ref('Identifiant reseau'), 'ilike', pattern))
+    .where((expressionBuilder) => expressionBuilder(expressionBuilder.ref('Identifiant reseau'), 'ilike', pattern))
     .orderBy(sql<string>`"Identifiant reseau"`, 'asc')
     .limit(10)
     .execute();
 
   return rows
-    .filter((row): row is typeof row & { identifiant_reseau: string } => row.identifiant_reseau !== null)
-    .map((row) => ({
-      gestionnaire: row.gestionnaire,
-      id_fcu: row.id_fcu,
-      identifiant_reseau: row.identifiant_reseau,
-      is_classe: row.is_classe === true,
-      localisation: row.communes?.join(', ') ?? null,
-      maitre_ouvrage: row.maitre_ouvrage,
-      nom_reseau: row.nom_reseau,
-    }));
+    .map((network) =>
+      network.identifiant_reseau
+        ? {
+            gestionnaire: network.gestionnaire,
+            id_fcu: network.id_fcu,
+            identifiant_reseau: network.identifiant_reseau,
+            is_classe: network.is_classe === true,
+            localisation: network.communes?.join(', ') ?? null,
+            maitre_ouvrage: network.maitre_ouvrage,
+            nom_reseau: network.nom_reseau,
+          }
+        : undefined
+    )
+    .filter(isDefined);
 };
 
 /**

--- a/src/modules/reseaux/server/trpc-routes.ts
+++ b/src/modules/reseaux/server/trpc-routes.ts
@@ -252,9 +252,12 @@ export const reseauxRouter = router({
   reseauDeChaleur: reseauDeChaleurRouter,
   reseauDeFroid: reseauDeFroidRouter,
   reseauEnConstruction: reseauEnConstructionRouter,
-  searchForContribution: route.input(z.object({ search: z.string().min(2).max(10) })).query(async ({ input }) => {
-    return await reseauxService.searchHeatNetworksForContribution(input.search);
-  }),
+  searchForContribution: route
+    .meta({ rateLimit: { limit: 100, windowMs: 60 * 1000 } })
+    .input(z.object({ search: z.string().min(2).max(100) }))
+    .query(async ({ input }) => {
+      return await reseauxService.searchHeatNetworksForContribution(input.search);
+    }),
   /**
    * Recherche publique de réseaux (de chaleur existants + en construction) par
    * nom, identifiant SNCU ou id_fcu. Renvoie la bbox PostGIS de chaque réseau

--- a/src/modules/reseaux/server/trpc-routes.ts
+++ b/src/modules/reseaux/server/trpc-routes.ts
@@ -252,6 +252,9 @@ export const reseauxRouter = router({
   reseauDeChaleur: reseauDeChaleurRouter,
   reseauDeFroid: reseauDeFroidRouter,
   reseauEnConstruction: reseauEnConstructionRouter,
+  searchForContribution: route.input(z.object({ search: z.string().min(2).max(10) })).query(async ({ input }) => {
+    return await reseauxService.searchHeatNetworksForContribution(input.search);
+  }),
   /**
    * Recherche publique de réseaux (de chaleur existants + en construction) par
    * nom, identifiant SNCU ou id_fcu. Renvoie la bbox PostGIS de chaque réseau

--- a/src/pages/api/contribution.ts
+++ b/src/pages/api/contribution.ts
@@ -142,7 +142,7 @@ function createServerContributionBranch(schema: ContributionFormBranch) {
       return schema.extend({
         fichiers: createServerFilesSchema(geoAllowedExtensions),
         fichiersPDP: createServerFilesSchema(geoAllowedExtensions, { required: false }),
-        puissanceTotalePrevisionnelleMW: z.string().nullable(),
+        puissanceTotalePrevisionnelleMW: z.string().optional(),
       });
     case 'ajout périmètre développement prioritaire':
       return schema.extend({

--- a/src/pages/api/contribution.ts
+++ b/src/pages/api/contribution.ts
@@ -6,12 +6,18 @@ import { z } from 'zod';
 
 import {
   docAllowedExtensions,
+  emailReferentCommercialRefineParams,
   filesLimits,
   geoAllowedExtensions,
+  isEmailReferentCommercialValid,
+  isSncuIdentificationValid,
+  isTypeUtilisateurAutreValid,
+  sncuIdentificationRefineParams,
+  typeUtilisateurAutreRefineParams,
   zContributionFormDataBase,
 } from '@/components/ContributionForm/ContributionForm';
 import { createNextApiRateLimiter } from '@/modules/security/server/rate-limit/next-pages';
-import { AirtableDB } from '@/server/db/airtable';
+import { AirtableDB, type FieldSet } from '@/server/db/airtable';
 import { logger } from '@/server/helpers/logger';
 import { handleRouteErrors, requirePostMethod } from '@/server/helpers/server';
 import { uploadTempFile } from '@/server/services/upload';
@@ -31,8 +37,8 @@ const createServerFilesSchema = (allowedExtensions: string[]) =>
       // formidable.File
       z.object({
         filepath: z.string(),
-        mimetype: z.string(),
-        originalFilename: z.string(),
+        mimetype: z.string().nullable(),
+        originalFilename: z.string().nullable(),
         size: z.number(),
       })
     )
@@ -47,12 +53,13 @@ const createServerFilesSchema = (allowedExtensions: string[]) =>
     })
     .superRefine((files, ctx) => {
       for (const file of files) {
-        const ext = `.${file.originalFilename.split('.').pop()?.toLowerCase()}`;
+        const fileName = file.originalFilename ?? '';
+        const ext = `.${fileName.split('.').pop()?.toLowerCase()}`;
         if (!allowedExtensions.includes(ext)) {
           ctx.addIssue({
             code: 'custom',
             fatal: true,
-            message: `L'extension "${ext}" du fichier "${file.originalFilename}" n'est pas autorisée. Extensions acceptées : ${allowedExtensions.join(', ')}.`,
+            message: `L'extension "${ext}" du fichier "${fileName}" n'est pas autorisée. Extensions acceptées : ${allowedExtensions.join(', ')}.`,
           });
           return z.NEVER;
         }
@@ -60,7 +67,8 @@ const createServerFilesSchema = (allowedExtensions: string[]) =>
     })
     .superRefine(async (files, ctx) => {
       for (const file of files) {
-        if (file.originalFilename.toLowerCase().endsWith('.zip')) {
+        const fileName = file.originalFilename ?? '';
+        if (fileName.toLowerCase().endsWith('.zip')) {
           const buffer = await readFile(file.filepath);
           const zip = await JSZip.loadAsync(buffer);
           const zipFileNames = Object.keys(zip.files);
@@ -70,7 +78,7 @@ const createServerFilesSchema = (allowedExtensions: string[]) =>
             ctx.addIssue({
               code: 'custom',
               fatal: true,
-              message: `Le fichier ZIP "${file.originalFilename}" ne contient aucun fichier avec une extension autorisée (${allowedInZip.join(', ')}).`,
+              message: `Le fichier ZIP "${fileName}" ne contient aucun fichier avec une extension autorisée (${allowedInZip.join(', ')}).`,
             });
             return z.NEVER;
           }
@@ -78,6 +86,24 @@ const createServerFilesSchema = (allowedExtensions: string[]) =>
       }
     })
     .optional();
+
+const parseMultipartNumber = (value: unknown) => {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  const trimmedValue = value.trim();
+  return trimmedValue === '' ? undefined : Number(trimmedValue.replace(',', '.'));
+};
+
+const positiveMultipartNumberSchema = z.preprocess(
+  parseMultipartNumber,
+  z.number({ error: 'Ce champ est obligatoire' }).positive('La puissance doit être supérieure à 0')
+);
+
+const optionalPositiveMultipartNumberSchema = z.preprocess(
+  parseMultipartNumber,
+  z.number().positive('La puissance doit être supérieure à 0').optional()
+);
 
 // mapping from typeDemande discriminator values to their allowed extensions
 const allowedExtensionsByTypeDemande: Record<string, string[]> = {
@@ -98,22 +124,66 @@ const zServerContributionFormData = z
         const extensions = allowedExtensionsByTypeDemande[typeDemande] ?? geoAllowedExtensions;
         return schema.extend({
           fichiers: createServerFilesSchema(extensions),
+          fichiersPDP: createServerFilesSchema(geoAllowedExtensions),
+          puissanceTotalePrevisionnelleMW:
+            typeDemande === 'ajout tracé réseau en construction' ? positiveMultipartNumberSchema : optionalPositiveMultipartNumberSchema,
         });
       })
     )
   )
-  .refine(
-    (data: Record<string, unknown>) => {
-      if (!data.ouvertAuxRaccordements) return true;
-      return typeof data.emailReferentCommercial === 'string' && data.emailReferentCommercial.length > 0;
-    },
-    {
-      message: 'Le référent commercial est obligatoire si le réseau est ouvert aux raccordements',
-      path: ['emailReferentCommercial'],
-    }
-  );
+  .refine(isEmailReferentCommercialValid, emailReferentCommercialRefineParams)
+  .refine(isTypeUtilisateurAutreValid, typeUtilisateurAutreRefineParams)
+  .refine(isSncuIdentificationValid, sncuIdentificationRefineParams);
 
 const contributionRateLimiter = createNextApiRateLimiter({ path: '/api/contribution' });
+
+type ServerContributionFormData = z.infer<typeof zServerContributionFormData>;
+type UploadedContributionFile = {
+  filepath: string;
+  originalFilename: string | null;
+};
+type AirtableUploadAttachment = {
+  filename: string;
+  url: string;
+};
+
+const uploadAirtableFiles = async (files: UploadedContributionFile[] | undefined, label: string): Promise<AirtableUploadAttachment[]> => {
+  return await Promise.all(
+    (files ?? []).map(async (file, index) => {
+      const originalFilename = file.originalFilename ?? `Fichier ${index + 1}`;
+      const externalURL = await uploadTempFile(file.filepath, originalFilename);
+      return {
+        filename: `${label} - ${originalFilename}`,
+        url: externalURL,
+      };
+    })
+  );
+};
+
+const buildAirtablePrecisions = (formValues: ServerContributionFormData): string | undefined => {
+  const userText = 'precisions' in formValues ? formValues.precisions : 'commentaire' in formValues ? formValues.commentaire : undefined;
+
+  const collectedDetails = [
+    'identifiantReseau' in formValues
+      ? formValues.identifiantReseau
+        ? `Identifiant SNCU : ${formValues.identifiantReseau}`
+        : formValues.reseauSansIdentifiantSNCU === true
+          ? 'Identifiant SNCU : aucun'
+          : undefined
+      : undefined,
+    'reseauDeclasse' in formValues && formValues.reseauDeclasse === true ? 'Réseau déclaré déclassé par arrêté : oui' : undefined,
+    'puissanceTotalePrevisionnelleMW' in formValues && formValues.puissanceTotalePrevisionnelleMW !== undefined
+      ? `Puissance totale prévisionnelle : ${formValues.puissanceTotalePrevisionnelleMW} MW`
+      : undefined,
+  ].filter(isNonEmptyString);
+
+  const collectedText =
+    collectedDetails.length > 0 ? ['Informations collectées par le formulaire :', ...collectedDetails].join('\n') : undefined;
+
+  return [userText, collectedText].filter(isNonEmptyString).join('\n\n') || undefined;
+};
+
+const isNonEmptyString = (value: string | undefined): value is string => Boolean(value);
 
 export default handleRouteErrors(async (req, res) => {
   requirePostMethod(req);
@@ -121,33 +191,31 @@ export default handleRouteErrors(async (req, res) => {
 
   const [arrayFields, files] = await formidable(filesLimits).parse(req);
   const fields = flattenMultipartData(arrayFields);
-  const formValues = await zServerContributionFormData.parseAsync({ ...fields, fichiers: files.fichiers });
+  const formValues = await zServerContributionFormData.parseAsync({ ...fields, fichiers: files.fichiers, fichiersPDP: files.fichiersPDP });
+  const [traceAttachments, pdpAttachments] = await Promise.all([
+    uploadAirtableFiles(files.fichiers, 'Tracé'),
+    uploadAirtableFiles(files.fichiersPDP, 'PDP'),
+  ]);
 
-  const record = await AirtableDB('FCU - Contribution').create({
+  const airtableRecord: FieldSet = {
     'Cadre subvention ADEME': formValues.dansCadreDemandeADEME,
-    'Date mise en service': (formValues as any).dateMiseEnServicePrevisionnelle,
+    'Date mise en service': 'dateMiseEnServicePrevisionnelle' in formValues ? formValues.dateMiseEnServicePrevisionnelle : undefined,
     Email: formValues.email,
-    Fichiers: await Promise.all(
-      (files.fichiers ?? []).map(async (fichier, index) => {
-        const externalURL = await uploadTempFile(fichier.filepath, fichier.originalFilename ?? `Fichier ${index + 1}`);
-        return {
-          filename: fichier.originalFilename ?? `Fichier ${index + 1}`,
-          url: externalURL,
-        } as any; // bypass wrong typing
-      })
-    ),
-    Localisation: (formValues as any).localisation,
-    "Maître d'ouvrage": (formValues as any).maitreOuvrage,
+    Fichiers: [...traceAttachments, ...pdpAttachments] as unknown as FieldSet[string],
+    Localisation: 'localisation' in formValues ? formValues.localisation : undefined,
+    "Maître d'ouvrage": 'maitreOuvrage' in formValues ? formValues.maitreOuvrage : undefined,
     Nom: formValues.nom,
-    'Nom gestionnaire': (formValues as any).gestionnaire,
-    ouvert_aux_raccordements: (formValues as any).ouvertAuxRaccordements,
-    Précisions: (formValues as any).precisions ?? (formValues as any).commentaire,
+    'Nom gestionnaire': 'gestionnaire' in formValues ? formValues.gestionnaire : undefined,
+    ouvert_aux_raccordements: 'ouvertAuxRaccordements' in formValues ? formValues.ouvertAuxRaccordements : undefined,
+    Précisions: buildAirtablePrecisions(formValues),
     Prénom: formValues.prenom,
-    'Référent commercial': (formValues as any).emailReferentCommercial,
-    'Réseau(x)': (formValues as any).nomReseau,
+    'Référent commercial': 'emailReferentCommercial' in formValues ? formValues.emailReferentCommercial : undefined,
+    'Réseau(x)': 'nomReseau' in formValues ? formValues.nomReseau : undefined,
     Souhait: formValues.typeDemande,
     Utilisateur: formValues.typeUtilisateur === 'Autre' ? formValues.typeUtilisateurAutre : formValues.typeUtilisateur,
-  });
+  };
+
+  const record = await AirtableDB('FCU - Contribution').create(airtableRecord);
 
   logger.info('create airtable record contribution', {
     id: record.id,

--- a/src/pages/api/contribution.ts
+++ b/src/pages/api/contribution.ts
@@ -13,9 +13,11 @@ import {
   isSncuIdentificationValid,
   isTypeUtilisateurAutreValid,
   sncuIdentificationRefineParams,
+  type TypeDemande,
   typeUtilisateurAutreRefineParams,
+  validateFileNames,
   zContributionFormDataBase,
-} from '@/components/ContributionForm/ContributionForm';
+} from '@/components/ContributionForm/schema';
 import { createNextApiRateLimiter } from '@/modules/security/server/rate-limit/next-pages';
 import { AirtableDB, type FieldSet } from '@/server/db/airtable';
 import { logger } from '@/server/helpers/logger';
@@ -27,65 +29,50 @@ import { nonEmptyArray } from '@/utils/typescript';
 
 export const config = {
   api: {
-    bodyParser: false, // disable because formidable handles all the parsing
+    bodyParser: false,
   },
 };
 
-const createServerFilesSchema = (allowedExtensions: string[]) =>
-  z
-    .array(
-      // formidable.File
-      z.object({
-        filepath: z.string(),
-        mimetype: z.string().nullable(),
-        originalFilename: z.string().nullable(),
-        size: z.number(),
-      })
-    )
+const zServerFile = z.object({
+  filepath: z.string(),
+  mimetype: z.string().nullable(),
+  originalFilename: z.string().nullable(),
+  size: z.number(),
+});
+
+type ServerFile = z.infer<typeof zServerFile>;
+
+const createServerFilesSchema = (allowedExtensions: string[], options: { required?: boolean } = {}) => {
+  const schema = z
+    .array(zServerFile, { error: 'Veuillez choisir un ou plusieurs fichiers' })
+    .min(1, { error: 'Veuillez choisir un ou plusieurs fichiers' })
     .refine((files) => files.length <= filesLimits.maxFiles, {
       error: `Vous devez choisir au maximum ${filesLimits.maxFiles} fichiers.`,
     })
     .refine((files) => files.every((file) => file.size <= filesLimits.maxFileSize), {
       error: `Chaque fichier doit être inférieur à ${formatFileSize(filesLimits.maxFileSize)}.`,
     })
-    .refine((files) => files.reduce((acc, file) => acc + file.size, 0) <= filesLimits.maxTotalFileSize, {
+    .refine((files) => files.reduce((totalFileSize, file) => totalFileSize + file.size, 0) <= filesLimits.maxTotalFileSize, {
       error: `Le total des fichier doit être inférieur à ${formatFileSize(filesLimits.maxTotalFileSize)}.`,
     })
-    .superRefine((files, ctx) => {
-      for (const file of files) {
-        const fileName = file.originalFilename ?? '';
-        const ext = `.${fileName.split('.').pop()?.toLowerCase()}`;
-        if (!allowedExtensions.includes(ext)) {
-          ctx.addIssue({
-            code: 'custom',
-            fatal: true,
-            message: `L'extension "${ext}" du fichier "${fileName}" n'est pas autorisée. Extensions acceptées : ${allowedExtensions.join(', ')}.`,
-          });
-          return z.NEVER;
-        }
+    .superRefine((files, context) => {
+      const directError = validateFileNames(files.map(getServerFileName), allowedExtensions);
+      if (directError) {
+        context.addIssue({ code: 'custom', fatal: true, message: directError });
+        return z.NEVER;
       }
     })
-    .superRefine(async (files, ctx) => {
-      for (const file of files) {
-        const fileName = file.originalFilename ?? '';
-        if (fileName.toLowerCase().endsWith('.zip')) {
-          const buffer = await readFile(file.filepath);
-          const zip = await JSZip.loadAsync(buffer);
-          const zipFileNames = Object.keys(zip.files);
-          const allowedInZip = allowedExtensions.filter((e) => e !== '.zip');
-          const hasRelevantFile = zipFileNames.some((name) => allowedInZip.some((ext) => name.toLowerCase().endsWith(ext)));
-          if (!hasRelevantFile) {
-            ctx.addIssue({
-              code: 'custom',
-              fatal: true,
-              message: `Le fichier ZIP "${fileName}" ne contient aucun fichier avec une extension autorisée (${allowedInZip.join(', ')}).`,
-            });
-            return z.NEVER;
-          }
-        }
+    .superRefine(async (files, context) => {
+      const zipErrors = await Promise.all(files.map((file) => inspectServerZipFile(file, allowedExtensions)));
+      const zipError = zipErrors.find(isNonEmptyString);
+      if (zipError) {
+        context.addIssue({ code: 'custom', fatal: true, message: zipError });
+        return z.NEVER;
       }
-    })
-    .optional();
+    });
+
+  return options.required === false ? schema.optional() : schema;
+};
 
 const parseMultipartNumber = (value: unknown) => {
   if (typeof value !== 'string') {
@@ -100,90 +87,17 @@ const positiveMultipartNumberSchema = z.preprocess(
   z.number({ error: 'Ce champ est obligatoire' }).positive('La puissance doit être supérieure à 0')
 );
 
-const optionalPositiveMultipartNumberSchema = z.preprocess(
-  parseMultipartNumber,
-  z.number().positive('La puissance doit être supérieure à 0').optional()
-);
+type ContributionFormBranch = (typeof zContributionFormDataBase.options)[number];
 
-// mapping from typeDemande discriminator values to their allowed extensions
-const allowedExtensionsByTypeDemande: Record<string, string[]> = {
-  'ajout périmètre développement prioritaire': geoAllowedExtensions,
-  'ajout schéma directeur': docAllowedExtensions,
-  'ajout tracé réseau en construction': geoAllowedExtensions,
-  'ajout tracé réseau existant': geoAllowedExtensions,
-  autre: geoAllowedExtensions, // fallback, "autre" has no file field but schema expects optional
-};
-
-// build the discriminated union with per-typeDemande file schemas
 const zServerContributionFormData = z
-  .discriminatedUnion(
-    'typeDemande',
-    nonEmptyArray(
-      zContributionFormDataBase.options.map((schema) => {
-        const typeDemande = schema.shape.typeDemande._def.values[0] as string;
-        const extensions = allowedExtensionsByTypeDemande[typeDemande] ?? geoAllowedExtensions;
-        return schema.extend({
-          fichiers: createServerFilesSchema(extensions),
-          fichiersPDP: createServerFilesSchema(geoAllowedExtensions),
-          puissanceTotalePrevisionnelleMW:
-            typeDemande === 'ajout tracé réseau en construction' ? positiveMultipartNumberSchema : optionalPositiveMultipartNumberSchema,
-        });
-      })
-    )
-  )
+  .discriminatedUnion('typeDemande', nonEmptyArray(zContributionFormDataBase.options.map(createServerContributionBranch)))
   .refine(isEmailReferentCommercialValid, emailReferentCommercialRefineParams)
   .refine(isTypeUtilisateurAutreValid, typeUtilisateurAutreRefineParams)
   .refine(isSncuIdentificationValid, sncuIdentificationRefineParams);
 
-const contributionRateLimiter = createNextApiRateLimiter({ path: '/api/contribution' });
-
 type ServerContributionFormData = z.infer<typeof zServerContributionFormData>;
-type UploadedContributionFile = {
-  filepath: string;
-  originalFilename: string | null;
-};
-type AirtableUploadAttachment = {
-  filename: string;
-  url: string;
-};
 
-const uploadAirtableFiles = async (files: UploadedContributionFile[] | undefined, label: string): Promise<AirtableUploadAttachment[]> => {
-  return await Promise.all(
-    (files ?? []).map(async (file, index) => {
-      const originalFilename = file.originalFilename ?? `Fichier ${index + 1}`;
-      const externalURL = await uploadTempFile(file.filepath, originalFilename);
-      return {
-        filename: `${label} - ${originalFilename}`,
-        url: externalURL,
-      };
-    })
-  );
-};
-
-const buildAirtablePrecisions = (formValues: ServerContributionFormData): string | undefined => {
-  const userText = 'precisions' in formValues ? formValues.precisions : 'commentaire' in formValues ? formValues.commentaire : undefined;
-
-  const collectedDetails = [
-    'identifiantReseau' in formValues
-      ? formValues.identifiantReseau
-        ? `Identifiant SNCU : ${formValues.identifiantReseau}`
-        : formValues.reseauSansIdentifiantSNCU === true
-          ? 'Identifiant SNCU : aucun'
-          : undefined
-      : undefined,
-    'reseauDeclasse' in formValues && formValues.reseauDeclasse === true ? 'Réseau déclaré déclassé par arrêté : oui' : undefined,
-    'puissanceTotalePrevisionnelleMW' in formValues && formValues.puissanceTotalePrevisionnelleMW !== undefined
-      ? `Puissance totale prévisionnelle : ${formValues.puissanceTotalePrevisionnelleMW} MW`
-      : undefined,
-  ].filter(isNonEmptyString);
-
-  const collectedText =
-    collectedDetails.length > 0 ? ['Informations collectées par le formulaire :', ...collectedDetails].join('\n') : undefined;
-
-  return [userText, collectedText].filter(isNonEmptyString).join('\n\n') || undefined;
-};
-
-const isNonEmptyString = (value: string | undefined): value is string => Boolean(value);
+const contributionRateLimiter = createNextApiRateLimiter({ path: '/api/contribution' });
 
 export default handleRouteErrors(async (req, res) => {
   requirePostMethod(req);
@@ -191,7 +105,12 @@ export default handleRouteErrors(async (req, res) => {
 
   const [arrayFields, files] = await formidable(filesLimits).parse(req);
   const fields = flattenMultipartData(arrayFields);
-  const formValues = await zServerContributionFormData.parseAsync({ ...fields, fichiers: files.fichiers, fichiersPDP: files.fichiersPDP });
+  const formValues = await zServerContributionFormData.parseAsync({
+    ...fields,
+    fichiers: files.fichiers,
+    fichiersPDP: files.fichiersPDP,
+  });
+
   const [traceAttachments, pdpAttachments] = await Promise.all([
     uploadAirtableFiles(files.fichiers, 'Tracé'),
     uploadAirtableFiles(files.fichiersPDP, 'PDP'),
@@ -199,7 +118,8 @@ export default handleRouteErrors(async (req, res) => {
 
   const airtableRecord: FieldSet = {
     'Cadre subvention ADEME': formValues.dansCadreDemandeADEME,
-    'Date mise en service': 'dateMiseEnServicePrevisionnelle' in formValues ? formValues.dateMiseEnServicePrevisionnelle : undefined,
+    'Date mise en service':
+      formValues.typeDemande === 'ajout tracé réseau en construction' ? formValues.dateMiseEnServicePrevisionnelle : undefined,
     Email: formValues.email,
     Fichiers: [...traceAttachments, ...pdpAttachments] as unknown as FieldSet[string],
     Localisation: 'localisation' in formValues ? formValues.localisation : undefined,
@@ -207,7 +127,7 @@ export default handleRouteErrors(async (req, res) => {
     Nom: formValues.nom,
     'Nom gestionnaire': 'gestionnaire' in formValues ? formValues.gestionnaire : undefined,
     ouvert_aux_raccordements: 'ouvertAuxRaccordements' in formValues ? formValues.ouvertAuxRaccordements : undefined,
-    Précisions: buildAirtablePrecisions(formValues),
+    Précisions: getContributionPrecisions(formValues),
     Prénom: formValues.prenom,
     'Référent commercial': 'emailReferentCommercial' in formValues ? formValues.emailReferentCommercial : undefined,
     'Réseau(x)': 'nomReseau' in formValues ? formValues.nomReseau : undefined,
@@ -221,3 +141,88 @@ export default handleRouteErrors(async (req, res) => {
     id: record.id,
   });
 });
+
+function createServerContributionBranch(schema: ContributionFormBranch) {
+  const typeDemande = schema.shape.typeDemande._def.values[0] as TypeDemande;
+
+  switch (typeDemande) {
+    case 'ajout tracé réseau existant':
+      return schema.extend({
+        fichiers: createServerFilesSchema(geoAllowedExtensions),
+        fichiersPDP: createServerFilesSchema(geoAllowedExtensions, { required: false }),
+      });
+    case 'ajout tracé réseau en construction':
+      return schema.extend({
+        fichiers: createServerFilesSchema(geoAllowedExtensions),
+        fichiersPDP: createServerFilesSchema(geoAllowedExtensions, { required: false }),
+        puissanceTotalePrevisionnelleMW: positiveMultipartNumberSchema,
+      });
+    case 'ajout périmètre développement prioritaire':
+      return schema.extend({
+        fichiers: createServerFilesSchema(geoAllowedExtensions),
+      });
+    case 'ajout schéma directeur':
+      return schema.extend({
+        fichiers: createServerFilesSchema(docAllowedExtensions),
+      });
+    case 'autre':
+      return schema;
+  }
+}
+
+const uploadAirtableFiles = (files: ServerFile[] | undefined, label: string) =>
+  Promise.all(
+    (files ?? []).map(async (file, fileIndex) => {
+      const filename = file.originalFilename ?? `${label} ${fileIndex + 1}`;
+      const externalURL = await uploadTempFile(file.filepath, filename);
+      return { filename, url: externalURL };
+    })
+  );
+
+const inspectServerZipFile = async (file: ServerFile, allowedExtensions: string[]) => {
+  const filename = getServerFileName(file);
+  if (!filename.toLowerCase().endsWith('.zip')) {
+    return null;
+  }
+
+  const buffer = await readFile(file.filepath);
+  const zip = await JSZip.loadAsync(buffer);
+  const zipFileNames = Object.values(zip.files)
+    .filter((zipFile) => !zipFile.dir)
+    .map((zipFile) => zipFile.name.split('/').pop())
+    .filter(isNonEmptyString);
+  const zipError = validateFileNames(
+    zipFileNames,
+    allowedExtensions.filter((extension) => extension !== '.zip')
+  );
+
+  return zipError ? `Dans "${filename}" : ${zipError}` : null;
+};
+
+const getContributionPrecisions = (formValues: ServerContributionFormData) =>
+  [
+    formValues.typeDemande === 'autre' ? formValues.precisions : undefined,
+    'commentaire' in formValues ? formValues.commentaire : undefined,
+    getSncuPrecision(formValues),
+    'reseauDeclasse' in formValues && formValues.reseauDeclasse === true ? 'Réseau déclaré déclassé par arrêté : oui' : undefined,
+    formValues.typeDemande === 'ajout tracé réseau en construction'
+      ? `Puissance totale prévisionnelle : ${formValues.puissanceTotalePrevisionnelleMW} MW`
+      : undefined,
+  ]
+    .filter(isNonEmptyString)
+    .join('\n');
+
+const getSncuPrecision = (formValues: ServerContributionFormData) => {
+  if (!('identifiantReseau' in formValues)) {
+    return undefined;
+  }
+  return formValues.identifiantReseau
+    ? `Identifiant SNCU : ${formValues.identifiantReseau}`
+    : formValues.reseauSansIdentifiantSNCU === true
+      ? 'Identifiant SNCU : aucun'
+      : undefined;
+};
+
+const getServerFileName = (file: ServerFile) => file.originalFilename ?? '';
+
+const isNonEmptyString = (value: string | null | undefined): value is string => typeof value === 'string' && value.length > 0;

--- a/src/pages/api/contribution.ts
+++ b/src/pages/api/contribution.ts
@@ -119,6 +119,7 @@ export default handleRouteErrors(async (req, res) => {
       formValues.typeDemande === 'ajout tracé réseau en construction' ? formValues.dateMiseEnServicePrevisionnelle : undefined,
     Email: formValues.email,
     Fichiers: [...traceAttachments, ...pdpAttachments] as unknown as FieldSet[string],
+    'ID SNCU': 'identifiantReseau' in formValues ? formValues.identifiantReseau : undefined,
     Localisation: 'localisation' in formValues ? formValues.localisation : undefined,
     "Maître d'ouvrage": 'maitreOuvrage' in formValues ? formValues.maitreOuvrage : undefined,
     Nom: formValues.nom,
@@ -126,7 +127,10 @@ export default handleRouteErrors(async (req, res) => {
     ouvert_aux_raccordements: 'ouvertAuxRaccordements' in formValues ? formValues.ouvertAuxRaccordements : undefined,
     Précisions: getContributionPrecisions(formValues),
     Prénom: formValues.prenom,
+    'Puissance totale prévisionnelle (MW)':
+      formValues.typeDemande === 'ajout tracé réseau en construction' ? formValues.puissanceTotalePrevisionnelleMW : undefined,
     'Référent commercial': 'emailReferentCommercial' in formValues ? formValues.emailReferentCommercial : undefined,
+    'Réseau déclassé': 'reseauDeclasse' in formValues ? formValues.reseauDeclasse === true : undefined,
     'Réseau(x)': 'nomReseau' in formValues ? formValues.nomReseau : undefined,
     Souhait: formValues.typeDemande,
     Utilisateur: formValues.typeUtilisateur === 'Autre' ? formValues.typeUtilisateurAutre : formValues.typeUtilisateur,
@@ -197,24 +201,9 @@ const inspectServerZipFile = async (file: ServerFile, allowedExtensions: string[
 };
 
 const getContributionPrecisions = (formValues: ServerContributionFormData) =>
-  [
-    formValues.typeDemande === 'autre' ? formValues.precisions : undefined,
-    'commentaire' in formValues ? formValues.commentaire : undefined,
-    getSncuPrecision(formValues),
-    'reseauDeclasse' in formValues && formValues.reseauDeclasse === true ? 'Réseau déclaré déclassé par arrêté : oui' : undefined,
-    formValues.typeDemande === 'ajout tracé réseau en construction'
-      ? `Puissance totale prévisionnelle : ${formValues.puissanceTotalePrevisionnelleMW} MW`
-      : undefined,
-  ]
+  [formValues.typeDemande === 'autre' ? formValues.precisions : undefined, 'commentaire' in formValues ? formValues.commentaire : undefined]
     .filter(isNonEmptyString)
     .join('\n');
-
-const getSncuPrecision = (formValues: ServerContributionFormData) => {
-  if (!('identifiantReseau' in formValues)) {
-    return undefined;
-  }
-  return formValues.identifiantReseau ? `Identifiant SNCU : ${formValues.identifiantReseau}` : 'Identifiant SNCU : aucun';
-};
 
 const getServerFileName = (file: ServerFile) => file.originalFilename ?? '';
 

--- a/src/pages/api/contribution.ts
+++ b/src/pages/api/contribution.ts
@@ -72,19 +72,6 @@ const createServerFilesSchema = (allowedExtensions: string[], options: { require
   return options.required === false ? schema.optional() : schema;
 };
 
-const parseMultipartNumber = (value: unknown) => {
-  if (typeof value !== 'string') {
-    return value;
-  }
-  const trimmedValue = value.trim();
-  return trimmedValue === '' ? undefined : Number(trimmedValue.replace(',', '.'));
-};
-
-const positiveMultipartNumberSchema = z.preprocess(
-  parseMultipartNumber,
-  z.number({ error: 'Ce champ est obligatoire' }).positive('La puissance doit être supérieure à 0')
-);
-
 type ContributionFormBranch = (typeof zContributionFormDataBase.options)[number];
 
 const zServerContributionFormData = z
@@ -155,7 +142,7 @@ function createServerContributionBranch(schema: ContributionFormBranch) {
       return schema.extend({
         fichiers: createServerFilesSchema(geoAllowedExtensions),
         fichiersPDP: createServerFilesSchema(geoAllowedExtensions, { required: false }),
-        puissanceTotalePrevisionnelleMW: positiveMultipartNumberSchema,
+        puissanceTotalePrevisionnelleMW: z.string().nullable(),
       });
     case 'ajout périmètre développement prioritaire':
       return schema.extend({

--- a/src/pages/api/contribution.ts
+++ b/src/pages/api/contribution.ts
@@ -92,8 +92,6 @@ const zServerContributionFormData = z
   .refine(isEmailReferentCommercialValid, emailReferentCommercialRefineParams)
   .refine(isTypeUtilisateurAutreValid, typeUtilisateurAutreRefineParams);
 
-type ServerContributionFormData = z.infer<typeof zServerContributionFormData>;
-
 const contributionRateLimiter = createNextApiRateLimiter({ path: '/api/contribution' });
 
 export default handleRouteErrors(async (req, res) => {
@@ -125,7 +123,8 @@ export default handleRouteErrors(async (req, res) => {
     Nom: formValues.nom,
     'Nom gestionnaire': 'gestionnaire' in formValues ? formValues.gestionnaire : undefined,
     ouvert_aux_raccordements: 'ouvertAuxRaccordements' in formValues ? formValues.ouvertAuxRaccordements : undefined,
-    Précisions: getContributionPrecisions(formValues),
+    Précisions:
+      formValues.typeDemande === 'autre' ? formValues.precisions : 'commentaire' in formValues ? formValues.commentaire : undefined,
     Prénom: formValues.prenom,
     'Puissance totale prévisionnelle (MW)':
       formValues.typeDemande === 'ajout tracé réseau en construction' ? formValues.puissanceTotalePrevisionnelleMW : undefined,
@@ -199,10 +198,5 @@ const inspectServerZipFile = async (file: ServerFile, allowedExtensions: string[
 
   return zipError ? `Dans "${filename}" : ${zipError}` : null;
 };
-
-const getContributionPrecisions = (formValues: ServerContributionFormData) =>
-  [formValues.typeDemande === 'autre' ? formValues.precisions : undefined, 'commentaire' in formValues ? formValues.commentaire : undefined]
-    .filter(isNonEmptyString)
-    .join('\n');
 
 const getServerFileName = (file: ServerFile) => file.originalFilename ?? '';

--- a/src/pages/api/contribution.ts
+++ b/src/pages/api/contribution.ts
@@ -23,11 +23,11 @@ import { handleRouteErrors, requirePostMethod } from '@/server/helpers/server';
 import { uploadTempFile } from '@/server/services/upload';
 import { flattenMultipartData } from '@/utils/form-utils';
 import { formatFileSize } from '@/utils/strings';
-import { nonEmptyArray } from '@/utils/typescript';
+import { isNonEmptyString, nonEmptyArray } from '@/utils/typescript';
 
 export const config = {
   api: {
-    bodyParser: false,
+    bodyParser: false, // disable because formidable handles all the parsing
   },
 };
 
@@ -50,7 +50,7 @@ const createServerFilesSchema = (allowedExtensions: string[], options: { require
     .refine((files) => files.every((file) => file.size <= filesLimits.maxFileSize), {
       error: `Chaque fichier doit être inférieur à ${formatFileSize(filesLimits.maxFileSize)}.`,
     })
-    .refine((files) => files.reduce((totalFileSize, file) => totalFileSize + file.size, 0) <= filesLimits.maxTotalFileSize, {
+    .refine((files) => files.reduce((acc, file) => acc + file.size, 0) <= filesLimits.maxTotalFileSize, {
       error: `Le total des fichier doit être inférieur à ${formatFileSize(filesLimits.maxTotalFileSize)}.`,
     })
     .superRefine((files, context) => {
@@ -206,5 +206,3 @@ const getContributionPrecisions = (formValues: ServerContributionFormData) =>
     .join('\n');
 
 const getServerFileName = (file: ServerFile) => file.originalFilename ?? '';
-
-const isNonEmptyString = (value: string | null | undefined): value is string => typeof value === 'string' && value.length > 0;

--- a/src/pages/api/contribution.ts
+++ b/src/pages/api/contribution.ts
@@ -10,9 +10,7 @@ import {
   filesLimits,
   geoAllowedExtensions,
   isEmailReferentCommercialValid,
-  isSncuIdentificationValid,
   isTypeUtilisateurAutreValid,
-  sncuIdentificationRefineParams,
   type TypeDemande,
   typeUtilisateurAutreRefineParams,
   validateFileNames,
@@ -92,8 +90,7 @@ type ContributionFormBranch = (typeof zContributionFormDataBase.options)[number]
 const zServerContributionFormData = z
   .discriminatedUnion('typeDemande', nonEmptyArray(zContributionFormDataBase.options.map(createServerContributionBranch)))
   .refine(isEmailReferentCommercialValid, emailReferentCommercialRefineParams)
-  .refine(isTypeUtilisateurAutreValid, typeUtilisateurAutreRefineParams)
-  .refine(isSncuIdentificationValid, sncuIdentificationRefineParams);
+  .refine(isTypeUtilisateurAutreValid, typeUtilisateurAutreRefineParams);
 
 type ServerContributionFormData = z.infer<typeof zServerContributionFormData>;
 
@@ -216,11 +213,7 @@ const getSncuPrecision = (formValues: ServerContributionFormData) => {
   if (!('identifiantReseau' in formValues)) {
     return undefined;
   }
-  return formValues.identifiantReseau
-    ? `Identifiant SNCU : ${formValues.identifiantReseau}`
-    : formValues.reseauSansIdentifiantSNCU === true
-      ? 'Identifiant SNCU : aucun'
-      : undefined;
+  return formValues.identifiantReseau ? `Identifiant SNCU : ${formValues.identifiantReseau}` : 'Identifiant SNCU : aucun';
 };
 
 const getServerFileName = (file: ServerFile) => file.originalFilename ?? '';

--- a/src/utils/typescript.ts
+++ b/src/utils/typescript.ts
@@ -74,6 +74,11 @@ export function nonEmptyArray<T>(array: T[]) {
   return array as NonEmptyArray<T>;
 }
 
+/**
+ * Check if a nullable string is present and non-empty.
+ */
+export const isNonEmptyString = (value: string | null | undefined): value is string => typeof value === 'string' && value.length > 0;
+
 export type RequiredFields<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
 
 /**


### PR DESCRIPTION
- [x]  Lorsque je clique sur « Ajouter le tracé d'un réseau existant » ou “ajouter le tracé d’un réseau en construction (nouveau réseau ou extension)” , ajoutez un champ qui demande l'identifiant SNCU du réseau, si existant.
    
    - [x] Lorsque je commence à saisir l'identifiant SNCU, une liste de suggestions me propose l'identifiant SNCU correspondant. 
    - [x] Si je n'ai pas d'identifiant SNCU, possibilité de cocher un bouton radio en dessous stipulant “ Le réseau n'a pas d'identifiant SNCU” - obligation de saisir l’ID ou sélectionner le bouton radio dans le formulaire
    - [x]  A partir de l'identifiant SNCU, récupérer les informations associées à ce réseau et les pré-remplir dans la partie :
        - nom du réseau
        - localisation
        - gestionnaire
        - maître d'ouvrage
    
    Si besoin, l'usager peut corriger les informations. 
    
- [x]  **Si** le réseau est classé,
    - [x] ajoutez un call out au-dessus de « Téléverser vos fichiers » qui stipule : « Votre réseau est classé. Nous vous invitons à déposer le périmètre de développement prioritaire ci-dessous pour informer les bâtiments concernés de l’obligation d’étude du raccordement. »
    - [x] ajouter une coche stipulant que “Le réseau a été déclassé par arrêté (si celui-ce n’est pas dans la [liste des réseaux déclassés](https://www.ecologie.gouv.fr/politiques-publiques/reseaux-chaleur) et/ou que vous n’avez pas encore transmis votre délibération - merci de l’envoyer à l’adresse [Laurent.Cadiou@developpement-durable.gouv.fr](mailto:Laurent.Cadiou@developpement-durable.gouv.fr))”
    - [x]  Si la coche ci-dessus n’a pas été cochée, ajouter la possibilité de téléverser un fichier PDP en plus du fichier tracé = Avoir 2 boutons  ‘sect fichiers’, un premier pour le tracé, un second pour le pdp. Préciser les formats acceptés (champ non obligatoire)
    - [x]  Si la coche a été cochée, ne pas afficher ce téléversement supplémentaire
- [x]  Si l’usager a sélectionné “ajouter un périmètre de développement prioritaire” demander également l’ID SNCU + possibiilté de déclarer qu’il n’a pas d’id SNCU.
- [x]  Si l’usager a sélectionné “ajouter le tracé d’un réseau en construction (nouveau réseau ou extension)”, ajouter un champ “Puissance totale prévisionnelle (MW)”