### PR TITLE
Corrige les labels du comparateur

### DIFF
--- a/src/components/ComparateurPublicodes/ParametresDuBatimentGrandPublic.tsx
+++ b/src/components/ComparateurPublicodes/ParametresDuBatimentGrandPublic.tsx
@@ -57,7 +57,6 @@ const ParametresDuBatimentGrandPublicForm: React.FC<ParametresDuBatimentGrandPub
         <>
           <Input
             name="bâtiment . habitants par logement"
-            label="bâtiment . habitants par logement"
             help="Le nombre d'habitants permet d'estimer la consommation d'eau chaude sanitaire du logement."
             nativeInputProps={{
               inputMode: 'numeric',

--- a/src/components/ComparateurPublicodes/SelectClimatisation.tsx
+++ b/src/components/ComparateurPublicodes/SelectClimatisation.tsx
@@ -12,7 +12,7 @@ const SelectClimatisation = ({ ...props }: SelectClimatisation) => {
 
   return (
     <Select
-      label="climatisation . incluse"
+      label="Inclure la climatisation"
       options={[
         {
           label: 'Non',


### PR DESCRIPTION
Suite refactor publicodes v2

Les clés étaient affichées directement pour certains champs