### PR TITLE
Corriger la récupération des Espaces Conseil France Rénov’

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -72,6 +72,10 @@ fileignoreconfig:
   - filecontent
 - filename: scripts/batenr/import-batenr-data.sh
   checksum: a5ca157984a05e458d8a8e83a74a06d45870e610c6b16cfb568e158b38c0b46f
+- filename: src/modules/chaleur-renouvelable/server/france-renov-spaces.ts
+  checksum: 54403c92867852fb5afabd8ca59ab8c70093fcb554a197c922e252cc6e0959db
+- filename: src/modules/chaleur-renouvelable/server/france-renov-spaces.spec.ts
+  checksum: 979c46d453b55a379026ab388098aa3d562993dd76869b797c511e5057b853ac
 scopeconfig:
 - scope: node
 allowed_patterns:

--- a/src/modules/chaleur-renouvelable/server/france-renov-spaces.spec.ts
+++ b/src/modules/chaleur-renouvelable/server/france-renov-spaces.spec.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const DATASET_URL = 'https://www.data.gouv.fr/api/1/datasets/6a1d5761c0e706be4aaef8e4/';
+const LATEST_CSV_URL = 'https://www.data.gouv.fr/api/1/datasets/r/main-resource-id';
+const RESOURCE_CSV_URL = 'https://static.data.gouv.fr/resource.csv';
+
+const csvContent = [
+  'Code Insee Commune,Adresse Structure,Code Postal Structure,Commune Structure,Email Structure,Nom Structure,Site Internet Structure,Telephone Structure,Telephone 2 Structure',
+  '01001, 2 boulevard Edouard Herriot,01000,BOURG-EN-BRESSE,dombesrenov@alec-ain.fr,Dombes Rénov +,www.alec-ain.fr,0474983376,',
+  '75056,6 rue Agrippa d Aubigne,75004,PARIS,contact@paris.fr,Agence parisienne du climat,https://www.apc-paris.com,0183769000,0140000000',
+].join('\n');
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('France Renov spaces service', () => {
+  it('loads the current main CSV resource from the stable data.gouv dataset', async () => {
+    const fetchMock = mockDataGouvFetch({
+      latest: LATEST_CSV_URL,
+      url: RESOURCE_CSV_URL,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { getFranceRenovSpaceByCityCode } = await importFreshService();
+
+    const franceRenovSpace = await getFranceRenovSpaceByCityCode('01001');
+
+    expect(franceRenovSpace).toStrictEqual({
+      address: '2 boulevard Edouard Herriot',
+      city: 'BOURG-EN-BRESSE',
+      email: 'dombesrenov@alec-ain.fr',
+      name: 'Dombes Rénov +',
+      phone: '0474983376',
+      secondaryPhone: '',
+      website: 'www.alec-ain.fr',
+      zipcode: '01000',
+    });
+    expect(fetchMock).toHaveBeenCalledWith(DATASET_URL, {});
+    expect(fetchMock).toHaveBeenCalledWith(LATEST_CSV_URL, {});
+    expect(fetchMock).not.toHaveBeenCalledWith(expect.stringContaining('tabular-api'), expect.anything());
+  });
+
+  it('caches the parsed CSV across city lookups', async () => {
+    const fetchMock = mockDataGouvFetch({
+      latest: LATEST_CSV_URL,
+      url: RESOURCE_CSV_URL,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { getFranceRenovSpaceByCityCode } = await importFreshService();
+
+    const firstFranceRenovSpace = await getFranceRenovSpaceByCityCode('01001');
+    const secondFranceRenovSpace = await getFranceRenovSpaceByCityCode('75056');
+    const missingFranceRenovSpace = await getFranceRenovSpaceByCityCode('99999');
+
+    expect(firstFranceRenovSpace?.name).toStrictEqual('Dombes Rénov +');
+    expect(secondFranceRenovSpace?.name).toStrictEqual('Agence parisienne du climat');
+    expect(missingFranceRenovSpace).toStrictEqual(null);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to the resource URL when latest is missing', async () => {
+    const fetchMock = mockDataGouvFetch({
+      latest: null,
+      url: RESOURCE_CSV_URL,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { getFranceRenovSpaceByCityCode } = await importFreshService();
+
+    await getFranceRenovSpaceByCityCode('01001');
+
+    expect(fetchMock).toHaveBeenCalledWith(RESOURCE_CSV_URL, {});
+  });
+});
+
+async function importFreshService() {
+  vi.resetModules();
+
+  return import('./france-renov-spaces');
+}
+
+function mockDataGouvFetch(resource: { latest: string | null; url: string }) {
+  return vi.fn(async (fetchUrl: string) => {
+    if (fetchUrl === DATASET_URL) {
+      return jsonResponse({
+        resources: [
+          {
+            format: 'csv',
+            latest: 'https://www.data.gouv.fr/api/1/datasets/r/documentation-resource-id',
+            type: 'documentation',
+            url: 'https://static.data.gouv.fr/documentation.csv',
+          },
+          {
+            format: 'csv',
+            latest: resource.latest,
+            type: 'main',
+            url: resource.url,
+          },
+        ],
+      });
+    }
+
+    if (fetchUrl === LATEST_CSV_URL || fetchUrl === RESOURCE_CSV_URL) {
+      return textResponse(csvContent);
+    }
+
+    return textResponse('', 404);
+  });
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status,
+  });
+}
+
+function textResponse(body: string, status = 200) {
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/csv',
+    },
+    status,
+  });
+}

--- a/src/modules/chaleur-renouvelable/server/france-renov-spaces.ts
+++ b/src/modules/chaleur-renouvelable/server/france-renov-spaces.ts
@@ -1,0 +1,106 @@
+import Papa from 'papaparse';
+
+import type { FranceRenovSpace } from '@/modules/chaleur-renouvelable/constants';
+import { fetchJSON, fetchText } from '@/utils/network';
+
+// The dataset is the stable anchor; the producer can replace the main file resource.
+const FRANCE_RENOV_SPACES_DATASET_URL = `https://www.data.gouv.fr/api/1/datasets/6a1d5761c0e706be4aaef8e4/`;
+const FRANCE_RENOV_SPACES_CACHE_DURATION_MS = 30 * 24 * 60 * 60 * 1000; // 30 jours
+
+type FranceRenovSpacesCache = {
+  expiresAt: number;
+  promise: Promise<Map<string, FranceRenovSpace>>;
+};
+
+type DataGouvDatasetResponse = {
+  resources: DataGouvResource[];
+};
+
+type DataGouvResource = {
+  format: string;
+  latest: string | null;
+  type: string;
+  url: string;
+};
+
+type FranceRenovSpaceCsvRow = {
+  'Adresse Structure': string;
+  'Code Insee Commune': string;
+  'Code Postal Structure': string;
+  'Commune Structure': string;
+  'Email Structure': string;
+  'Nom Structure': string;
+  'Site Internet Structure': string | null;
+  'Telephone Structure': string;
+  'Telephone 2 Structure': string | null;
+};
+
+let franceRenovSpacesByCityCodeCache: FranceRenovSpacesCache | null = null;
+
+export const getFranceRenovSpaceByCityCode = async (cityCode: string): Promise<FranceRenovSpace | null> => {
+  const franceRenovSpacesByCityCode = await getFranceRenovSpacesByCityCode();
+
+  return franceRenovSpacesByCityCode.get(cityCode) ?? null;
+};
+
+const getFranceRenovSpacesByCityCode = async () => {
+  if (!franceRenovSpacesByCityCodeCache || franceRenovSpacesByCityCodeCache.expiresAt <= Date.now()) {
+    franceRenovSpacesByCityCodeCache = {
+      expiresAt: Date.now() + FRANCE_RENOV_SPACES_CACHE_DURATION_MS,
+      promise: loadFranceRenovSpacesByCityCode(),
+    };
+  }
+
+  const franceRenovSpacesByCityCodePromise = franceRenovSpacesByCityCodeCache.promise;
+
+  try {
+    return await franceRenovSpacesByCityCodePromise;
+  } catch (error) {
+    if (franceRenovSpacesByCityCodeCache?.promise === franceRenovSpacesByCityCodePromise) {
+      franceRenovSpacesByCityCodeCache = null;
+    }
+
+    throw error;
+  }
+};
+
+const loadFranceRenovSpacesByCityCode = async () => {
+  const csvUrl = await getFranceRenovSpacesCsvUrl();
+  const csv = await fetchText(csvUrl);
+  const parsedCsv = Papa.parse<FranceRenovSpaceCsvRow>(csv, {
+    header: true,
+    skipEmptyLines: true,
+  });
+
+  if (parsedCsv.errors.length > 0) {
+    throw new Error(`France Renov spaces CSV parsing errors: ${JSON.stringify(parsedCsv.errors)}`);
+  }
+
+  return new Map(
+    parsedCsv.data
+      .filter((franceRenovSpaceCsvRow) => franceRenovSpaceCsvRow['Code Insee Commune'])
+      .map((franceRenovSpaceCsvRow) => [franceRenovSpaceCsvRow['Code Insee Commune'], toFranceRenovSpace(franceRenovSpaceCsvRow)])
+  );
+};
+
+const getFranceRenovSpacesCsvUrl = async () => {
+  const dataset = await fetchJSON<DataGouvDatasetResponse>(FRANCE_RENOV_SPACES_DATASET_URL);
+  const mainCsvResource = dataset.resources.find((resource) => resource.type === 'main' && resource.format.toLowerCase() === 'csv');
+
+  if (!mainCsvResource) {
+    throw new Error(`Impossible de récupérer le CSV sur data.gouv, url du dataset : ${FRANCE_RENOV_SPACES_DATASET_URL}`);
+  }
+
+  return mainCsvResource.latest ?? mainCsvResource.url;
+};
+
+const toFranceRenovSpace = (franceRenovSpaceCsvRow: FranceRenovSpaceCsvRow): FranceRenovSpace => ({
+  address: franceRenovSpaceCsvRow['Adresse Structure'].trim(),
+  city: franceRenovSpaceCsvRow['Commune Structure'],
+  email: franceRenovSpaceCsvRow['Email Structure'],
+  name: franceRenovSpaceCsvRow['Nom Structure'],
+  phone: franceRenovSpaceCsvRow['Telephone Structure'],
+  secondaryPhone: franceRenovSpaceCsvRow['Telephone 2 Structure'],
+  website: franceRenovSpaceCsvRow['Site Internet Structure'],
+  zipcode: franceRenovSpaceCsvRow['Code Postal Structure'],
+});

--- a/src/modules/chaleur-renouvelable/server/service.ts
+++ b/src/modules/chaleur-renouvelable/server/service.ts
@@ -25,6 +25,8 @@ import { kdb, sql } from '@/server/db/kysely';
 import { getEligilityStatus } from '@/server/services/addresseInformation';
 import { fetchJSON } from '@/utils/network';
 
+import { getFranceRenovSpaceByCityCode } from './france-renov-spaces';
+
 const batEnrBatimentColumns = [
   'ac1',
   'ac2',
@@ -54,7 +56,6 @@ const batEnrBatimentColumns = [
 
 const DEMANDE_CHALEUR_RENOUVELABLE_NOTIFICATION_EMAIL = serverConfig.contactEmail;
 const BAT_ENR_PRESELECTED_BUILDING_RADIUS_METERS = businessRules.fcrBuildingCandidatesRadiusMeters.value;
-const FRANCE_RENOV_SPACES_RESOURCE_ID = 'bc99b9d4-1b70-48e1-9958-98cceacd0c93';
 
 type BanAddressSearchResponse = {
   features: {
@@ -62,17 +63,6 @@ type BanAddressSearchResponse = {
       citycode: string;
     };
   }[];
-};
-
-type FranceRenovSpaceRow = {
-  'Adresse Structure': string;
-  'Code Postal Structure': string;
-  'Commune Structure': string;
-  'Email Structure': string;
-  'Nom Structure': string;
-  'Site Internet Structure': string | null;
-  'Telephone Structure': string;
-  'Telephone 2 Structure': string | null;
 };
 
 const singleConstructionHousingCount = sql<number | null>`
@@ -442,17 +432,7 @@ export const getFranceRenovSpace = async (input: FranceRenovSpaceInput): Promise
     return null;
   }
 
-  const result = await fetchJSON<{ data: FranceRenovSpaceRow[] }>(
-    `https://tabular-api.data.gouv.fr/api/resources/${FRANCE_RENOV_SPACES_RESOURCE_ID}/data/`,
-    {
-      params: {
-        'Code Insee Commune__exact': cityCode,
-        page_size: '1',
-      },
-    }
-  );
-
-  return result.data[0] ? toFranceRenovSpace(result.data[0]) : null;
+  return getFranceRenovSpaceByCityCode(cityCode);
 };
 
 const getFranceRenovCityCode = async ({ address, batimentConstructionId }: FranceRenovSpaceInput) => {
@@ -499,17 +479,6 @@ const getCityCodeFromAddress = async (address: string) => {
 
   return result.features[0]?.properties.citycode ?? null;
 };
-
-const toFranceRenovSpace = (row: FranceRenovSpaceRow): FranceRenovSpace => ({
-  address: row['Adresse Structure'].trim(),
-  city: row['Commune Structure'],
-  email: row['Email Structure'],
-  name: row['Nom Structure'],
-  phone: row['Telephone Structure'],
-  secondaryPhone: row['Telephone 2 Structure'],
-  website: row['Site Internet Structure'],
-  zipcode: row['Code Postal Structure'],
-});
 
 type RnbAddressBuildingsResponse = {
   results: {

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -73,6 +73,23 @@ export const fetchJSON = async <Data = any>(
   return await res.json();
 };
 
+export const fetchText = async (
+  url: string,
+  variables: RequestInit & {
+    params?: Record<string, any>;
+  } = {}
+): Promise<string> => {
+  const { params, ...init } = variables;
+
+  const queryString = params ? `?${objectToURLSearchParams(params as Record<string, string>).toString()}` : '';
+
+  const res = await fetch(`${url}${queryString}`, init);
+  if (!res.ok) {
+    await handleError(res, url);
+  }
+  return await res.text();
+};
+
 export const postFetchJSON = fetchMethod('POST');
 export const putFetchJSON = fetchMethod('PUT');
 export const patchFetchJSON = fetchMethod('PATCH');


### PR DESCRIPTION
L’appel à `tabular-api.data.gouv.fr` échoue ’ car le jeu de données des Espaces Conseil France Rénov data.gouv de l'ANAH a été mis à jour, il faut donc :

- [x] remplacer l’UUID de ressource tabulaire figé par le jeu de données data.gouv stable
- [x] résoude dynamiquement la ressource CSV principale courante
- [x] parser le CSV officiel et mettre en cache le mapping code INSEE -> Espace Conseil